### PR TITLE
Translation tooling

### DIFF
--- a/share/da.po
+++ b/share/da.po
@@ -1,37 +1,47 @@
-msgid ""
+msgid  ""
 msgstr ""
-"Language: da\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 1.0.0\n"
 "PO-Revision-Date: 2017-12-18\n"
-"Language-Team: Zonemaster Team\n"
-"MIME-Version: 1.0\n"
 "Last-Translator: Mats Dufberg <mats.dufberg@iis.se>\n"
+"Language-Team: Zonemaster Team\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #: ADDRESS:NAMESERVERS_IP_WITH_REVERSE
 msgid  "Reverse DNS entry exist for all Nameserver IP addresses."
 msgstr "Reverse DNS eksisterer for samtlige navneserveradresser."
 
 #: ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
-msgid  "Nameserver {ns} has an IP address ({address}) with prefix {prefix} referenced in {reference} as a '{name}'."
-msgstr "Navneserveren {ns} har en IP-adresse ({address}) med præfikset {prefix}, som {reference} klassificerer som '{name}'."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with prefix {prefix} "
+"referenced in {reference} as a '{name}'."
+msgstr ""
+"Navneserveren {ns} har en IP-adresse ({address}) med præfikset {prefix}, som "
+"{reference} klassificerer som '{name}'."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MATCH
 msgid  "All reverse DNS entry matches name server name."
 msgstr "Alle PTR-records matcher navneservernavne."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MISMATCH
-msgid  "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
-msgstr "Navneserveren {ns} har en IP-adresse ({address}) med en ikke matchende PTR ({names})."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with mismatched PTR result "
+"({names})."
+msgstr ""
+"Navneserveren {ns} har en IP-adresse ({address}) med en ikke matchende PTR "
+"({names})."
 
 #: ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
 msgid  "Nameserver {ns} has an IP address ({address}) without PTR configured."
-msgstr "Navneserveren {ns} har en IP-adresse ({address}) uden konfigureret PTR."
+msgstr ""
+"Navneserveren {ns} har en IP-adresse ({address}) uden konfigureret PTR."
 
 #: ADDRESS:NO_IP_PRIVATE_NETWORK
 msgid  "All Nameserver addresses are in the routable public addressing space."
-msgstr "Alle navneserveradresser eksisterer i det routebare offentlige adresserum."
+msgstr ""
+"Alle navneserveradresser eksisterer i det routebare offentlige adresserum."
 
 #: ADDRESS:NO_RESPONSE_PTR_QUERY
 msgid  "No response from nameserver(s) on PTR query ({reverse})."
@@ -42,8 +52,11 @@ msgid  "Nameservers did not respond to A query."
 msgstr "Navneserverne svarede ikke på en A-forespørgsel."
 
 #: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
-msgstr "Domænenavnet ({dname}) indeholder en label ({dlabel}), der er for lang ({dlength}/{max})."
+msgid  ""
+"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+msgstr ""
+"Domænenavnet ({dname}) indeholder en label ({dlabel}), der er for lang "
+"({dlength}/{max})."
 
 #: BASIC:DOMAIN_NAME_TOO_LONG
 msgid  "Domain name is too long ({fqdnlength}/{max})."
@@ -54,7 +67,8 @@ msgid  "Domain name ({dname}) has a zero length label."
 msgstr "Domænenavnet ({dname}) har en label med længden nul."
 
 #: BASIC:HAS_A_RECORDS
-msgid  "Nameserver {ns} returned A record(s) for {dname}."
+#, fuzzy
+msgid  "Nameserver {ns}/{address} returned A record(s) for {dname}."
 msgstr "Navneserveren {ns} svarede med A-record(s) for {dname}."
 
 #: BASIC:HAS_NAMESERVERS
@@ -63,35 +77,47 @@ msgstr "Navneserveren {ns} returnerede disse servere som glue: {nsnlist}."
 
 #: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
 msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
-msgstr "Fungerende navneserver fundet. Test på \"A\"-forespørgsel for www.{zname} afbrydes."
+msgstr ""
+"Fungerende navneserver fundet. Test på \"A\"-forespørgsel for www.{zname} "
+"afbrydes."
 
 #: BASIC:HAS_PARENT
 msgid  "Parent domain '{pname}' was found for the tested domain."
 msgstr "Forælder-domænet '{pname}' blev fundet for det testede domæne."
 
-#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
+#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED
+#: DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 er deaktiveret, udfører ikke \"{rrtype}\"-forespørgsel til {ns}/{address}."
+msgstr ""
+"IPv4 er deaktiveret, udfører ikke \"{rrtype}\"-forespørgsel til {ns}/"
+"{address}."
 
 #: BASIC:IPV4_ENABLED
 msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 er aktiveret, kan udføre \"{rrtype}\"-forespørgsel til {ns}/{address}."
+msgstr ""
+"IPv4 er aktiveret, kan udføre \"{rrtype}\"-forespørgsel til {ns}/{address}."
 
-#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
+#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED
+#: DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 er deaktiveret, udfører ikke \"{rrtype}\"-forespørgsel til {ns}/{address}."
+msgstr ""
+"IPv6 er deaktiveret, udfører ikke \"{rrtype}\"-forespørgsel til {ns}/"
+"{address}."
 
 #: BASIC:IPV6_ENABLED
 msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 er aktiveret, kan udføre \"{rrtype}\"-forespørgsel til {ns}/{address}."
+msgstr ""
+"IPv6 er aktiveret, kan udføre \"{rrtype}\"-forespørgsel til {ns}/{address}."
 
 #: BASIC:NO_A_RECORDS
-msgid  "Nameserver {ns} did not return A record(s) for {dname}."
+#, fuzzy
+msgid  "Nameserver {ns}/{address} did not return A record(s) for {dname}."
 msgstr "Navneserveren {ns} returnerede ikke nogle A-records for {dname}."
 
 #: BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
 msgid  "No NS records for tested zone from parent. NS tests aborted."
-msgstr "Ingen NS-records for den testede zone fra forælderzonen. NS-test afbrydes."
+msgstr ""
+"Ingen NS-records for den testede zone fra forælderzonen. NS-test afbrydes."
 
 #: BASIC:NO_PARENT
 msgid  "No parent domain could be found for the tested domain."
@@ -99,11 +125,32 @@ msgstr "Ikke muligt at finde forælder-domænet for det testede domæne."
 
 #: BASIC:NS_FAILED
 msgid  "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
-msgstr "Navneserveren {ns}/{address} returnerede ikke NS-records. RCODE var {rcode}."
+msgstr ""
+"Navneserveren {ns}/{address} returnerede ikke NS-records. RCODE var {rcode}."
 
 #: BASIC:NS_NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond to NS query."
 msgstr "Navneserveren {ns}/{address} svarede ikke på en NS-forespørgsel."
+
+#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
+msgid  "[ASN:ANNOUNCE_BY] {address};{asn}"
+msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
+
+#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
+msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
+msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
+
+#: CONNECTIVITY:ASN_INFOS_RAW
+msgid  "[ASN:RAW] {address};{data}"
+msgstr "[ASN:RAW] {address};{data}"
+
+#: CONNECTIVITY:IPV4_ASN
+msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
+msgstr "Navneserverne har IPv4-adresser i følgende AS'er: {asn}."
+
+#: CONNECTIVITY:IPV6_ASN
+msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
+msgstr "Navneserverne har IPv6-adresser i følgende AS: {asn}."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
@@ -157,25 +204,23 @@ msgstr "Navneserveren {ns}/{address} er ikke tilgængelig over TCP port 53."
 msgid  "Nameserver {ns}/{address} not accessible over UDP on port 53."
 msgstr "Navneserveren {ns}/{address} er ikke tilgængelig over UDP port 53."
 
-#: CONNECTIVITY:IPV4_ASN
-msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
-msgstr "Navneserverne har IPv4-adresser i følgende AS'er: {asn}."
+#: CONSISTENCY:ADDRESSES_MATCH
+msgid  "Glue records are consistent between glue and authoritative data."
+msgstr "Glue-records er konsistente mellem forælder og barn."
 
-#: CONNECTIVITY:IPV6_ASN
-msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
-msgstr "Navneserverne har IPv6-adresser i følgende AS: {asn}."
+#: CONSISTENCY:EXTRA_ADDRESS_CHILD
+msgid  ""
+"Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+msgstr ""
+"Barnet har ekstra IP-adresser på navneservere som ikke findes hos forælderen "
+"({addresses})."
 
-#: CONNECTIVITY:ASN_INFOS_RAW
-msgid  "[ASN:RAW] {address};{data}"
-msgstr "[ASN:RAW] {address};{data}"
-
-#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
-msgid  "[ASN:ANNOUNCE_BY] {address};{asn}"
-msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
-
-#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
-msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
-msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
+#: CONSISTENCY:EXTRA_ADDRESS_PARENT
+msgid  ""
+"Parent has extra nameserver IP address(es) not listed at child ({addresses})."
+msgstr ""
+"Forælder har ekstra IP-adresser på navneservere som ikke findes hos barnet "
+"({addresses})."
 
 #: CONSISTENCY:MULTIPLE_NS_SET
 msgid  "Saw {count} NS set."
@@ -203,7 +248,8 @@ msgstr "Intet svar på NS-forespørgsel fra nameserveren {ns}/{address}."
 
 #: CONSISTENCY:NO_RESPONSE_SOA_QUERY
 msgid  "No response from nameserver {ns}/{address} on SOA queries."
-msgstr "Intet svar fra navneserveren {ns}/{address} på forespørgsel om SOA-record."
+msgstr ""
+"Intet svar fra navneserveren {ns}/{address} på forespørgsel om SOA-record."
 
 #: CONSISTENCY:NS_SET
 msgid  "Saw NS set ({nsset}) on following nameserver set : {servers}."
@@ -222,8 +268,12 @@ msgid  "A single SOA serial number was seen ({serial})."
 msgstr "Et enkelt SOA-serienummer blev returneret ({serial})."
 
 #: CONSISTENCY:ONE_SOA_TIME_PARAMETER_SET
-msgid  "A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
-msgstr "Et enkelt SOA-tidsparametersæt blev returneret (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
+msgid  ""
+"A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum})."
+msgstr ""
+"Et enkelt SOA-tidsparametersæt blev returneret (REFRESH={refresh},"
+"RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
 
 #: CONSISTENCY:SOA_RNAME
 msgid  "Saw SOA rname {rname} on following nameserver set : {servers}."
@@ -234,28 +284,28 @@ msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
 msgstr "Så SOA-serienummer {serial} på følgende navneservere : {servers}."
 
 #: CONSISTENCY:SOA_SERIAL_VARIATION
-msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
-msgstr "Forskellen mellem det mindste serienummer ({serial_min}) og det største ({serial_max}) er større end det tilladte ({max_variation})."
+msgid  ""
+"Difference between the smaller serial ({serial_min}) and the bigger one "
+"({serial_max}) is greater than the maximum allowed ({max_variation})."
+msgstr ""
+"Forskellen mellem det mindste serienummer ({serial_min}) og det største "
+"({serial_max}) er større end det tilladte ({max_variation})."
 
 #: CONSISTENCY:SOA_TIME_PARAMETER_SET
-msgid  "Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
-msgstr "Så dette SOA-tidsparametersæt (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) på følgende navneservere : {servers}."
-
-#: CONSISTENCY:EXTRA_ADDRESS_PARENT
-msgid  "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
-msgstr "Forælder har ekstra IP-adresser på navneservere som ikke findes hos barnet ({addresses})."
-
-#: CONSISTENCY:EXTRA_ADDRESS_CHILD
-msgid  "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
-msgstr "Barnet har ekstra IP-adresser på navneservere som ikke findes hos forælderen ({addresses})."
+msgid  ""
+"Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},"
+"MINIMUM={minimum}) on following nameserver set : {servers}."
+msgstr ""
+"Så dette SOA-tidsparametersæt (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum}) på følgende navneservere : {servers}."
 
 #: CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-msgid  "No common nameserver IP addresses between child ({child}) and parent ({glue})."
-msgstr "Ingen fælles IP-adresser på navneservere mellem barnet ({child}) og forælderen ({glue})."
-
-#: CONSISTENCY:ADDRESSES_MATCH
-msgid  "Glue records are consistent between glue and authoritative data."
-msgstr "Glue-records er konsistente mellem forælder og barn."
+msgid  ""
+"No common nameserver IP addresses between child ({child}) and parent "
+"({glue})."
+msgstr ""
+"Ingen fælles IP-adresser på navneservere mellem barnet ({child}) og "
+"forælderen ({glue})."
 
 #: DELEGATION:ARE_AUTHORITATIVE
 msgid  "All these nameservers are confirmed to be authoritative : {nsset}."
@@ -266,20 +316,32 @@ msgid  "All the IP addresses used by the nameservers are unique"
 msgstr "Alle navneservernes IP-adresser er unikke."
 
 #: DELEGATION:ENOUGH_NS
-msgid  "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Barnet returnerer tilstrækkeligt antal ({count}) navneservere ({ns}). Mindsteværdi sat til {minimum}."
+msgid  ""
+"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Barnet returnerer tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi sat til {minimum}."
 
 #: DELEGATION:ENOUGH_NS_GLUE
-msgid  "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Forælderen returnerer tilstrækkeligt antal ({count}) navneservere ({glue}). Mindsteværdi sat til {minimum}."
+msgid  ""
+"Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Forælderen returnerer tilstrækkeligt antal ({count}) navneservere ({glue}). "
+"Mindsteværdi sat til {minimum}."
 
 #: DELEGATION:EXTRA_NAME_CHILD
 msgid  "Child has nameserver(s) not listed at parent ({extra})."
-msgstr "Barnet indeholder en eller flera navneservere som ikke findes hos forælderen ({extra})."
+msgstr ""
+"Barnet indeholder en eller flera navneservere som ikke findes hos forælderen "
+"({extra})."
 
 #: DELEGATION:EXTRA_NAME_PARENT
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
-msgstr "Forælderen har en eller flera navneservere som ikke findes hos barnet ({extra})."
+msgstr ""
+"Forælderen har en eller flera navneservere som ikke findes hos barnet "
+"({extra})."
 
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
@@ -290,12 +352,20 @@ msgid  "All of the nameserver names are listed both at parent and child."
 msgstr "Alle navneservere listet findes både hos forælder og barn."
 
 #: DELEGATION:NOT_ENOUGH_NS
-msgid  "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Barnet returnerer ikke tilstrækkeligt antal ({count}) navneservere ({ns}). Mindsteværdi er sat til {minimum}."
+msgid  ""
+"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Barnet returnerer ikke tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi er sat til {minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_GLUE
-msgid  "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Forælderen returnerer ikke tilstrækkeligt antal ({count}) navneservere ({glue}). Mindsteværdi er sat til {minimum}."
+msgid  ""
+"Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
+"to {minimum}."
+msgstr ""
+"Forælderen returnerer ikke tilstrækkeligt antal ({count}) navneservere "
+"({glue}). Mindsteværdi er sat til {minimum}."
 
 #: DELEGATION:NS_RR_IS_CNAME
 msgid  "Nameserver {ns} {address_type} RR point to CNAME."
@@ -306,12 +376,20 @@ msgid  "No nameserver point to CNAME alias."
 msgstr "Ingen NS-record peger på et CNAME-alias."
 
 #: DELEGATION:REFERRAL_SIZE_LARGE
-msgid  "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
-msgstr "Den mindst mulige lovlige pakkestørrelse for henvisninger er større end 512 oktetter ({size})."
+msgid  ""
+"The smallest possible legal referral packet is larger than 512 octets (it is "
+"{size})."
+msgstr ""
+"Den mindst mulige lovlige pakkestørrelse for henvisninger er større end 512 "
+"oktetter ({size})."
 
 #: DELEGATION:REFERRAL_SIZE_OK
-msgid  "The smallest possible legal referral packet is smaller than 513 octets (it is {size})."
-msgstr "Den mindst mulige lovlige pakkestørrelse for henvisninger er mindre end eller lig med 512 oktetter ({size})."
+msgid  ""
+"The smallest possible legal referral packet is smaller than 513 octets (it "
+"is {size})."
+msgstr ""
+"Den mindst mulige lovlige pakkestørrelse for henvisninger er mindre end "
+"eller lig med 512 oktetter ({size})."
 
 #: DELEGATION:SAME_IP_ADDRESS
 msgid  "IP {address} refers to multiple nameservers ({nss})."
@@ -323,7 +401,8 @@ msgstr "Alle navneservere har en SOA-record."
 
 #: DELEGATION:SOA_NOT_EXISTS
 msgid  "A SOA query NOERROR response from {ns} was received empty."
-msgstr "En SOA-forespørgsel med RCODE NOERROR fra {ns} returnerede et tomt svar."
+msgstr ""
+"En SOA-forespørgsel med RCODE NOERROR fra {ns} returnerede et tomt svar."
 
 #: DELEGATION:TOTAL_NAME_MISMATCH
 msgid  "None of the nameservers listed at the parent are listed at the child."
@@ -334,32 +413,63 @@ msgid  "No DNSKEYs found. Additional tests skipped."
 msgstr "Ingen DNSKEY-records fundet. Yderligere tests ignoreret."
 
 #: DNSSEC:ALGORITHM_DEPRECATED
-msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-recorden med tag {keytag} anvender forældet algoritme nummer {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender forældet algoritme nummer "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_OK
-msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "DNSKEY-recorden med tag {keytag} anvender algoritme nummer {algorithm}/({description}), hvilket er OK."
+msgid  ""
+"The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
+"({description}), which is OK."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender algoritme nummer {algorithm}/"
+"({description}), hvilket er OK."
 
 #: DNSSEC:ALGORITHM_PRIVATE
-msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-recorden med tag {keytag} anvender den private algoritme med nummer {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender den private algoritme med nummer "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_RESERVED
-msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-recorden med tag {keytag} anvender reserveret algoritme nummer {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender reserveret algoritme nummer "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNASSIGNED
-msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-recorden med tag {keytag} anvender en ikke tildelt algoritme med nummer {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender en ikke tildelt algoritme med "
+"nummer {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNKNOWN
 msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
-msgstr "DNSKEY-recorden med tag {keytag} anvender ukendt algoritme med nummer {algorithm}."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender ukendt algoritme med nummer "
+"{algorithm}."
 
 #: DNSSEC:COMMON_KEYTAGS
 msgid  "There are both DS and DNSKEY records with key tags {keytags}."
 msgstr "Der findes både DS- and DNSKEY-records med keytag {keytags}."
+
+#: DNSSEC:DELEGATION_NOT_SIGNED
+msgid  "Delegation from parent to child is not properly signed {reason}."
+msgstr ""
+"Delegeringen fra forælder- til børnezone er ikke korrekt signeret ({reason})."
+
+#: DNSSEC:DELEGATION_SIGNED
+msgid  "Delegation from parent to child is properly signed."
+msgstr "Delegeringen fra forælder- til børnezonen er korrekt signeret."
 
 #: DNSSEC:DNSKEY_AND_DS
 msgid  "{parent} sent a DS record, and {child} a DNSKEY record."
@@ -367,19 +477,27 @@ msgstr "{parent} returnerede en DS-record, og {child} en DNSKEY-record."
 
 #: DNSSEC:DNSKEY_BUT_NOT_DS
 msgid  "{child} sent a DNSKEY record, but {parent} did not send a DS record."
-msgstr "{child} returnerede en DNSKEY-record, men {parent} returnerede ikke en DS-record."
+msgstr ""
+"{child} returnerede en DNSKEY-record, men {parent} returnerede ikke en DS-"
+"record."
 
 #: DNSSEC:DNSKEY_NOT_SIGNED
 msgid  "The apex DNSKEY RRset was not correctly signed."
 msgstr "DNSKEY RRset i zonetoppen var ikke korrekt signeret."
 
 #: DNSSEC:DNSKEY_SIGNATURE_NOT_OK
-msgid  "Signature for DNSKEY with tag {signature} failed to verify with error '{error}'."
-msgstr "Verificering af signaturen for DNSKEY-recorden med keytag {signature} fejlede med fejlmeddelelsen '{error}'."
+msgid  ""
+"Signature for DNSKEY with tag {signature} failed to verify with error "
+"'{error}'."
+msgstr ""
+"Verificering af signaturen for DNSKEY-recorden med keytag {signature} "
+"fejlede med fejlmeddelelsen '{error}'."
 
 #: DNSSEC:DNSKEY_SIGNATURE_OK
 msgid  "A signature for DNSKEY with tag {signature} was correctly signed."
-msgstr "Verificering af en signatur for DNSKEY-recorden med keytag {signature} lykkedes."
+msgstr ""
+"Verificering af en signatur for DNSKEY-recorden med keytag {signature} "
+"lykkedes."
 
 #: DNSSEC:DNSKEY_SIGNED
 msgid  "The apex DNSKEY RRset was correcly signed."
@@ -387,27 +505,40 @@ msgstr "DNSKEY RRset i zonetoppen var korrekt signeret."
 
 #: DNSSEC:DS_BUT_NOT_DNSKEY
 msgid  "{parent} sent a DS record, but {child} did not send a DNSKEY record."
-msgstr "{parent} returnerede en DS-record, men {child} returnerede ingen DNSKEY-record."
+msgstr ""
+"{parent} returnerede en DS-record, men {child} returnerede ingen DNSKEY-"
+"record."
 
 #: DNSSEC:DS_DIGTYPE_NOT_OK
 msgid  "DS record with keytag {keytag} uses forbidden digest type {digtype}."
-msgstr "DS-recorden med keytag {keytag} anvender en illegal digest-type {digtype}."
+msgstr ""
+"DS-recorden med keytag {keytag} anvender en illegal digest-type {digtype}."
 
 #: DNSSEC:DS_DIGTYPE_OK
 msgid  "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
-msgstr "DS-recorden med keytag {keytag} anvender digest-typen {digtype}, hvilket er OK."
+msgstr ""
+"DS-recorden med keytag {keytag} anvender digest-typen {digtype}, hvilket er "
+"OK."
 
 #: DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
-msgstr "DS-recorden med keytag {keytag} og digest type {digtype} matcher ikke DNSKEY-recorden med samme keytag."
-
-#: DNSSEC:DS_MATCHES_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY with the same tag."
-msgstr "DS-recorden med keytag {keytag} og digest type {digtype} matcher DNSKEY-recorden med samme keytag."
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} does not match the "
+"DNSKEY with the same tag."
+msgstr ""
+"DS-recorden med keytag {keytag} og digest type {digtype} matcher ikke DNSKEY-"
+"recorden med samme keytag."
 
 #: DNSSEC:DS_FOUND
 msgid  "Found DS records with tags {keytags}."
 msgstr "Fandt DS-records med tags {keytags}."
+
+#: DNSSEC:DS_MATCHES_DNSKEY
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
+"with the same tag."
+msgstr ""
+"DS-recorden med keytag {keytag} og digest type {digtype} matcher DNSKEY-"
+"recorden med samme keytag."
 
 #: DNSSEC:DS_MATCH_FOUND
 msgid  "At least one DS record with a matching DNSKEY record was found."
@@ -418,24 +549,41 @@ msgid  "No DS record with a matching DNSKEY record was found."
 msgstr "Ingen DS-record med en matchende DNSKEY-record blev fundet."
 
 #: DNSSEC:DS_RFC4509_NOT_VALID
-msgid  "Existing DS with digest type 2, while they do not match DNSKEY records, prevent use of DS with digest type 1 (RFC4509, section 3)."
-msgstr "Eksisterende DS med digest type 2 forbyder, på trods af, at de ikke matcher DNSKEY-records, brug af DS med digest type 1 (RFC4509, section 3)."
+msgid  ""
+"Existing DS with digest type 2, while they do not match DNSKEY records, "
+"prevent use of DS with digest type 1 (RFC4509, section 3)."
+msgstr ""
+"Eksisterende DS med digest type 2 forbyder, på trods af, at de ikke matcher "
+"DNSKEY-records, brug af DS med digest type 1 (RFC4509, section 3)."
 
 #: DNSSEC:DURATION_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is too long."
-msgstr "RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en gyldighed på {duration} sekunder, hvilket er for længe."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is too long."
+msgstr ""
+"RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en gyldighed "
+"på {duration} sekunder, hvilket er for længe."
 
 #: DNSSEC:DURATION_OK
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
-msgstr "RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en gyldighed på {duration} sekunder, hvilket er OK."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is just fine."
+msgstr ""
+"RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en gyldighed "
+"på {duration} sekunder, hvilket er OK."
 
 #: DNSSEC:EXTRA_PROCESSING_BROKEN
-msgid  "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
-msgstr "Navneserveren {server} returnerede {keys} DNSKEY-records, og {sigs} RRSIG-records."
+msgid  ""
+"Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
+msgstr ""
+"Navneserveren {server} returnerede {keys} DNSKEY-records, og {sigs} RRSIG-"
+"records."
 
 #: DNSSEC:EXTRA_PROCESSING_OK
 msgid  "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Navneserveren {server} returnerede {keys} DNSKEY-records, og {sigs} RRSIG-records."
+msgstr ""
+"Navneserveren {server} returnerede {keys} DNSKEY-records, og {sigs} RRSIG-"
+"records."
 
 #: DNSSEC:HAS_NSEC
 msgid  "The zone has NSEC records."
@@ -450,16 +598,24 @@ msgid  "The zone has NSEC3 opt-out records."
 msgstr "Zonen indeholder NSEC3 opt-out records."
 
 #: DNSSEC:INVALID_NAME_RCODE
-msgid  "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
-msgstr "Svaret på en forespørgsel om navnet {name}, som ikke må eksistere, returnerede RCODE {rcode}."
+msgid  ""
+"When asked for the name {name}, which must not exist, the response had RCODE "
+"{rcode}."
+msgstr ""
+"Svaret på en forespørgsel om navnet {name}, som ikke må eksistere, "
+"returnerede RCODE {rcode}."
 
 #: DNSSEC:ITERATIONS_OK
 msgid  "The number of NSEC3 iterations is {count}, which is OK."
 msgstr "Antallet af NSEC3-iterationer er {count}, hvilket er OK."
 
 #: DNSSEC:KEY_DETAILS
-msgid  "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
-msgstr "Key med keytag {keytag}, detaljer : Size = {keysize}, Flags ({sep}, {rfc5011})."
+msgid  ""
+"Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
+"{rfc5011})."
+msgstr ""
+"Key med keytag {keytag}, detaljer : Size = {keysize}, Flags ({sep}, "
+"{rfc5011})."
 
 #: DNSSEC:MANY_ITERATIONS
 msgid  "The number of NSEC3 iterations is {count}, which is on the high side."
@@ -486,12 +642,20 @@ msgid  "{from} returned no DS records for {zone}."
 msgstr "{from} returnerede ingen DS-records for {zone}."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS
-msgid  "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Kan ikke teste DNSKEY-signaturer, fordi vi fik {keys} DNSKEY-records og {sigs} RRSIG-records."
+msgid  ""
+"Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
+"{sigs} RRSIG records."
+msgstr ""
+"Kan ikke teste DNSKEY-signaturer, fordi vi fik {keys} DNSKEY-records og "
+"{sigs} RRSIG-records."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-msgid  "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} RRSIG records and {soas} SOA records."
-msgstr "Kan ikke teste SOA-signaturer på baggrund af {keys} DNSKEY-records, {sigs} RRSIG-records og {soas} SOA-records."
+msgid  ""
+"Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
+"RRSIG records and {soas} SOA records."
+msgstr ""
+"Kan ikke teste SOA-signaturer på baggrund af {keys} DNSKEY-records, {sigs} "
+"RRSIG-records og {soas} SOA-records."
 
 #: DNSSEC:NO_NSEC3PARAM
 msgid  "{server} returned no NSEC3PARAM records."
@@ -515,7 +679,9 @@ msgstr "Mindst en signatur signerede NSEC3 RRset korrekt."
 
 #: DNSSEC:NSEC3_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Forsøg på at verificere NSEC3 RRset med RRSIG {sig} returnerede fejlen '{error}'."
+msgstr ""
+"Forsøg på at verificere NSEC3 RRset med RRSIG {sig} returnerede fejlen "
+"'{error}'."
 
 #: DNSSEC:NSEC_COVERS
 msgid  "NSEC covers {name}."
@@ -535,31 +701,49 @@ msgstr "Mindst en signatur signerede NSEC RRset korrekt."
 
 #: DNSSEC:NSEC_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Forsøg på at verificere NSEC RRset med RRSIG {sig} returnerede fejlen '{error}'."
+msgstr ""
+"Forsøg på at verificere NSEC RRset med RRSIG {sig} returnerede fejlen "
+"'{error}'."
 
 #: DNSSEC:REMAINING_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
-msgstr "RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en resterende gyldighed på {duration} sekunder, hvilket er for længe."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too long."
+msgstr ""
+"RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en resterende "
+"gyldighed på {duration} sekunder, hvilket er for længe."
 
 #: DNSSEC:REMAINING_SHORT
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
-msgstr "RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en resterende gyldighed på {duration} sekunder, hvilket er for lidt."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too short."
+msgstr ""
+"RRSIG-recorden med keytag {tag}, dækkende typerne {types} har en resterende "
+"gyldighed på {duration} sekunder, hvilket er for lidt."
 
 #: DNSSEC:RRSIG_EXPIRATION
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
 msgstr "RRSIG med keytag {tag} dækkende typerne {types} udløber : {date}."
 
 #: DNSSEC:RRSIG_EXPIRED
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
-msgstr "RRSIG-recorden med {tag}, dækkende typerne {types}, er allerede udløbet (udløbsdato er: {expiration})."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has already expired "
+"(expiration is: {expiration})."
+msgstr ""
+"RRSIG-recorden med {tag}, dækkende typerne {types}, er allerede udløbet "
+"(udløbsdato er: {expiration})."
 
 #: DNSSEC:SOA_NOT_SIGNED
 msgid  "No RRSIG correctly signed the SOA RRset."
 msgstr "Ingen RRSIG signerede SOA RRset korrekt."
 
 #: DNSSEC:SOA_SIGNATURE_NOT_OK
-msgid  "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
-msgstr "Forsøg på at verificere SOA RRset med signatur {signature} returnerede fejlen '{error}'."
+msgid  ""
+"Trying to verify SOA RRset with signature {signature} gave error '{error}'."
+msgstr ""
+"Forsøg på at verificere SOA RRset med signatur {signature} returnerede "
+"fejlen '{error}'."
 
 #: DNSSEC:SOA_SIGNATURE_OK
 msgid  "RRSIG {signature} correctly signs SOA RRset."
@@ -570,28 +754,31 @@ msgid  "At least one RRSIG correctly signs the SOA RRset."
 msgstr "Mindst en RRSIG-record signerer SOA RRset korrekt."
 
 #: DNSSEC:TOO_MANY_ITERATIONS
-msgid  "The number of NSEC3 iterations is {count}, which is too high for key length {keylength}."
-msgstr "Antallet af NSEC3-iterationer er {count}, hvilket er for højt for nøglelængden {keylength}."
-
-#: DNSSEC:DELEGATION_NOT_SIGNED
-msgid  "Delegation from parent to child is not properly signed {reason}."
-msgstr "Delegeringen fra forælder- til børnezone er ikke korrekt signeret ({reason})."
-
-#: DNSSEC:DELEGATION_SIGNED
-msgid  "Delegation from parent to child is properly signed."
-msgstr "Delegeringen fra forælder- til børnezonen er korrekt signeret."
+msgid  ""
+"The number of NSEC3 iterations is {count}, which is too high for key length "
+"{keylength}."
+msgstr ""
+"Antallet af NSEC3-iterationer er {count}, hvilket er for højt for "
+"nøglelængden {keylength}."
 
 #: EXAMPLE:EXAMPLE_TAG
 msgid  "This is an example tag."
 msgstr "Dette er et eksempel-tag."
 
 #: NAMESERVER:AAAA_WELL_PROCESSED
-msgid  "The following nameservers answer AAAA queries without problems : {names}."
-msgstr "De følgende navneservere svarede problemfrit på alle AAAA-forespørgsler : {names}."
+msgid  ""
+"The following nameservers answer AAAA queries without problems : {names}."
+msgstr ""
+"De følgende navneservere svarede problemfrit på alle AAAA-forespørgsler : "
+"{names}."
 
 #: NAMESERVER:ANSWER_BAD_RCODE
-msgid  "Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode})."
-msgstr "Navneserveren {ns}/{address} besvarede en AAAA-forespørgsel med den uventede returkode ({rcode})."
+msgid  ""
+"Nameserver {ns}/{address} answered AAAA query with an unexpected rcode "
+"({rcode})."
+msgstr ""
+"Navneserveren {ns}/{address} besvarede en AAAA-forespørgsel med den uventede "
+"returkode ({rcode})."
 
 #: NAMESERVER:AXFR_AVAILABLE
 msgid  "Nameserver {ns}/{address} allow zone transfer using AXFR."
@@ -609,16 +796,81 @@ msgstr "Alle navneservere kan oversættes til en IP-adresse."
 msgid  "The following nameservers failed to resolve to an IP address : {names}."
 msgstr "IP-adresser bag følgende navneservere kunne ikke findes : {names}."
 
+#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers do not reply consistently."
+msgstr ""
+"Ikke alle navneservere svarede konsistent på forespørgsler vedrørende "
+"recordtype {type} på \"{query}\" med en blanding af versaler og minuskler."
+
+#: NAMESERVER:CASE_QUERIES_RESULTS_OK
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers reply consistently."
+msgstr ""
+"Alle navneservere svarede konsistent på forespørgsler vedrørende recordtype "
+"{type} på \"{query}\" med en blanding af versaler og minuskler."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different answers."
+msgstr ""
+"Navneserveren {ns}/{address} returnerede forskellige svar på forespørgsler "
+"vedrørende recordtype {type} på \"{query1}\" og \"{query2}\"."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+msgstr ""
+"Navneserveren {ns}/{address} returnerede forskellige RCODE (\"{rcode1}\" vs "
+"\"{rcode2}\") på forespørgsler vedrørende recordtype {type} på \"{query1}\" "
+"og \"{query2}\"."
+
+#: NAMESERVER:CASE_QUERY_NO_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query}\", nameserver {ns}/{address} "
+"returns nothing."
+msgstr ""
+"Navneserveren {ns}/{address} returnerede intet svar på forespørgsel "
+"vedrørende recordtype {type} på \"{query}\"."
+
+#: NAMESERVER:CASE_QUERY_SAME_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same answers."
+msgstr ""
+"Navneserveren {ns}/{address} returnerede ens svar på forespørgsler "
+"vedrørende recordtype {type} på \"{query1}\" og \"{query2}\"."
+
+#: NAMESERVER:CASE_QUERY_SAME_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same RCODE \"{rcode}\"."
+msgstr ""
+"Navneserveren {ns}/{address} returnerede samme RCODE \"{rcode}\" på "
+"forespørgsler vedrørende recordtype {type} på \"{query1}\" og \"{query2}\"."
+
 #: NAMESERVER:DIFFERENT_SOURCE_IP
-msgid  "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
-msgstr "Navneserveren {ns}/{address} svarede på en SOA-forespørgsel fra en anden kilde ({source})."
+msgid  ""
+"Nameserver {ns}/{address} replies on a SOA query with a different source "
+"address ({source})."
+msgstr ""
+"Navneserveren {ns}/{address} svarede på en SOA-forespørgsel fra en anden "
+"kilde ({source})."
 
 #: NAMESERVER:EDNS0_BAD_ANSWER
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
-msgstr "Navneserveren {ns}/{address} understøtter ikke EDNS0 (OPT ikke markeret i svaret)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
+msgstr ""
+"Navneserveren {ns}/{address} understøtter ikke EDNS0 (OPT ikke markeret i "
+"svaret)."
 
 #: NAMESERVER:EDNS0_BAD_QUERY
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
 msgstr "Navneserveren {ns}/{address} understøtter ikke EDNS0 (svarer FORMERR)."
 
 #: NAMESERVER:EDNS0_SUPPORT
@@ -633,81 +885,74 @@ msgstr "Navneserveren {ns}/{address} er rekursiv."
 msgid  "None of the following nameservers is a recursor : {names}."
 msgstr "Ingen af de følgende navneservere er rekursive : {names}."
 
-#: NAMESERVER:RECURSIVITY_UNDEF
-msgid  "Can not determine nameservers recursivity."
-msgstr "Kan ikke afgøre, om navneserverne er rekursive."
-
 #: NAMESERVER:NO_RESOLUTION
 msgid  "No nameservers succeeded to resolve to an IP address."
 msgstr "IP-adresse ikke fundet for nogen af navneserverne."
+
+#: NAMESERVER:NO_UPWARD_REFERRAL
+msgid  "None of the following nameservers returns an upward referral : {names}."
+msgstr ""
+"Ingen af følgende navneservere returnerede en opadgående henvisning : "
+"{names}."
+
+#: NAMESERVER:QNAME_CASE_INSENSITIVE
+msgid  ""
+"Nameserver {ns}/{address} does not preserve original case of queried names."
+msgstr ""
+"Nameservern {ns}/{address} bevarede ikke versaler og minuskler fra "
+"forespørgslen."
+
+#: NAMESERVER:QNAME_CASE_SENSITIVE
+msgid  "Nameserver {ns}/{address} preserves original case of queried names."
+msgstr ""
+"Navneserveren {ns}/{address} bevarede versaler og minuskler fra "
+"forespørgslen."
 
 #: NAMESERVER:QUERY_DROPPED
 msgid  "Nameserver {ns}/{address} dropped AAAA query."
 msgstr "Navneserveren {ns}/{address} mistede en AAAA-forespørgsel."
 
+#: NAMESERVER:RECURSIVITY_UNDEF
+#, fuzzy
+msgid  ""
+"Cannot determine if the following servers are recursive nameservers or not: "
+"{names}."
+msgstr "Ingen af de følgende navneservere er rekursive : {names}."
+
 #: NAMESERVER:SAME_SOURCE_IP
 msgid  "All nameservers reply with same IP used to query them."
 msgstr "Alle navneservere svarede fra samme IP-adresse som de blev spurgt på."
+
+#: NAMESERVER:UPWARD_REFERRAL
+msgid  "Nameserver {ns}/{address} returns an upward referral."
+msgstr ""
+"Nameservern {ns}/{address} returnerede en henvisning til en forælderzone."
 
 #: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
 msgid  "Upward referral tests skipped for root zone."
 msgstr "Opadgående test af henvisninger springes over for root-zonen."
 
-#: NAMESERVER:UPWARD_REFERRAL
-msgid  "Nameserver {ns}/{address} returns an upward referral."
-msgstr "Nameservern {ns}/{address} returnerede en henvisning til en forælderzone."
-
-#: NAMESERVER:NO_UPWARD_REFERRAL
-msgid  "None of the following nameservers returns an upward referral : {names}."
-msgstr "Ingen af følgende navneservere returnerede en opadgående henvisning : {names}."
-
-#: NAMESERVER:QNAME_CASE_SENSITIVE
-msgid  "Nameserver {ns}/{address} preserves original case of queried names."
-msgstr "Navneserveren {ns}/{address} bevarede versaler og minuskler fra forespørgslen."
-
-#: NAMESERVER:QNAME_CASE_INSENSITIVE
-msgid  "Nameserver {ns}/{address} does not preserve original case of queried names."
-msgstr "Nameservern {ns}/{address} bevarede ikke versaler og minuskler fra forespørgslen."
-
-#: NAMESERVER:CASE_QUERY_SAME_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-msgstr "Navneserveren {ns}/{address} returnerede ens svar på forespørgsler vedrørende recordtype {type} på \"{query1}\" og \"{query2}\"."
-
-#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-msgstr "Navneserveren {ns}/{address} returnerede forskellige svar på forespørgsler vedrørende recordtype {type} på \"{query1}\" og \"{query2}\"."
-
-#: NAMESERVER:CASE_QUERY_SAME_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "Navneserveren {ns}/{address} returnerede samme RCODE \"{rcode}\" på forespørgsler vedrørende recordtype {type} på \"{query1}\" og \"{query2}\"."
-
-#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "Navneserveren {ns}/{address} returnerede forskellige RCODE (\"{rcode1}\" vs \"{rcode2}\") på forespørgsler vedrørende recordtype {type} på \"{query1}\" og \"{query2}\"."
-
-#: NAMESERVER:CASE_QUERY_NO_ANSWER
-msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-msgstr "Navneserveren {ns}/{address} returnerede intet svar på forespørgsel vedrørende recordtype {type} på \"{query}\"."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_OK
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-msgstr "Alle navneservere svarede konsistent på forespørgsler vedrørende recordtype {type} på \"{query}\" med en blanding af versaler og minuskler."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
-msgstr "Ikke alle navneservere svarede konsistent på forespørgsler vedrørende recordtype {type} på \"{query}\" med en blanding af versaler og minuskler."
-
 #: SYNTAX:DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domænenavnet ({name}) har en label ({label}) med bindestreg i position 3 og 4, og et præfiks som ikke er 'xn--'."
+msgid  ""
+"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domænenavnet ({name}) har en label ({label}) med bindestreg i position 3 og "
+"4, og et præfiks som ikke er 'xn--'."
 
 #: SYNTAX:INITIAL_HYPHEN
-msgid  "Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
-msgstr "Domænenavnet ({name}) har en label ({label}) som begynder med en bindestreg."
+msgid  ""
+"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+msgstr ""
+"Domænenavnet ({name}) har en label ({label}) som begynder med en bindestreg."
 
 #: SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
-msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "SOA MNAME ({name}) har en label ({label}) med bindestreg i position 3 og 4 (og et præfix som ikke er 'xn--'."
+msgid  ""
+"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"SOA MNAME ({name}) har en label ({label}) med bindestreg i position 3 og 4 "
+"(og et præfix som ikke er 'xn--'."
 
 #: SYNTAX:MNAME_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in SOA MNAME ({name})."
@@ -722,8 +967,12 @@ msgid  "SOA MNAME ({name}) syntax is valid."
 msgstr "SOA MNAME ({name}) syntaks er valid."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domænets MX ({name}) har en label ({label}) med bindestreg i position 3 og 4, og et præfiks som ikke er 'xn--'."
+msgid  ""
+"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domænets MX ({name}) har en label ({label}) med bindestreg i position 3 og "
+"4, og et præfiks som ikke er 'xn--'."
 
 #: SYNTAX:MX_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in MX ({name})."
@@ -738,8 +987,12 @@ msgid  "Domain name MX ({name}) syntax is valid."
 msgstr "Domænenavnets MX-record ({name}) syntaks er valid."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
-msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Navneserveren ({name}) har en label ({label}) med bindestreg i position 3 og 4, og et præfiks som ikke er 'xn--'."
+msgid  ""
+"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Navneserveren ({name}) har en label ({label}) med bindestreg i position 3 og "
+"4, og et præfiks som ikke er 'xn--'."
 
 #: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the nameserver ({name})."
@@ -758,12 +1011,18 @@ msgid  "Found illegal characters in the domain name ({name})."
 msgstr "Ulovlige tegn fundet i domænenavnet ({name})."
 
 #: SYNTAX:NO_DOUBLE_DASH
-msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domænenavnet ({name}) indeholder ikke bindestreg i position 3 og 4 (med et præfiks, der ikke er 'xn--')."
+msgid  ""
+"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
+"and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domænenavnet ({name}) indeholder ikke bindestreg i position 3 og 4 (med et "
+"præfiks, der ikke er 'xn--')."
 
 #: SYNTAX:NO_ENDING_HYPHENS
 msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
-msgstr "Alle labels i domænenavnet ({name}) begynder eller slutter ikke med bindestreg."
+msgstr ""
+"Alle labels i domænenavnet ({name}) begynder eller slutter ikke med "
+"bindestreg."
 
 #: SYNTAX:NO_RESPONSE_MX_QUERY ZONE:NO_RESPONSE_MX_QUERY
 msgid  "No response from nameserver(s) on MX queries."
@@ -778,7 +1037,8 @@ msgid  "No illegal characters in the domain name ({name})."
 msgstr "Udelukkende lovlige tegn i domænenavnet ({name})."
 
 #: SYNTAX:RNAME_MISUSED_AT_SIGN
-msgid  "There must be no misused '@' character in the SOA RNAME field ({rname})."
+msgid  ""
+"There must be no misused '@' character in the SOA RNAME field ({rname})."
 msgstr "'@' må ikke anvendes i SOA RNAME ({rname})."
 
 #: SYNTAX:RNAME_NO_AT_SIGN
@@ -795,7 +1055,8 @@ msgstr "SOA RNAME værdi ({rname}) overholder RFC2822."
 
 #: SYNTAX:TERMINAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) ending with an hyphen ('-')."
-msgstr "Domænenavnet ({name}) har en label ({label}) som slutter med en bindestreg."
+msgstr ""
+"Domænenavnet ({name}) har en label ({label}) som slutter med en bindestreg."
 
 #: SYSTEM:ADDED_FAKE_DELEGATION
 msgid  "Added a fake delegation for domain {domain} to name server {ns}."
@@ -803,7 +1064,9 @@ msgstr "Tilføjet en falsk delegering for {domain} til navneserver {ns}."
 
 #: SYSTEM:CANNOT_CONTINUE
 msgid  "Not enough data about {zone} was found to be able to run tests."
-msgstr "Kunne ikke finde tilstrækkeligt med information om {zone} til at afvikle test."
+msgstr ""
+"Kunne ikke finde tilstrækkeligt med information om {zone} til at afvikle "
+"test."
 
 #: SYSTEM:CONFIG_FILE
 msgid  "Configuration was read from {name}."
@@ -813,33 +1076,51 @@ msgstr "Konfigurationen blev hentet fra {name}."
 msgid  "Using prerequisite module {name} version {version}."
 msgstr "Anvender version {version} af modulet {name}."
 
-#: SYSTEM:GLOBAL_VERSION
-msgid  "Using version {version} of the Zonemaster engine."
-msgstr "Anvender version {version} af Zonemasters testmotor."
-
 #: SYSTEM:FAKE_DELEGATION
 msgid  "Followed a fake delegation."
 msgstr "Fulgte en falsk delegering."
 
-#: SYSTEM:FAKE_DELEGATION_TO_SELF
-msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Navneserveren {ns} tilføjede ikke en falsk delegering for domænet {domain}."
-
 #: SYSTEM:FAKE_DELEGATION_IN_ZONE_NO_IP
-msgid  "The fake delegation of domain {domain} includes an in-zone name server {ns} without mandatory glue (without IP address)."
-msgstr "Ugyldig delegation for domænenavnet {domain} til zone indeholdende en navneserver {ns} uden IP-adresse."
+msgid  ""
+"The fake delegation of domain {domain} includes an in-zone name server {ns} "
+"without mandatory glue (without IP address)."
+msgstr ""
+"Ugyldig delegation for domænenavnet {domain} til zone indeholdende en "
+"navneserver {ns} uden IP-adresse."
 
 #: SYSTEM:FAKE_DELEGATION_NO_IP
-msgid  "The fake delegation of domain {domain} includes a name server {ns} that cannot be resolved to any IP address."
-msgstr "Ugyldig delegation for domænenavnet {domain} til en navneserver {ns} uden IP-adresse."
+msgid  ""
+"The fake delegation of domain {domain} includes a name server {ns} that "
+"cannot be resolved to any IP address."
+msgstr ""
+"Ugyldig delegation for domænenavnet {domain} til en navneserver {ns} uden IP-"
+"adresse."
+
+#: SYSTEM:FAKE_DELEGATION_TO_SELF
+msgid  ""
+"Name server {ns} not adding fake delegation for domain {domain} to itself."
+msgstr ""
+"Navneserveren {ns} tilføjede ikke en falsk delegering for domænet {domain}."
+
+#: SYSTEM:GLOBAL_VERSION
+msgid  "Using version {version} of the Zonemaster engine."
+msgstr "Anvender version {version} af Zonemasters testmotor."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
-msgstr "Callback-funktionen for log-modulet døde med fejlmeddelelsen: {exception}"
+msgstr ""
+"Callback-funktionen for log-modulet døde med fejlmeddelelsen: {exception}"
 
 #: SYSTEM:LOOKUP_ERROR
-msgid  "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
-msgstr "DNS-forespørgsel til {ns} på {name}/{type}/{class} fejlede med beskeden: {message}"
+msgid  ""
+"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+msgstr ""
+"DNS-forespørgsel til {ns} på {name}/{type}/{class} fejlede med beskeden: "
+"{message}"
+
+#: SYSTEM:MODULE_END
+msgid  "Module {module} finished running."
+msgstr "Modulet {module} afsluttede."
 
 #: SYSTEM:MODULE_ERROR
 msgid  "Fatal error in {module}: {msg}"
@@ -849,13 +1130,17 @@ msgstr "Fatal fejl i {module}: {msg}"
 msgid  "Using module {module} version {version}."
 msgstr "Anvender version {version} af modulet {module}."
 
-#: SYSTEM:MODULE_END
-msgid  "Module {module} finished running."
-msgstr "Modulet {module} afsluttede."
-
 #: SYSTEM:NO_NETWORK
 msgid  "Both IPv4 and IPv6 are disabled."
 msgstr "Både IPv4 og IPv6 er deaktiveret."
+
+#: SYSTEM:PACKET_BIG
+msgid  ""
+"Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try "
+"with \"{command}\")."
+msgstr ""
+"Pakkestørrelse ({size}) overstiger normal maksimum størrelse på {maxsize} "
+"bytes (prøv med \"{command}\")."
 
 #: SYSTEM:POLICY_DISABLED
 msgid  "The module {name} was disabled by the policy."
@@ -875,27 +1160,39 @@ msgstr "IPv6 er deaktiveret, sender ingen forespørgsel til {ns}."
 
 #: SYSTEM:UNKNOWN_METHOD
 msgid  "Request to run unknown method {method} in module {module}."
-msgstr "Anmodning om at afvikle den ukendte metode {method} i modulet {module}."
+msgstr ""
+"Anmodning om at afvikle den ukendte metode {method} i modulet {module}."
 
 #: SYSTEM:UNKNOWN_MODULE
-msgid  "Request to run {method} in unknown module {module}. Known modules: {known}."
-msgstr "Anmodning om at afvikle metoden {method} i det ukendte modul {module}. Kendte moduler: {known}."
-
-#: SYSTEM:PACKET_BIG
-msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
-msgstr "Pakkestørrelse ({size}) overstiger normal maksimum størrelse på {maxsize} bytes (prøv med \"{command}\")."
+msgid  ""
+"Request to run {method} in unknown module {module}. Known modules: {known}."
+msgstr ""
+"Anmodning om at afvikle metoden {method} i det ukendte modul {module}. "
+"Kendte moduler: {known}."
 
 #: ZONE:EXPIRE_LOWER_THAN_REFRESH
-msgid  "SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value ({refresh})."
-msgstr "Værdien for SOA 'expire' ({expire}) er mindre end værdien for SOA 'refresh' ({refresh})."
+msgid  ""
+"SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value "
+"({refresh})."
+msgstr ""
+"Værdien for SOA 'expire' ({expire}) er mindre end værdien for SOA "
+"'refresh' ({refresh})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_LOWER
-msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({required_expire})."
-msgstr "Værdien for SOA 'expire' ({expire}) er mindre end anbefalet ({required_expire})."
+msgid  ""
+"SOA 'expire' value ({expire}) is less than the recommended one "
+"({required_expire})."
+msgstr ""
+"Værdien for SOA 'expire' ({expire}) er mindre end anbefalet "
+"({required_expire})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
-msgstr "SOA 'expire' værdi ({expire}) er højere end den anbefalede minimumsværdi ({required_expire}) og ikke mindre end 'refresh' værdi ({refresh})."
+msgid  ""
+"SOA 'expire' value ({expire}) is higher than the minimum recommended value "
+"({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr ""
+"SOA 'expire' værdi ({expire}) er højere end den anbefalede minimumsværdi "
+"({required_expire}) og ikke mindre end 'refresh' værdi ({refresh})."
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."
@@ -907,19 +1204,26 @@ msgstr "SOA 'MNAME'-navneserveren ({mname}) er autoritativ for zonen '{zone}'."
 
 #: ZONE:MNAME_IS_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
-msgstr "SOA 'MNAME' ({mname}) refererer til en NS-record som er et alias (CNAME)."
+msgstr ""
+"SOA 'MNAME' ({mname}) refererer til en NS-record som er et alias (CNAME)."
 
 #: ZONE:MNAME_IS_NOT_CNAME
-msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
+msgid  ""
+"SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
 msgstr "SOA MNAME {mname} refererer ikke til et alias (CNAME)."
 
 #: ZONE:MNAME_NOT_AUTHORITATIVE
-msgid  "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
+msgid  ""
+"SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
 msgstr "SOA 'MNAME' ({ns}/{address}) er ikke autoritativ for zonen '{zone}'."
 
 #: ZONE:MNAME_NOT_IN_GLUE
-msgid  "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for tested zone ({ns})."
-msgstr "Navneserveren i SOA 'MNAME' ({mname}) er ikke blandt de NS-records ({ns}) som angivet i forælderzonen \"parent\"."
+msgid  ""
+"SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
+"tested zone ({ns})."
+msgstr ""
+"Navneserveren i SOA 'MNAME' ({mname}) er ikke blandt de NS-records ({ns}) "
+"som angivet i forælderzonen \"parent\"."
 
 #: ZONE:MNAME_NO_RESPONSE
 msgid  "SOA 'mname' nameserver {ns}/{address} does not respond."
@@ -943,40 +1247,79 @@ msgstr "MX-record for domænenavnet peger ikke på et alias (CNAME)."
 
 #: ZONE:NO_MX_RECORD
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
-msgstr "Manglende RR til levering af e-mail (MX-, A- eller AAAA-record) for domænet."
+msgstr ""
+"Manglende RR til levering af e-mail (MX-, A- eller AAAA-record) for domænet."
 
 #: ZONE:REFRESH_HIGHER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
-msgstr "SOA 'refresh'-værdi ({refresh}) er større end SOA 'retry'-værdi ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"SOA 'refresh'-værdi ({refresh}) er større end SOA 'retry'-værdi ({retry})."
 
 #: ZONE:REFRESH_LOWER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value ({retry})."
-msgstr "SOA-recordens 'refresh'-værdi ({refresh}) er mindre end SOA 'retry'-værdi ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"SOA-recordens 'refresh'-værdi ({refresh}) er mindre end SOA 'retry'-værdi "
+"({retry})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_LOWER
-msgid  "SOA 'refresh' value ({refresh}) is less than the recommended one ({required_refresh})."
-msgstr "SOA-recordens 'refresh'-værdi ({refresh}) er mindre end anbefalet værdi ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is less than the recommended one "
+"({required_refresh})."
+msgstr ""
+"SOA-recordens 'refresh'-værdi ({refresh}) er mindre end anbefalet værdi "
+"({required_refresh})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_OK
-msgid  "SOA 'refresh' value ({refresh}) is higher than the minimum recommended value ({required_refresh})."
-msgstr "SOA 'refresh'-værdi ({refresh}) er større end den anbefalede minimumsværdi ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the minimum recommended value "
+"({required_refresh})."
+msgstr ""
+"SOA 'refresh'-værdi ({refresh}) er større end den anbefalede minimumsværdi "
+"({required_refresh})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_LOWER
-msgid  "SOA 'retry' value ({retry}) is less than the recommended one ({required_retry})."
-msgstr "SOA-recordens 'retry'-værdi ({retry}) er mindre end anbefalet værdi ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is less than the recommended one "
+"({required_retry})."
+msgstr ""
+"SOA-recordens 'retry'-værdi ({retry}) er mindre end anbefalet værdi "
+"({required_retry})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_OK
-msgid  "SOA 'retry' value ({retry}) is more than the minimum recommended value ({required_retry})."
-msgstr "SOA 'retry'-værdi ({retry}) er større end den anbefalede minimumsværdi ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is more than the minimum recommended value "
+"({required_retry})."
+msgstr ""
+"SOA 'retry'-værdi ({retry}) er større end den anbefalede minimumsværdi "
+"({required_retry})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_HIGHER
-msgid  "SOA 'minimum' value ({minimum}) is higher than the recommended one ({highest_minimum})."
-msgstr "SOA-recordens 'minimum'-værdi ({minimum}) er større end anbefalet værdi ({highest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is higher than the recommended one "
+"({highest_minimum})."
+msgstr ""
+"SOA-recordens 'minimum'-værdi ({minimum}) er større end anbefalet værdi "
+"({highest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_LOWER
-msgid  "SOA 'minimum' value ({minimum}) is less than the recommended one ({lowest_minimum})."
-msgstr "SOA-recordens 'minimum'-værdi ({minimum}) er mindre end anbefalet værdi ({lowest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is less than the recommended one "
+"({lowest_minimum})."
+msgstr ""
+"SOA-recordens 'minimum'-værdi ({minimum}) er mindre end anbefalet værdi "
+"({lowest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_OK
-msgid  "SOA 'minimum' value ({minimum}) is between the recommended ones ({lowest_minimum}/{highest_minimum})."
-msgstr "SOA 'minimum' værdi ({minimum}) er i det anbefalede område ({lowest_minimum}/{highest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is between the recommended ones "
+"({lowest_minimum}/{highest_minimum})."
+msgstr ""
+"SOA 'minimum' værdi ({minimum}) er i det anbefalede område ({lowest_minimum}/"
+"{highest_minimum})."
+
+#~ msgid "Can not determine nameservers recursivity."
+#~ msgstr "Kan ikke afgøre, om navneserverne er rekursive."

--- a/share/en.po
+++ b/share/en.po
@@ -1,29 +1,37 @@
-msgid ""
+msgid  ""
 msgstr ""
-"Language: en\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 1.0.0\n"
 "PO-Revision-Date: 2017-12-18\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #: ADDRESS:NAMESERVERS_IP_WITH_REVERSE
 msgid  "Reverse DNS entry exist for all Nameserver IP addresses."
 msgstr "Reverse DNS entry exists for each Nameserver IP address."
 
 #: ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
-msgid  "Nameserver {ns} has an IP address ({address}) with prefix {prefix} referenced in {reference} as a '{name}'."
-msgstr "Nameserver {ns} has an IP address ({address}) with prefix {prefix} referenced in {reference} as a '{name}'."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with prefix {prefix} "
+"referenced in {reference} as a '{name}'."
+msgstr ""
+"Nameserver {ns} has an IP address ({address}) with prefix {prefix} "
+"referenced in {reference} as a '{name}'."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MATCH
 msgid  "All reverse DNS entry matches name server name."
 msgstr "Every reverse DNS entry matches name server name."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MISMATCH
-msgid  "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
-msgstr "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with mismatched PTR result "
+"({names})."
+msgstr ""
+"Nameserver {ns} has an IP address ({address}) with mismatched PTR result "
+"({names})."
 
 #: ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
 msgid  "Nameserver {ns} has an IP address ({address}) without PTR configured."
@@ -42,8 +50,10 @@ msgid  "Nameservers did not respond to A query."
 msgstr "Nameservers did not respond to A query."
 
 #: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
-msgstr "Label ({dlabel}) in domain name ({dname}) is too long ({dlength}/{max})."
+msgid  ""
+"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+msgstr ""
+"Label ({dlabel}) in domain name ({dname}) is too long ({dlength}/{max})."
 
 #: BASIC:DOMAIN_NAME_TOO_LONG
 msgid  "Domain name is too long ({fqdnlength}/{max})."
@@ -69,7 +79,8 @@ msgstr "Functional nameserver found. \"A\" query for www.{zname} test skipped."
 msgid  "Parent domain '{pname}' was found for the tested domain."
 msgstr "Parent domain '{pname}' was found for the tested domain."
 
-#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
+#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED
+#: DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 
@@ -77,7 +88,8 @@ msgstr "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
 
-#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
+#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED
+#: DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 
@@ -99,11 +111,32 @@ msgstr "No parent domain could be found for the domain under test."
 
 #: BASIC:NS_FAILED
 msgid  "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
-msgstr "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
+msgstr ""
+"Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
 
 #: BASIC:NS_NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond to NS query."
 msgstr "Nameserver {ns}/{address} did not respond to NS query."
+
+#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
+msgid  "[ASN:ANNOUNCE_BY] {address};{asn}"
+msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
+
+#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
+msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
+msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
+
+#: CONNECTIVITY:ASN_INFOS_RAW
+msgid  "[ASN:RAW] {address};{data}"
+msgstr "[ASN:RAW] {address};{data}"
+
+#: CONNECTIVITY:IPV4_ASN
+msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
+msgstr "Name servers have IPv4 addresses in the following ASs: {asn}."
+
+#: CONNECTIVITY:IPV6_ASN
+msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
+msgstr "Name servers have IPv6 addresses in the following ASs: {asn}."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
@@ -115,7 +148,8 @@ msgstr "Authoritative IPv4 nameservers are in more than one AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_WITH_UNIQ_AS
 msgid  "All nameservers IPv4 addresses are in the same AS ({asn})."
-msgstr "All nameservers in the delegation have IPv4 addresses in the same AS ({asn})."
+msgstr ""
+"All nameservers in the delegation have IPv4 addresses in the same AS ({asn})."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
 msgid  "No IPv6 nameserver address is in an AS."
@@ -127,7 +161,8 @@ msgstr "Authoritative IPv6 nameservers are in more than one AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_WITH_UNIQ_AS
 msgid  "All nameservers IPv6 addresses are in the same AS ({asn})."
-msgstr "All nameservers in the delegation have IPv6 addresses in the same AS ({asn})."
+msgstr ""
+"All nameservers in the delegation have IPv6 addresses in the same AS ({asn})."
 
 #: CONNECTIVITY:NAMESERVERS_NO_AS
 msgid  "No nameserver address is in an AS."
@@ -157,25 +192,21 @@ msgstr "Nameserver {ns}/{address} not accessible over TCP on port 53."
 msgid  "Nameserver {ns}/{address} not accessible over UDP on port 53."
 msgstr "Nameserver {ns}/{address} not accessible over UDP on port 53."
 
-#: CONNECTIVITY:IPV4_ASN
-msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
-msgstr "Name servers have IPv4 addresses in the following ASs: {asn}."
+#: CONSISTENCY:ADDRESSES_MATCH
+msgid  "Glue records are consistent between glue and authoritative data."
+msgstr "Glue records are consistent between glue and authoritative data."
 
-#: CONNECTIVITY:IPV6_ASN
-msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
-msgstr "Name servers have IPv6 addresses in the following ASs: {asn}."
+#: CONSISTENCY:EXTRA_ADDRESS_CHILD
+msgid  ""
+"Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+msgstr ""
+"Child has extra nameserver IP address(es) not listed at parent ({addresses})."
 
-#: CONNECTIVITY:ASN_INFOS_RAW
-msgid  "[ASN:RAW] {address};{data}"
-msgstr "[ASN:RAW] {address};{data}"
-
-#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
-msgid  "[ASN:ANNOUNCE_BY] {address};{asn}"
-msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
-
-#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
-msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
-msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
+#: CONSISTENCY:EXTRA_ADDRESS_PARENT
+msgid  ""
+"Parent has extra nameserver IP address(es) not listed at child ({addresses})."
+msgstr ""
+"Parent has extra nameserver IP address(es) not listed at child ({addresses})."
 
 #: CONSISTENCY:MULTIPLE_NS_SET
 msgid  "Saw {count} NS set."
@@ -222,8 +253,12 @@ msgid  "A single SOA serial number was seen ({serial})."
 msgstr "A single SOA serial number was found ({serial})."
 
 #: CONSISTENCY:ONE_SOA_TIME_PARAMETER_SET
-msgid  "A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
-msgstr "A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
+msgid  ""
+"A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum})."
+msgstr ""
+"A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum})."
 
 #: CONSISTENCY:SOA_RNAME
 msgid  "Saw SOA rname {rname} on following nameserver set : {servers}."
@@ -231,31 +266,32 @@ msgstr "Found SOA rname {rname} on following nameserver set : {servers}."
 
 #: CONSISTENCY:SOA_SERIAL
 msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
-msgstr "Found SOA serial number {serial} on following nameserver set : {servers}."
+msgstr ""
+"Found SOA serial number {serial} on following nameserver set : {servers}."
 
 #: CONSISTENCY:SOA_SERIAL_VARIATION
-msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
-msgstr "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
+msgid  ""
+"Difference between the smaller serial ({serial_min}) and the bigger one "
+"({serial_max}) is greater than the maximum allowed ({max_variation})."
+msgstr ""
+"Difference between the smaller serial ({serial_min}) and the bigger one "
+"({serial_max}) is greater than the maximum allowed ({max_variation})."
 
 #: CONSISTENCY:SOA_TIME_PARAMETER_SET
-msgid  "Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
-msgstr "Found SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
-
-#: CONSISTENCY:EXTRA_ADDRESS_PARENT
-msgid  "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
-msgstr "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
-
-#: CONSISTENCY:EXTRA_ADDRESS_CHILD
-msgid  "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
-msgstr "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+msgid  ""
+"Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},"
+"MINIMUM={minimum}) on following nameserver set : {servers}."
+msgstr ""
+"Found SOA time parameter set (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
 
 #: CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-msgid  "No common nameserver IP addresses between child ({child}) and parent ({glue})."
-msgstr "No common nameserver IP addresses between child ({child}) and parent ({glue})."
-
-#: CONSISTENCY:ADDRESSES_MATCH
-msgid  "Glue records are consistent between glue and authoritative data."
-msgstr "Glue records are consistent between glue and authoritative data."
+msgid  ""
+"No common nameserver IP addresses between child ({child}) and parent "
+"({glue})."
+msgstr ""
+"No common nameserver IP addresses between child ({child}) and parent "
+"({glue})."
 
 #: DELEGATION:ARE_AUTHORITATIVE
 msgid  "All these nameservers are confirmed to be authoritative : {nsset}."
@@ -266,12 +302,20 @@ msgid  "All the IP addresses used by the nameservers are unique"
 msgstr "All the IP addresses used by the nameservers are unique"
 
 #: DELEGATION:ENOUGH_NS
-msgid  "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
+msgid  ""
+"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
 
 #: DELEGATION:ENOUGH_NS_GLUE
-msgid  "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
+msgid  ""
+"Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
+"{minimum}."
 
 #: DELEGATION:EXTRA_NAME_CHILD
 msgid  "Child has nameserver(s) not listed at parent ({extra})."
@@ -290,12 +334,20 @@ msgid  "All of the nameserver names are listed both at parent and child."
 msgstr "All of the nameserver names are listed both at parent and child."
 
 #: DELEGATION:NOT_ENOUGH_NS
-msgid  "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
+msgid  ""
+"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_GLUE
-msgid  "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
+msgid  ""
+"Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
+"to {minimum}."
+msgstr ""
+"Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
+"to {minimum}."
 
 #: DELEGATION:NS_RR_IS_CNAME
 msgid  "Nameserver {ns} {address_type} RR point to CNAME."
@@ -306,12 +358,20 @@ msgid  "No nameserver point to CNAME alias."
 msgstr "No nameserver points to CNAME alias."
 
 #: DELEGATION:REFERRAL_SIZE_LARGE
-msgid  "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
-msgstr "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
+msgid  ""
+"The smallest possible legal referral packet is larger than 512 octets (it is "
+"{size})."
+msgstr ""
+"The smallest possible legal referral packet is larger than 512 octets (it is "
+"{size})."
 
 #: DELEGATION:REFERRAL_SIZE_OK
-msgid  "The smallest possible legal referral packet is smaller than 513 octets (it is {size})."
-msgstr "The smallest possible legal referral packet is smaller than 513 octets (it is {size})."
+msgid  ""
+"The smallest possible legal referral packet is smaller than 513 octets (it "
+"is {size})."
+msgstr ""
+"The smallest possible legal referral packet is smaller than 513 octets (it "
+"is {size})."
 
 #: DELEGATION:SAME_IP_ADDRESS
 msgid  "IP {address} refers to multiple nameservers ({nss})."
@@ -334,32 +394,61 @@ msgid  "No DNSKEYs found. Additional tests skipped."
 msgstr "No DNSKEYs found. Additional tests skipped."
 
 #: DNSSEC:ALGORITHM_DEPRECATED
-msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
+"({description})."
 
 #: DNSSEC:ALGORITHM_OK
-msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}) [OK]."
+msgid  ""
+"The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
+"({description}), which is OK."
+msgstr ""
+"The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
+"({description}) [OK]."
 
 #: DNSSEC:ALGORITHM_PRIVATE
-msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
+"({description})."
 
 #: DNSSEC:ALGORITHM_RESERVED
-msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
-msgstr "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
+"({description})."
 
 #: DNSSEC:ALGORITHM_UNASSIGNED
-msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
-msgstr "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
+"({description})."
 
 #: DNSSEC:ALGORITHM_UNKNOWN
 msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
-msgstr "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
+msgstr ""
+"The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
 
 #: DNSSEC:COMMON_KEYTAGS
 msgid  "There are both DS and DNSKEY records with key tags {keytags}."
 msgstr "There are both DS and DNSKEY records with key tags {keytags}."
+
+#: DNSSEC:DELEGATION_NOT_SIGNED
+msgid  "Delegation from parent to child is not properly signed {reason}."
+msgstr "Delegation from parent to child is not properly signed ({reason})."
+
+#: DNSSEC:DELEGATION_SIGNED
+msgid  "Delegation from parent to child is properly signed."
+msgstr "Delegation from parent to child is properly signed."
 
 #: DNSSEC:DNSKEY_AND_DS
 msgid  "{parent} sent a DS record, and {child} a DNSKEY record."
@@ -374,8 +463,12 @@ msgid  "The apex DNSKEY RRset was not correctly signed."
 msgstr "The apex DNSKEY RRset was not correctly signed."
 
 #: DNSSEC:DNSKEY_SIGNATURE_NOT_OK
-msgid  "Signature for DNSKEY with tag {signature} failed to verify with error '{error}'."
-msgstr "Signature verification for DNSKEY with tag {signature} failed with error '{error}'."
+msgid  ""
+"Signature for DNSKEY with tag {signature} failed to verify with error "
+"'{error}'."
+msgstr ""
+"Signature verification for DNSKEY with tag {signature} failed with error "
+"'{error}'."
 
 #: DNSSEC:DNSKEY_SIGNATURE_OK
 msgid  "A signature for DNSKEY with tag {signature} was correctly signed."
@@ -395,19 +488,28 @@ msgstr "DS record with keytag {keytag} uses forbidden digest type {digtype}."
 
 #: DNSSEC:DS_DIGTYPE_OK
 msgid  "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
-msgstr "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
+msgstr ""
+"DS record with keytag {keytag} uses digest type {digtype}, which is OK."
 
 #: DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
-msgstr "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
-
-#: DNSSEC:DS_MATCHES_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY with the same tag."
-msgstr "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY with the same tag."
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} does not match the "
+"DNSKEY with the same tag."
+msgstr ""
+"DS record with keytag {keytag} and digest type {digtype} does not match the "
+"DNSKEY with the same tag."
 
 #: DNSSEC:DS_FOUND
 msgid  "Found DS records with tags {keytags}."
 msgstr "Found DS records with tags {keytags}."
+
+#: DNSSEC:DS_MATCHES_DNSKEY
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
+"with the same tag."
+msgstr ""
+"DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
+"with the same tag."
 
 #: DNSSEC:DS_MATCH_FOUND
 msgid  "At least one DS record with a matching DNSKEY record was found."
@@ -418,24 +520,39 @@ msgid  "No DS record with a matching DNSKEY record was found."
 msgstr "No DS record with a matching DNSKEY record was found."
 
 #: DNSSEC:DS_RFC4509_NOT_VALID
-msgid  "Existing DS with digest type 2, while they do not match DNSKEY records, prevent use of DS with digest type 1 (RFC4509, section 3)."
-msgstr "Existing DS with digest type 2, while they do not match DNSKEY records, prevent use of DS with digest type 1 (RFC4509, section 3)."
+msgid  ""
+"Existing DS with digest type 2, while they do not match DNSKEY records, "
+"prevent use of DS with digest type 1 (RFC4509, section 3)."
+msgstr ""
+"Existing DS with digest type 2, while they do not match DNSKEY records, "
+"prevent use of DS with digest type 1 (RFC4509, section 3)."
 
 #: DNSSEC:DURATION_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is too long."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is too long."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is too long."
+msgstr ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is too long."
 
 #: DNSSEC:DURATION_OK
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is just fine."
+msgstr ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is just fine."
 
 #: DNSSEC:EXTRA_PROCESSING_BROKEN
-msgid  "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
-msgstr "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
+msgid  ""
+"Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
+msgstr ""
+"Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
 
 #: DNSSEC:EXTRA_PROCESSING_OK
 msgid  "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
+msgstr ""
+"Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
 
 #: DNSSEC:HAS_NSEC
 msgid  "The zone has NSEC records."
@@ -450,16 +567,24 @@ msgid  "The zone has NSEC3 opt-out records."
 msgstr "The zone has NSEC3 opt-out records."
 
 #: DNSSEC:INVALID_NAME_RCODE
-msgid  "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
-msgstr "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
+msgid  ""
+"When asked for the name {name}, which must not exist, the response had RCODE "
+"{rcode}."
+msgstr ""
+"When asked for the name {name}, which must not exist, the response had RCODE "
+"{rcode}."
 
 #: DNSSEC:ITERATIONS_OK
 msgid  "The number of NSEC3 iterations is {count}, which is OK."
 msgstr "The number of NSEC3 iterations is {count}, which is OK."
 
 #: DNSSEC:KEY_DETAILS
-msgid  "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
-msgstr "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
+msgid  ""
+"Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
+"{rfc5011})."
+msgstr ""
+"Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
+"{rfc5011})."
 
 #: DNSSEC:MANY_ITERATIONS
 msgid  "The number of NSEC3 iterations is {count}, which is on the high side."
@@ -486,12 +611,20 @@ msgid  "{from} returned no DS records for {zone}."
 msgstr "{from} returned no DS records for {zone}."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS
-msgid  "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and {sigs} RRSIG records."
+msgid  ""
+"Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
+"{sigs} RRSIG records."
+msgstr ""
+"Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
+"{sigs} RRSIG records."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-msgid  "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} RRSIG records and {soas} SOA records."
-msgstr "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} RRSIG records and {soas} SOA records."
+msgid  ""
+"Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
+"RRSIG records and {soas} SOA records."
+msgstr ""
+"Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
+"RRSIG records and {soas} SOA records."
 
 #: DNSSEC:NO_NSEC3PARAM
 msgid  "{server} returned no NSEC3PARAM records."
@@ -538,28 +671,44 @@ msgid  "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 msgstr "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 
 #: DNSSEC:REMAINING_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too long."
+msgstr ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too long."
 
 #: DNSSEC:REMAINING_SHORT
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too short."
+msgstr ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too short."
 
 #: DNSSEC:RRSIG_EXPIRATION
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+msgstr ""
+"RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
 
 #: DNSSEC:RRSIG_EXPIRED
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
-msgstr "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has already expired "
+"(expiration is: {expiration})."
+msgstr ""
+"RRSIG with keytag {tag} and covering type(s) {types} has already expired "
+"(expiration is: {expiration})."
 
 #: DNSSEC:SOA_NOT_SIGNED
 msgid  "No RRSIG correctly signed the SOA RRset."
 msgstr "No RRSIG correctly signed the SOA RRset."
 
 #: DNSSEC:SOA_SIGNATURE_NOT_OK
-msgid  "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
-msgstr "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
+msgid  ""
+"Trying to verify SOA RRset with signature {signature} gave error '{error}'."
+msgstr ""
+"Trying to verify SOA RRset with signature {signature} gave error '{error}'."
 
 #: DNSSEC:SOA_SIGNATURE_OK
 msgid  "RRSIG {signature} correctly signs SOA RRset."
@@ -570,28 +719,30 @@ msgid  "At least one RRSIG correctly signs the SOA RRset."
 msgstr "At least one RRSIG correctly signs the SOA RRset."
 
 #: DNSSEC:TOO_MANY_ITERATIONS
-msgid  "The number of NSEC3 iterations is {count}, which is too high for key length {keylength}."
-msgstr "The number of NSEC3 iterations is {count}, which is too high for key length {keylength}."
-
-#: DNSSEC:DELEGATION_NOT_SIGNED
-msgid  "Delegation from parent to child is not properly signed {reason}."
-msgstr "Delegation from parent to child is not properly signed ({reason})."
-
-#: DNSSEC:DELEGATION_SIGNED
-msgid  "Delegation from parent to child is properly signed."
-msgstr "Delegation from parent to child is properly signed."
+msgid  ""
+"The number of NSEC3 iterations is {count}, which is too high for key length "
+"{keylength}."
+msgstr ""
+"The number of NSEC3 iterations is {count}, which is too high for key length "
+"{keylength}."
 
 #: EXAMPLE:EXAMPLE_TAG
 msgid  "This is an example tag."
 msgstr "This is an example tag."
 
 #: NAMESERVER:AAAA_WELL_PROCESSED
-msgid  "The following nameservers answer AAAA queries without problems : {names}."
-msgstr "The following nameservers answer AAAA queries without problems : {names}."
+msgid  ""
+"The following nameservers answer AAAA queries without problems : {names}."
+msgstr ""
+"The following nameservers answer AAAA queries without problems : {names}."
 
 #: NAMESERVER:ANSWER_BAD_RCODE
-msgid  "Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode})."
-msgstr "Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode})."
+msgid  ""
+"Nameserver {ns}/{address} answered AAAA query with an unexpected rcode "
+"({rcode})."
+msgstr ""
+"Nameserver {ns}/{address} answered AAAA query with an unexpected rcode "
+"({rcode})."
 
 #: NAMESERVER:AXFR_AVAILABLE
 msgid  "Nameserver {ns}/{address} allow zone transfer using AXFR."
@@ -607,19 +758,84 @@ msgstr "All nameservers succeeded to resolve to an IP address."
 
 #: NAMESERVER:CAN_NOT_BE_RESOLVED
 msgid  "The following nameservers failed to resolve to an IP address : {names}."
-msgstr "The following nameservers failed to resolve to an IP address : {names}."
+msgstr ""
+"The following nameservers failed to resolve to an IP address : {names}."
+
+#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers do not reply consistently."
+msgstr ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers do not reply consistently."
+
+#: NAMESERVER:CASE_QUERIES_RESULTS_OK
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers reply consistently."
+msgstr ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers reply consistently."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different answers."
+msgstr ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different answers."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+msgstr ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+
+#: NAMESERVER:CASE_QUERY_NO_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query}\", nameserver {ns}/{address} "
+"returns nothing."
+msgstr ""
+"When asked for {type} records on \"{query}\", nameserver {ns}/{address} "
+"returns nothing."
+
+#: NAMESERVER:CASE_QUERY_SAME_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same answers."
+msgstr ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same answers."
+
+#: NAMESERVER:CASE_QUERY_SAME_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same RCODE \"{rcode}\"."
+msgstr ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same RCODE \"{rcode}\"."
 
 #: NAMESERVER:DIFFERENT_SOURCE_IP
-msgid  "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
-msgstr "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
+msgid  ""
+"Nameserver {ns}/{address} replies on a SOA query with a different source "
+"address ({source})."
+msgstr ""
+"Nameserver {ns}/{address} replies on a SOA query with a different source "
+"address ({source})."
 
 #: NAMESERVER:EDNS0_BAD_ANSWER
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
-msgstr "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
+msgstr ""
+"Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
 
 #: NAMESERVER:EDNS0_BAD_QUERY
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
-msgstr "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
+msgstr ""
+"Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
 
 #: NAMESERVER:EDNS0_SUPPORT
 msgid  "The following nameservers support EDNS0 : {names}."
@@ -633,81 +849,72 @@ msgstr "Nameserver {ns}/{address} is a recursor."
 msgid  "None of the following nameservers is a recursor : {names}."
 msgstr "None of the following nameservers is a recursor : {names}."
 
-#: NAMESERVER:RECURSIVITY_UNDEF
-msgid  "Cannot determine if the following servers are recursive nameservers or not: {names}."
-msgstr "Cannot determine if the following servers are recursive nameservers or not: {names}."
-
 #: NAMESERVER:NO_RESOLUTION
 msgid  "No nameservers succeeded to resolve to an IP address."
 msgstr "No nameserver was successfully resolved to an IP address."
+
+#: NAMESERVER:NO_UPWARD_REFERRAL
+msgid  "None of the following nameservers returns an upward referral : {names}."
+msgstr ""
+"None of the following nameservers returns an upward referral : {names}."
+
+#: NAMESERVER:QNAME_CASE_INSENSITIVE
+msgid  ""
+"Nameserver {ns}/{address} does not preserve original case of queried names."
+msgstr ""
+"Nameserver {ns}/{address} does not preserve original case of queried names "
+"({dname})."
+
+#: NAMESERVER:QNAME_CASE_SENSITIVE
+msgid  "Nameserver {ns}/{address} preserves original case of queried names."
+msgstr ""
+"Nameserver {ns}/{address} preserves original case of queried names ({dname})."
 
 #: NAMESERVER:QUERY_DROPPED
 msgid  "Nameserver {ns}/{address} dropped AAAA query."
 msgstr "Nameserver {ns}/{address} dropped AAAA query."
 
+#: NAMESERVER:RECURSIVITY_UNDEF
+msgid  ""
+"Cannot determine if the following servers are recursive nameservers or not: "
+"{names}."
+msgstr ""
+"Cannot determine if the following servers are recursive nameservers or not: "
+"{names}."
+
 #: NAMESERVER:SAME_SOURCE_IP
 msgid  "All nameservers reply with same IP used to query them."
 msgstr "All nameservers reply with same IP used to query them."
-
-#: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
-msgid  "Upward referral tests skipped for root zone."
-msgstr "Upward referral tests skipped for root zone."
 
 #: NAMESERVER:UPWARD_REFERRAL
 msgid  "Nameserver {ns}/{address} returns an upward referral."
 msgstr "Nameserver {ns}/{address} returns an upward referral."
 
-#: NAMESERVER:NO_UPWARD_REFERRAL
-msgid  "None of the following nameservers returns an upward referral : {names}."
-msgstr "None of the following nameservers returns an upward referral : {names}."
-
-#: NAMESERVER:QNAME_CASE_SENSITIVE
-msgid  "Nameserver {ns}/{address} preserves original case of queried names."
-msgstr "Nameserver {ns}/{address} preserves original case of queried names ({dname})."
-
-#: NAMESERVER:QNAME_CASE_INSENSITIVE
-msgid  "Nameserver {ns}/{address} does not preserve original case of queried names."
-msgstr "Nameserver {ns}/{address} does not preserve original case of queried names ({dname})."
-
-#: NAMESERVER:CASE_QUERY_SAME_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-
-#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-
-#: NAMESERVER:CASE_QUERY_SAME_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-
-#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-
-#: NAMESERVER:CASE_QUERY_NO_ANSWER
-msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-msgstr "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_OK
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-msgstr "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
-msgstr "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
+#: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
+msgid  "Upward referral tests skipped for root zone."
+msgstr "Upward referral tests skipped for root zone."
 
 #: SYNTAX:DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
+msgid  ""
+"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
 
 #: SYNTAX:INITIAL_HYPHEN
-msgid  "Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
-msgstr "Domain name ({name}) has a label ({label}) starting with a hyphen ('-')."
+msgid  ""
+"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+msgstr ""
+"Domain name ({name}) has a label ({label}) starting with a hyphen ('-')."
 
 #: SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
-msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
+msgid  ""
+"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
 
 #: SYNTAX:MNAME_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in SOA MNAME ({name})."
@@ -722,8 +929,12 @@ msgid  "SOA MNAME ({name}) syntax is valid."
 msgstr "SOA MNAME ({name}) syntax is valid."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
+msgid  ""
+"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
 
 #: SYNTAX:MX_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in MX ({name})."
@@ -738,8 +949,12 @@ msgid  "Domain name MX ({name}) syntax is valid."
 msgstr "Domain name MX ({name}) syntax is valid."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
-msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
+msgid  ""
+"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
 
 #: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the nameserver ({name})."
@@ -758,8 +973,12 @@ msgid  "Found illegal characters in the domain name ({name})."
 msgstr "Found illegal characters in the domain name ({name})."
 
 #: SYNTAX:NO_DOUBLE_DASH
-msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
+msgid  ""
+"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
+"and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
+"and 4 (with a prefix which is not 'xn--')."
 
 #: SYNTAX:NO_ENDING_HYPHENS
 msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
@@ -778,7 +997,8 @@ msgid  "No illegal characters in the domain name ({name})."
 msgstr "No illegal characters in the domain name ({name})."
 
 #: SYNTAX:RNAME_MISUSED_AT_SIGN
-msgid  "There must be no misused '@' character in the SOA RNAME field ({rname})."
+msgid  ""
+"There must be no misused '@' character in the SOA RNAME field ({rname})."
 msgstr "Misused '@' character found in SOA RNAME field ({rname})."
 
 #: SYNTAX:RNAME_NO_AT_SIGN
@@ -813,33 +1033,49 @@ msgstr "Configuration was read from {name}."
 msgid  "Using prerequisite module {name} version {version}."
 msgstr "Using prerequisite module {name} version {version}."
 
-#: SYSTEM:GLOBAL_VERSION
-msgid "Using version {version} of the Zonemaster engine."
-msgstr "Using version {version} of the Zonemaster engine."
-
 #: SYSTEM:FAKE_DELEGATION
 msgid  "Followed a fake delegation."
 msgstr "Followed a fake delegation."
 
-#: SYSTEM:FAKE_DELEGATION_TO_SELF
-msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Name server {ns} not adding fake delegation for domain {domain} to itself."
-
 #: SYSTEM:FAKE_DELEGATION_IN_ZONE_NO_IP
-msgid  "The fake delegation of domain {domain} includes an in-zone name server {ns} without mandatory glue (without IP address)."
-msgstr "The fake delegation of domain {domain} includes an in-zone name server {ns} without mandatory glue (without IP address)."
+msgid  ""
+"The fake delegation of domain {domain} includes an in-zone name server {ns} "
+"without mandatory glue (without IP address)."
+msgstr ""
+"The fake delegation of domain {domain} includes an in-zone name server {ns} "
+"without mandatory glue (without IP address)."
 
 #: SYSTEM:FAKE_DELEGATION_NO_IP
-msgid  "The fake delegation of domain {domain} includes a name server {ns} that cannot be resolved to any IP address."
-msgstr "The fake delegation of domain {domain} includes a name server {ns} that cannot be resolved to any IP address."
+msgid  ""
+"The fake delegation of domain {domain} includes a name server {ns} that "
+"cannot be resolved to any IP address."
+msgstr ""
+"The fake delegation of domain {domain} includes a name server {ns} that "
+"cannot be resolved to any IP address."
+
+#: SYSTEM:FAKE_DELEGATION_TO_SELF
+msgid  ""
+"Name server {ns} not adding fake delegation for domain {domain} to itself."
+msgstr ""
+"Name server {ns} not adding fake delegation for domain {domain} to itself."
+
+#: SYSTEM:GLOBAL_VERSION
+msgid  "Using version {version} of the Zonemaster engine."
+msgstr "Using version {version} of the Zonemaster engine."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
 msgstr "Logger callback died with error: {exception}"
 
 #: SYSTEM:LOOKUP_ERROR
-msgid  "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
-msgstr "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+msgid  ""
+"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+msgstr ""
+"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+
+#: SYSTEM:MODULE_END
+msgid  "Module {module} finished running."
+msgstr "Module {module} finished running."
 
 #: SYSTEM:MODULE_ERROR
 msgid  "Fatal error in {module}: {msg}"
@@ -849,13 +1085,17 @@ msgstr "Fatal error in {module}: {msg}"
 msgid  "Using module {module} version {version}."
 msgstr "Using module {module} version {version}."
 
-#: SYSTEM:MODULE_END
-msgid  "Module {module} finished running."
-msgstr "Module {module} finished running."
-
 #: SYSTEM:NO_NETWORK
 msgid  "Both IPv4 and IPv6 are disabled."
 msgstr "Both IPv4 and IPv6 are disabled."
+
+#: SYSTEM:PACKET_BIG
+msgid  ""
+"Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try "
+"with \"{command}\")."
+msgstr ""
+"Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try "
+"with \"{command}\")."
 
 #: SYSTEM:POLICY_DISABLED
 msgid  "The module {name} was disabled by the policy."
@@ -878,24 +1118,34 @@ msgid  "Request to run unknown method {method} in module {module}."
 msgstr "Request to run unknown method {method} in module {module}."
 
 #: SYSTEM:UNKNOWN_MODULE
-msgid  "Request to run {method} in unknown module {module}. Known modules: {known}."
-msgstr "Request to run {method} in unknown module {module}. Known modules: {known}."
-
-#: SYSTEM:PACKET_BIG
-msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
-msgstr "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
+msgid  ""
+"Request to run {method} in unknown module {module}. Known modules: {known}."
+msgstr ""
+"Request to run {method} in unknown module {module}. Known modules: {known}."
 
 #: ZONE:EXPIRE_LOWER_THAN_REFRESH
-msgid  "SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value ({refresh})."
-msgstr "SOA 'expire' value ({expire}) is less than the SOA 'refresh' value ({refresh})."
+msgid  ""
+"SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value "
+"({refresh})."
+msgstr ""
+"SOA 'expire' value ({expire}) is less than the SOA 'refresh' value "
+"({refresh})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_LOWER
-msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({required_expire})."
-msgstr "SOA 'expire' value ({expire}) is less than the recommended minimum ({required_expire})."
+msgid  ""
+"SOA 'expire' value ({expire}) is less than the recommended one "
+"({required_expire})."
+msgstr ""
+"SOA 'expire' value ({expire}) is less than the recommended minimum "
+"({required_expire})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
-msgstr "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgid  ""
+"SOA 'expire' value ({expire}) is higher than the minimum recommended value "
+"({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr ""
+"SOA 'expire' value ({expire}) is higher than the minimum recommended value "
+"({required_expire}) and not lower than the 'refresh' value ({refresh})."
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."
@@ -910,16 +1160,24 @@ msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
 msgstr "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
 
 #: ZONE:MNAME_IS_NOT_CNAME
-msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
-msgstr "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
+msgid  ""
+"SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
+msgstr ""
+"SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
 
 #: ZONE:MNAME_NOT_AUTHORITATIVE
-msgid  "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
-msgstr "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
+msgid  ""
+"SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
+msgstr ""
+"SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
 
 #: ZONE:MNAME_NOT_IN_GLUE
-msgid  "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for tested zone ({ns})."
-msgstr "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for tested zone ({ns})."
+msgid  ""
+"SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
+"tested zone ({ns})."
+msgstr ""
+"SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
+"tested zone ({ns})."
 
 #: ZONE:MNAME_NO_RESPONSE
 msgid  "SOA 'mname' nameserver {ns}/{address} does not respond."
@@ -943,41 +1201,77 @@ msgstr "MX record for the domain is not pointing to a CNAME."
 
 #: ZONE:NO_MX_RECORD
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
-msgstr "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
+msgstr ""
+"No target (MX, A or AAAA record) to deliver e-mail for the domain name."
 
 #: ZONE:REFRESH_HIGHER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
-msgstr "SOA 'refresh' value ({refresh}) is greater than the SOA 'retry' value ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"SOA 'refresh' value ({refresh}) is greater than the SOA 'retry' value "
+"({retry})."
 
 #: ZONE:REFRESH_LOWER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value ({retry})."
-msgstr "SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value "
+"({retry})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_LOWER
-msgid  "SOA 'refresh' value ({refresh}) is less than the recommended one ({required_refresh})."
-msgstr "SOA 'refresh' value ({refresh}) is less than the recommended minimum ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is less than the recommended one "
+"({required_refresh})."
+msgstr ""
+"SOA 'refresh' value ({refresh}) is less than the recommended minimum "
+"({required_refresh})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_OK
-msgid  "SOA 'refresh' value ({refresh}) is higher than the minimum recommended value ({required_refresh})."
-msgstr "SOA 'refresh' value ({refresh}) is greater than the minimum recommended value ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the minimum recommended value "
+"({required_refresh})."
+msgstr ""
+"SOA 'refresh' value ({refresh}) is greater than the minimum recommended "
+"value ({required_refresh})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_LOWER
-msgid  "SOA 'retry' value ({retry}) is less than the recommended one ({required_retry})."
-msgstr "SOA 'retry' value ({retry}) is less than the recommended minimum ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is less than the recommended one "
+"({required_retry})."
+msgstr ""
+"SOA 'retry' value ({retry}) is less than the recommended minimum "
+"({required_retry})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_OK
-msgid  "SOA 'retry' value ({retry}) is more than the minimum recommended value ({required_retry})."
-msgstr "SOA 'retry' value ({retry}) is greater than the minimum recommended value ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is more than the minimum recommended value "
+"({required_retry})."
+msgstr ""
+"SOA 'retry' value ({retry}) is greater than the minimum recommended value "
+"({required_retry})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_HIGHER
-msgid  "SOA 'minimum' value ({minimum}) is higher than the recommended one ({highest_minimum})."
-msgstr "SOA 'minimum' value ({minimum}) is greater than the recommended one ({highest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is higher than the recommended one "
+"({highest_minimum})."
+msgstr ""
+"SOA 'minimum' value ({minimum}) is greater than the recommended one "
+"({highest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_LOWER
-msgid  "SOA 'minimum' value ({minimum}) is less than the recommended one ({lowest_minimum})."
-msgstr "SOA 'minimum' value ({minimum}) is less than the recommended minimum ({lowest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is less than the recommended one "
+"({lowest_minimum})."
+msgstr ""
+"SOA 'minimum' value ({minimum}) is less than the recommended minimum "
+"({lowest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_OK
-msgid  "SOA 'minimum' value ({minimum}) is between the recommended ones ({lowest_minimum}/{highest_minimum})."
-msgstr "SOA 'minimum' value ({minimum}) is within the recommended ones ({lowest_minimum}/{highest_minimum})."
-
+msgid  ""
+"SOA 'minimum' value ({minimum}) is between the recommended ones "
+"({lowest_minimum}/{highest_minimum})."
+msgstr ""
+"SOA 'minimum' value ({minimum}) is within the recommended ones "
+"({lowest_minimum}/{highest_minimum})."

--- a/share/fr.po
+++ b/share/fr.po
@@ -1,49 +1,68 @@
-msgid ""
+msgid  ""
 msgstr ""
-"Language: fr\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 1.0.0\n"
 "PO-Revision-Date: 2017-12-18\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #: ADDRESS:NAMESERVERS_IP_WITH_REVERSE
 msgid  "Reverse DNS entry exist for all Nameserver IP addresses."
-msgstr "Les différentes adresses IP des serveurs de noms ont toutes un enregistrement \"PTR\" (reverse) associé dans le DNS."
+msgstr ""
+"Les différentes adresses IP des serveurs de noms ont toutes un "
+"enregistrement \"PTR\" (reverse) associé dans le DNS."
 
 #: ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
-msgid  "Nameserver {ns} has an IP address ({address}) with prefix {prefix} referenced in {reference} as a '{name}'."
-msgstr "Le serveur de noms {ns} a une adresse IP ({address}) dont le préfixe est référéncé dans le {reference} sous le libellé '{name}'."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with prefix {prefix} "
+"referenced in {reference} as a '{name}'."
+msgstr ""
+"Le serveur de noms {ns} a une adresse IP ({address}) dont le préfixe est "
+"référéncé dans le {reference} sous le libellé '{name}'."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MATCH
 msgid  "All reverse DNS entry matches name server name."
 msgstr "Tous les enregistrements PTR correspondent aux serveurs de noms."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MISMATCH
-msgid  "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
-msgstr "Le serveur de noms {ns} a une adresse IP ({address}) qui ne correspond pas aux enregistrements \"PTR\" retournés ({names}) pour celle-ci."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with mismatched PTR result "
+"({names})."
+msgstr ""
+"Le serveur de noms {ns} a une adresse IP ({address}) qui ne correspond pas "
+"aux enregistrements \"PTR\" retournés ({names}) pour celle-ci."
 
 #: ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
 msgid  "Nameserver {ns} has an IP address ({address}) without PTR configured."
-msgstr "Le serveur de noms {ns} a une adresse IP ({address}) sans enregistrement \"PTR\" correspondant."
+msgstr ""
+"Le serveur de noms {ns} a une adresse IP ({address}) sans enregistrement "
+"\"PTR\" correspondant."
 
 #: ADDRESS:NO_IP_PRIVATE_NETWORK
 msgid  "All Nameserver addresses are in the routable public addressing space."
-msgstr "Toutes les adresses IP des serveurs de noms sont dans l'espace d'adresses publiques routables."
+msgstr ""
+"Toutes les adresses IP des serveurs de noms sont dans l'espace d'adresses "
+"publiques routables."
 
 #: ADDRESS:NO_RESPONSE_PTR_QUERY
 msgid  "No response from nameserver(s) on PTR query ({reverse})."
-msgstr "Aucune réponse des serveurs de noms sur une requête de type \"PTR\" ({reverse})."
+msgstr ""
+"Aucune réponse des serveurs de noms sur une requête de type \"PTR"
+"\" ({reverse})."
 
 #: BASIC:A_QUERY_NO_RESPONSES
 msgid  "Nameservers did not respond to A query."
 msgstr "Aucune réponse des serveurs de noms sur une requête de type \"A\"."
 
 #: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
-msgstr "Le nom de domaine '{dname}' a un label ({dlabel}) trop long ({dlength}/{max})."
+msgid  ""
+"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+msgstr ""
+"Le nom de domaine '{dname}' a un label ({dlabel}) trop long ({dlength}/"
+"{max})."
 
 #: BASIC:DOMAIN_NAME_TOO_LONG
 msgid  "Domain name is too long ({fqdnlength}/{max})."
@@ -55,43 +74,64 @@ msgstr "Le nom de domaine '{dname}' a un label de taille zéro."
 
 #: BASIC:HAS_A_RECORDS
 msgid  "Nameserver {ns}/{address} returned A record(s) for {dname}."
-msgstr "Le serveur de noms {ns}/{address} renvoie un enregistrement de type \"A\" en réponse à une requête pour '{dname}'."
+msgstr ""
+"Le serveur de noms {ns}/{address} renvoie un enregistrement de type \"A\" en "
+"réponse à une requête pour '{dname}'."
 
 #: BASIC:HAS_NAMESERVERS
 msgid  "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr "Une requête NS sur le serveur de noms {ns} renvoie la liste de serveurs de noms suivants: {nsnlist}."
+msgstr ""
+"Une requête NS sur le serveur de noms {ns} renvoie la liste de serveurs de "
+"noms suivants: {nsnlist}."
 
 #: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
 msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
-msgstr "Un serveur de noms fonctionnel a été trouvé. Inutile de réaliser une requête de type \"A\" sur www.{zname}."
+msgstr ""
+"Un serveur de noms fonctionnel a été trouvé. Inutile de réaliser une requête "
+"de type \"A\" sur www.{zname}."
 
 #: BASIC:HAS_PARENT
 msgid  "Parent domain '{pname}' was found for the tested domain."
-msgstr "Une zone parente '{pname}' a pu être trouvée pour le nom de domaine testé."
+msgstr ""
+"Une zone parente '{pname}' a pu être trouvée pour le nom de domaine testé."
 
-#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
+#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED
+#: DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 a été désactivé, la requête de type \"{rrtype}\" sur le serveur {ns}/{address} est annulée."
+msgstr ""
+"IPv4 a été désactivé, la requête de type \"{rrtype}\" sur le serveur {ns}/"
+"{address} est annulée."
 
 #: BASIC:IPV4_ENABLED
 msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 est activé, il est possible de réaliser une requête de type \"{rrtype}\" sur le serveur {ns}/{address}."
+msgstr ""
+"IPv4 est activé, il est possible de réaliser une requête de type "
+"\"{rrtype}\" sur le serveur {ns}/{address}."
 
-#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
+#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED
+#: DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 a été désactivé, la requête de type \"{rrtype}\" sur le serveur {ns} est annulée."
+msgstr ""
+"IPv6 a été désactivé, la requête de type \"{rrtype}\" sur le serveur {ns} "
+"est annulée."
 
 #: BASIC:IPV6_ENABLED
 msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 est activé, il est possible de réaliser une requête de type \"{rrtype}\" sur le serveur {ns}."
+msgstr ""
+"IPv6 est activé, il est possible de réaliser une requête de type "
+"\"{rrtype}\" sur le serveur {ns}."
 
 #: BASIC:NO_A_RECORDS
 msgid  "Nameserver {ns}/{address} did not return A record(s) for {dname}."
-msgstr "Le serveur de noms {ns}/{address} ne renvoie pas d'enregistrement de type \"A\" en réponse à une requête pour '{dname}'."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne renvoie pas d'enregistrement de type \"A"
+"\" en réponse à une requête pour '{dname}'."
 
 #: BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
 msgid  "No NS records for tested zone from parent. NS tests aborted."
-msgstr "Aucun enregistrement de type \"NS\" renvoyé par la zone parente pour la zone testée. Les tests complémentaires sur ces serveurs sont annulés."
+msgstr ""
+"Aucun enregistrement de type \"NS\" renvoyé par la zone parente pour la zone "
+"testée. Les tests complémentaires sur ces serveurs sont annulés."
 
 #: BASIC:NO_PARENT
 msgid  "No parent domain could be found for the tested domain."
@@ -99,75 +139,14 @@ msgstr "Aucune zone parente n'a pu être trouvée pour le nom de domaine testé.
 
 #: BASIC:NS_FAILED
 msgid  "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
-msgstr "Le serveur de noms {ns}/{address} ne renvoie pas d'enregistrements de type \"NS\" pour la zone testée. Le code {rcode} a été retourné."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne renvoie pas d'enregistrements de type "
+"\"NS\" pour la zone testée. Le code {rcode} a été retourné."
 
 #: BASIC:NS_NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond to NS query."
-msgstr "Le serveur de noms {ns}/{address} ne répond pas à une requête de type \"NS\"."
-
-#: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
-msgid  "No IPv4 nameserver address is in an AS."
-msgstr "Aucune adresse IPv4 des serveurs de noms ne se trouve dans un AS."
-
-#: CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
-msgid  "Authoritative IPv4 nameservers are in more than one AS."
-msgstr "Les adresses IPv4 des serveurs faisant autorité se trouvent dans plusieurs AS."
-
-#: CONNECTIVITY:NAMESERVERS_IPV4_WITH_UNIQ_AS
-msgid  "All nameservers IPv4 addresses are in the same AS ({asn})."
-msgstr "Toutes les adresses IPv4 des serveurs de noms retournées par les serveurs de noms de la zone parente se trouvent dans le même AS ({asn})."
-
-#: CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
-msgid  "No IPv6 nameserver address is in an AS."
-msgstr "Aucune adresse IPv6 des serveurs de noms ne se trouve dans un AS."
-
-#: CONNECTIVITY:NAMESERVERS_IPV6_WITH_MULTIPLE_AS
-msgid  "Authoritative IPv6 nameservers are in more than one AS."
-msgstr "Les adresses IPv6 des serveurs faisant autorité se trouvent dans plusieurs AS."
-
-#: CONNECTIVITY:NAMESERVERS_IPV6_WITH_UNIQ_AS
-msgid  "All nameservers IPv6 addresses are in the same AS ({asn})."
-msgstr "Toutes les adresses IPv6 des serveurs de noms retournées par les serveurs de noms de la zone parente se trouvent dans le même AS ({asn})."
-
-#: CONNECTIVITY:NAMESERVERS_NO_AS
-msgid  "No nameserver address is in an AS."
-msgstr "Aucune adresse IP des serveurs de noms ne se trouve dans un AS."
-
-#: CONNECTIVITY:NAMESERVERS_WITH_MULTIPLE_AS
-msgid  "Domain's authoritative nameservers do not belong to the same AS."
-msgstr "Les serveurs de noms pour le nom de domaine ne se trouvent pas tous dans le même AS."
-
-#: CONNECTIVITY:NAMESERVERS_WITH_UNIQ_AS
-msgid  "All nameservers are in the same AS ({asn})."
-msgstr "Tous les serveurs de noms pour le nom de domaine retournés par les serveurs de noms de la zone parente se trouvent dans le même AS ({asn})."
-
-#: CONNECTIVITY:NAMESERVER_HAS_TCP_53
-msgid  "Nameserver {ns}/{address} accessible over TCP on port 53."
-msgstr "Le serveur de noms {ns}/{address} est accessible via TCP sur le port 53."
-
-#: CONNECTIVITY:NAMESERVER_HAS_UDP_53
-msgid  "Nameserver {ns}/{address} accessible over UDP on port 53."
-msgstr "Le serveur de noms {ns}/{address} est accessible via UDP sur le port 53."
-
-#: CONNECTIVITY:NAMESERVER_NO_TCP_53
-msgid  "Nameserver {ns}/{address} not accessible over TCP on port 53."
-msgstr "Le serveur de noms {ns}/{address} n'est pas accessible via TCP sur le port 53."
-
-#: CONNECTIVITY:NAMESERVER_NO_UDP_53
-msgid  "Nameserver {ns}/{address} not accessible over UDP on port 53."
-msgstr "Le serveur de noms {ns}/{address} n'est pas accessible via UDP sur le port 53."
-
-#: CONNECTIVITY:IPV4_ASN
-msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
-msgstr "Les serveurs de noms ont des adresses IPv4 dans les AS suivants: {asn}."
-
-#: CONNECTIVITY:IPV6_ASN
-msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
-msgstr "Les serveurs de noms ont des adresses IPv6 dans les AS suivants: {asn}."
-
-#: CONNECTIVITY:ASN_INFOS_RAW
-msgid  "[ASN:RAW] {address};{data}"
-msgstr "[ASN:RAW] {address};{data}"
+msgstr ""
+"Le serveur de noms {ns}/{address} ne répond pas à une requête de type \"NS\"."
 
 #: CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
 msgid  "[ASN:ANNOUNCE_BY] {address};{asn}"
@@ -177,21 +156,133 @@ msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
 msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
 msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
 
+#: CONNECTIVITY:ASN_INFOS_RAW
+msgid  "[ASN:RAW] {address};{data}"
+msgstr "[ASN:RAW] {address};{data}"
+
+#: CONNECTIVITY:IPV4_ASN
+msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
+msgstr ""
+"Les serveurs de noms ont des adresses IPv4 dans les AS suivants: {asn}."
+
+#: CONNECTIVITY:IPV6_ASN
+msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
+msgstr ""
+"Les serveurs de noms ont des adresses IPv6 dans les AS suivants: {asn}."
+
+#: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
+msgid  "No IPv4 nameserver address is in an AS."
+msgstr "Aucune adresse IPv4 des serveurs de noms ne se trouve dans un AS."
+
+#: CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
+msgid  "Authoritative IPv4 nameservers are in more than one AS."
+msgstr ""
+"Les adresses IPv4 des serveurs faisant autorité se trouvent dans plusieurs "
+"AS."
+
+#: CONNECTIVITY:NAMESERVERS_IPV4_WITH_UNIQ_AS
+msgid  "All nameservers IPv4 addresses are in the same AS ({asn})."
+msgstr ""
+"Toutes les adresses IPv4 des serveurs de noms retournées par les serveurs de "
+"noms de la zone parente se trouvent dans le même AS ({asn})."
+
+#: CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
+msgid  "No IPv6 nameserver address is in an AS."
+msgstr "Aucune adresse IPv6 des serveurs de noms ne se trouve dans un AS."
+
+#: CONNECTIVITY:NAMESERVERS_IPV6_WITH_MULTIPLE_AS
+msgid  "Authoritative IPv6 nameservers are in more than one AS."
+msgstr ""
+"Les adresses IPv6 des serveurs faisant autorité se trouvent dans plusieurs "
+"AS."
+
+#: CONNECTIVITY:NAMESERVERS_IPV6_WITH_UNIQ_AS
+msgid  "All nameservers IPv6 addresses are in the same AS ({asn})."
+msgstr ""
+"Toutes les adresses IPv6 des serveurs de noms retournées par les serveurs de "
+"noms de la zone parente se trouvent dans le même AS ({asn})."
+
+#: CONNECTIVITY:NAMESERVERS_NO_AS
+msgid  "No nameserver address is in an AS."
+msgstr "Aucune adresse IP des serveurs de noms ne se trouve dans un AS."
+
+#: CONNECTIVITY:NAMESERVERS_WITH_MULTIPLE_AS
+msgid  "Domain's authoritative nameservers do not belong to the same AS."
+msgstr ""
+"Les serveurs de noms pour le nom de domaine ne se trouvent pas tous dans le "
+"même AS."
+
+#: CONNECTIVITY:NAMESERVERS_WITH_UNIQ_AS
+msgid  "All nameservers are in the same AS ({asn})."
+msgstr ""
+"Tous les serveurs de noms pour le nom de domaine retournés par les serveurs "
+"de noms de la zone parente se trouvent dans le même AS ({asn})."
+
+#: CONNECTIVITY:NAMESERVER_HAS_TCP_53
+msgid  "Nameserver {ns}/{address} accessible over TCP on port 53."
+msgstr ""
+"Le serveur de noms {ns}/{address} est accessible via TCP sur le port 53."
+
+#: CONNECTIVITY:NAMESERVER_HAS_UDP_53
+msgid  "Nameserver {ns}/{address} accessible over UDP on port 53."
+msgstr ""
+"Le serveur de noms {ns}/{address} est accessible via UDP sur le port 53."
+
+#: CONNECTIVITY:NAMESERVER_NO_TCP_53
+msgid  "Nameserver {ns}/{address} not accessible over TCP on port 53."
+msgstr ""
+"Le serveur de noms {ns}/{address} n'est pas accessible via TCP sur le port "
+"53."
+
+#: CONNECTIVITY:NAMESERVER_NO_UDP_53
+msgid  "Nameserver {ns}/{address} not accessible over UDP on port 53."
+msgstr ""
+"Le serveur de noms {ns}/{address} n'est pas accessible via UDP sur le port "
+"53."
+
+#: CONSISTENCY:ADDRESSES_MATCH
+msgid  "Glue records are consistent between glue and authoritative data."
+msgstr ""
+"La liste des adresses IP des serveurs de nom retournée par les serveurs de "
+"noms de la zone parente et par ceux de la zone est identique."
+
+#: CONSISTENCY:EXTRA_ADDRESS_CHILD
+msgid  ""
+"Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+msgstr ""
+"Les serveurs de noms de la zone retournent des adresses IP pour les serveurs "
+"de nom de la zone qui ne sont pas connues par les serveurs de noms de la "
+"zone parente ({addresses})."
+
+#: CONSISTENCY:EXTRA_ADDRESS_PARENT
+msgid  ""
+"Parent has extra nameserver IP address(es) not listed at child ({addresses})."
+msgstr ""
+"Les serveurs de noms de la zone parente retournent des adresses IP pour les "
+"serveurs de nom de la zone qui ne sont pas connues par les serveurs de noms "
+"de la zone ({addresses})."
+
 #: CONSISTENCY:MULTIPLE_NS_SET
 msgid  "Saw {count} NS set."
-msgstr "Plusieurs ensembles de serveurs de noms ({count}) ont été trouvés dans les différents SOA."
+msgstr ""
+"Plusieurs ensembles de serveurs de noms ({count}) ont été trouvés dans les "
+"différents SOA."
 
 #: CONSISTENCY:MULTIPLE_SOA_RNAMES
 msgid  "Saw {count} SOA rname."
-msgstr "Plusieurs adresses mail ({count}) ont été trouvées dans les différents SOA."
+msgstr ""
+"Plusieurs adresses mail ({count}) ont été trouvées dans les différents SOA."
 
 #: CONSISTENCY:MULTIPLE_SOA_SERIALS
 msgid  "Saw {count} SOA serial numbers."
-msgstr "Plusieurs numéros de série ({count}) ont été trouvés dans les différents SOA."
+msgstr ""
+"Plusieurs numéros de série ({count}) ont été trouvés dans les différents SOA."
 
 #: CONSISTENCY:MULTIPLE_SOA_TIME_PARAMETER_SET
 msgid  "Saw {count} SOA time parameter set."
-msgstr "Plusieurs ensembles de paramètres temporels ({count}) ont été trouvés dans les différents SOA."
+msgstr ""
+"Plusieurs ensembles de paramètres temporels ({count}) ont été trouvés dans "
+"les différents SOA."
 
 #: CONSISTENCY:NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond."
@@ -199,183 +290,297 @@ msgstr "Le serveur de noms {ns}/{address} n'a pas répondu."
 
 #: CONSISTENCY:NO_RESPONSE_NS_QUERY
 msgid  "No response from nameserver {ns}/{address} on NS queries."
-msgstr "Le serveur de noms {ns}/{address} n'a pas répondu aux requêtes de type \"NS\"."
+msgstr ""
+"Le serveur de noms {ns}/{address} n'a pas répondu aux requêtes de type \"NS"
+"\"."
 
 #: CONSISTENCY:NO_RESPONSE_SOA_QUERY
 msgid  "No response from nameserver {ns}/{address} on SOA queries."
-msgstr "Le serveur de noms {ns}/{address} n'a pas répondu aux requêtes de type \"SOA\"."
+msgstr ""
+"Le serveur de noms {ns}/{address} n'a pas répondu aux requêtes de type \"SOA"
+"\"."
 
 #: CONSISTENCY:NS_SET
 msgid  "Saw NS set ({nsset}) on following nameserver set : {servers}."
-msgstr "L'ensemble de serveurs de noms ({nsset}) est défini sur les serveurs suivants : {servers}."
+msgstr ""
+"L'ensemble de serveurs de noms ({nsset}) est défini sur les serveurs "
+"suivants : {servers}."
 
 #: CONSISTENCY:ONE_NS_SET
 msgid  "A unique NS set was seen ({nsset})."
-msgstr "Un unique ensemble de serveurs de noms est configuré sur les serveurs de la zone testée ({nsset})."
+msgstr ""
+"Un unique ensemble de serveurs de noms est configuré sur les serveurs de la "
+"zone testée ({nsset})."
 
 #: CONSISTENCY:ONE_SOA_RNAME
 msgid  "A single SOA rname value was seen ({rname})"
-msgstr "Une unique adresse mail a été trouvée dans les enregistrements de type \"SOA\" de la zone testée ({rname})."
+msgstr ""
+"Une unique adresse mail a été trouvée dans les enregistrements de type \"SOA"
+"\" de la zone testée ({rname})."
 
 #: CONSISTENCY:ONE_SOA_SERIAL
 msgid  "A single SOA serial number was seen ({serial})."
-msgstr "Un unique numéro de série a été trouvé dans les enregistrements de type \"SOA\" de la zone testée ({serial})."
+msgstr ""
+"Un unique numéro de série a été trouvé dans les enregistrements de type \"SOA"
+"\" de la zone testée ({serial})."
 
 #: CONSISTENCY:ONE_SOA_TIME_PARAMETER_SET
-msgid  "A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
-msgstr "Un unique ensemble de paramètres temporels a été trouvé (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
+msgid  ""
+"A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum})."
+msgstr ""
+"Un unique ensemble de paramètres temporels a été trouvé (REFRESH={refresh},"
+"RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
 
 #: CONSISTENCY:SOA_RNAME
 msgid  "Saw SOA rname {rname} on following nameserver set : {servers}."
-msgstr "L'adresse mail {rname} a été récupérée sur les serveurs suivants : {servers}."
+msgstr ""
+"L'adresse mail {rname} a été récupérée sur les serveurs suivants : {servers}."
 
 #: CONSISTENCY:SOA_SERIAL
 msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
-msgstr "Le numéro de série {serial} a été récupérée sur les serveurs suivants : {servers}."
+msgstr ""
+"Le numéro de série {serial} a été récupérée sur les serveurs suivants : "
+"{servers}."
 
 #: CONSISTENCY:SOA_SERIAL_VARIATION
-msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
-msgstr "La différence entre le plus petit numéro de série de la zone récupéré ({serial_min}) et le plus grand ({serial_max}) est supérieure au maximum autorisé ({max_variation})."
+msgid  ""
+"Difference between the smaller serial ({serial_min}) and the bigger one "
+"({serial_max}) is greater than the maximum allowed ({max_variation})."
+msgstr ""
+"La différence entre le plus petit numéro de série de la zone récupéré "
+"({serial_min}) et le plus grand ({serial_max}) est supérieure au maximum "
+"autorisé ({max_variation})."
 
 #: CONSISTENCY:SOA_TIME_PARAMETER_SET
-msgid  "Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
-msgstr "L'ensemble de paramètres temporels (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) a été récupérée sur les serveurs suivants : {servers}."
-
-#: CONSISTENCY:EXTRA_ADDRESS_PARENT
-msgid  "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
-msgstr "Les serveurs de noms de la zone parente retournent des adresses IP pour les serveurs de nom de la zone qui ne sont pas connues par les serveurs de noms de la zone ({addresses})."
-
-#: CONSISTENCY:EXTRA_ADDRESS_CHILD
-msgid  "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
-msgstr "Les serveurs de noms de la zone retournent des adresses IP pour les serveurs de nom de la zone qui ne sont pas connues par les serveurs de noms de la zone parente ({addresses})."
+msgid  ""
+"Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},"
+"MINIMUM={minimum}) on following nameserver set : {servers}."
+msgstr ""
+"L'ensemble de paramètres temporels (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum}) a été récupérée sur les serveurs "
+"suivants : {servers}."
 
 #: CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-msgid  "No common nameserver IP addresses between child ({child}) and parent ({glue})."
-msgstr "La liste des adresses IP des serveurs de nom retournée par les serveurs de noms de la zone parente et par ceux de la zone est complètement différente."
-
-#: CONSISTENCY:ADDRESSES_MATCH
-msgid  "Glue records are consistent between glue and authoritative data."
-msgstr "La liste des adresses IP des serveurs de nom retournée par les serveurs de noms de la zone parente et par ceux de la zone est identique."
+msgid  ""
+"No common nameserver IP addresses between child ({child}) and parent "
+"({glue})."
+msgstr ""
+"La liste des adresses IP des serveurs de nom retournée par les serveurs de "
+"noms de la zone parente et par ceux de la zone est complètement différente."
 
 #: DELEGATION:ARE_AUTHORITATIVE
 msgid  "All these nameservers are confirmed to be authoritative : {nsset}."
-msgstr "Ces serveurs de noms ont pu être vérifiés comme faisant autorité : {nsset}."
+msgstr ""
+"Ces serveurs de noms ont pu être vérifiés comme faisant autorité : {nsset}."
 
 #: DELEGATION:DISTINCT_IP_ADDRESS
 msgid  "All the IP addresses used by the nameservers are unique"
-msgstr "Toutes les adresses IP utilisées par les serveurs de noms sont uniques."
+msgstr ""
+"Toutes les adresses IP utilisées par les serveurs de noms sont uniques."
 
 #: DELEGATION:ENOUGH_NS
-msgid  "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Les serveurs de noms de la zone retournent suffisamment de serveurs ({count}) faisant autorité ({ns}). La limite inférieure étant fixée à {minimum}."
+msgid  ""
+"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Les serveurs de noms de la zone retournent suffisamment de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
 
 #: DELEGATION:ENOUGH_NS_GLUE
-msgid  "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Les serveurs de noms de la zone parente retournent suffisamment de serveurs ({count}) faisant autorité ({glue}). La limite inférieure étant fixée à {minimum}."
+msgid  ""
+"Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Les serveurs de noms de la zone parente retournent suffisamment de serveurs "
+"({count}) faisant autorité ({glue}). La limite inférieure étant fixée à "
+"{minimum}."
 
 #: DELEGATION:EXTRA_NAME_CHILD
 msgid  "Child has nameserver(s) not listed at parent ({extra})."
-msgstr "Les serveurs de noms de la zone retournent des serveurs faisant autorité ({extra}) qui ne le sont pas par les serveurs de noms de la zone parente."
+msgstr ""
+"Les serveurs de noms de la zone retournent des serveurs faisant autorité "
+"({extra}) qui ne le sont pas par les serveurs de noms de la zone parente."
 
 #: DELEGATION:EXTRA_NAME_PARENT
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
-msgstr "Les serveurs de noms de la zone parente retournent des serveurs faisant autorité ({extra}) qui ne le sont pas par les serveurs de noms de la zone."
+msgstr ""
+"Les serveurs de noms de la zone parente retournent des serveurs faisant "
+"autorité ({extra}) qui ne le sont pas par les serveurs de noms de la zone."
 
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
-msgstr "La réponse du serveur de noms {ns} reçue sur le port 53/{proto} ne fait pas autorité."
+msgstr ""
+"La réponse du serveur de noms {ns} reçue sur le port 53/{proto} ne fait pas "
+"autorité."
 
 #: DELEGATION:NAMES_MATCH
 msgid  "All of the nameserver names are listed both at parent and child."
-msgstr "Tous les serveurs de noms de la zone font partie de la liste des serveurs de noms retournés par les serveurs de noms de la zone parente ainsi que par les serveurs de noms de la zone elle-même."
+msgstr ""
+"Tous les serveurs de noms de la zone font partie de la liste des serveurs de "
+"noms retournés par les serveurs de noms de la zone parente ainsi que par les "
+"serveurs de noms de la zone elle-même."
 
 #: DELEGATION:NOT_ENOUGH_NS
-msgid  "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Les serveurs de noms de la zone ne retournent pas assez de serveurs ({count}) faisant autorité ({ns}). La limite inférieure étant fixée à {minimum}."
+msgid  ""
+"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Les serveurs de noms de la zone ne retournent pas assez de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_GLUE
-msgid  "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Les serveurs de noms de la zone parente ne retournent pas assez de serveurs ({count}) faisant autorité ({glue}). La limite inférieure étant fixée à {minimum}."
+msgid  ""
+"Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
+"to {minimum}."
+msgstr ""
+"Les serveurs de noms de la zone parente ne retournent pas assez de serveurs "
+"({count}) faisant autorité ({glue}). La limite inférieure étant fixée à "
+"{minimum}."
 
 #: DELEGATION:NS_RR_IS_CNAME
 msgid  "Nameserver {ns} {address_type} RR point to CNAME."
-msgstr "L'enregistrement de type \"{address_type}\" retourné par le serveur de noms {ns} est un alias (CNAME)."
+msgstr ""
+"L'enregistrement de type \"{address_type}\" retourné par le serveur de noms "
+"{ns} est un alias (CNAME)."
 
 #: DELEGATION:NS_RR_NO_CNAME
 msgid  "No nameserver point to CNAME alias."
 msgstr "Aucun serveur de noms ne pointe sur un alias (CNAME)."
 
 #: DELEGATION:REFERRAL_SIZE_LARGE
-msgid  "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
-msgstr "La plus petite taille d'un paquet légal contenant une référence (referral) est supérieur à 512 octets (elle est de {size})."
+msgid  ""
+"The smallest possible legal referral packet is larger than 512 octets (it is "
+"{size})."
+msgstr ""
+"La plus petite taille d'un paquet légal contenant une référence (referral) "
+"est supérieur à 512 octets (elle est de {size})."
 
 #: DELEGATION:REFERRAL_SIZE_OK
-msgid  "The smallest possible legal referral packet is smaller than 513 octets (it is {size})."
-msgstr "La plus petite taille d'un paquet légal contenant une référence (referral) est inférieure à 513 octets (elle est de {size})."
+msgid  ""
+"The smallest possible legal referral packet is smaller than 513 octets (it "
+"is {size})."
+msgstr ""
+"La plus petite taille d'un paquet légal contenant une référence (referral) "
+"est inférieure à 513 octets (elle est de {size})."
 
 #: DELEGATION:SAME_IP_ADDRESS
 msgid  "IP {address} refers to multiple nameservers ({nss})."
-msgstr "L'adresse IP {address} fait référence à plusieurs serveurs de noms ({nss})."
+msgstr ""
+"L'adresse IP {address} fait référence à plusieurs serveurs de noms ({nss})."
 
 #: DELEGATION:SOA_EXISTS
 msgid  "All the nameservers have SOA record."
-msgstr "Tous les serveurs de noms retournent un enregistrement de type \"SOA\"."
+msgstr ""
+"Tous les serveurs de noms retournent un enregistrement de type \"SOA\"."
 
 #: DELEGATION:SOA_NOT_EXISTS
 msgid  "A SOA query NOERROR response from {ns} was received empty."
-msgstr "Une réponse à une requête pour un enregistrement de type \"SOA\" sur le serveur de noms {ns} a été reçue vide alors que le code retour est \"NOERROR\"."
+msgstr ""
+"Une réponse à une requête pour un enregistrement de type \"SOA\" sur le "
+"serveur de noms {ns} a été reçue vide alors que le code retour est \"NOERROR"
+"\"."
 
 #: DELEGATION:TOTAL_NAME_MISMATCH
 msgid  "None of the nameservers listed at the parent are listed at the child."
-msgstr "La liste des serveurs de noms retournée par les serveurs de noms de la zone parente et par ceux de la zone est complètement différente."
+msgstr ""
+"La liste des serveurs de noms retournée par les serveurs de noms de la zone "
+"parente et par ceux de la zone est complètement différente."
 
 #: DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
 msgid  "No DNSKEYs found. Additional tests skipped."
-msgstr "Pas d'enregistrement de type \"DNSKEY\" trouvé. Les tests additionnels sont abandonnés."
+msgstr ""
+"Pas d'enregistrement de type \"DNSKEY\" trouvé. Les tests additionnels sont "
+"abandonnés."
 
 #: DNSSEC:ALGORITHM_DEPRECATED
-msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme obsolète {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme obsolète "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_OK
-msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme correct {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
+"({description}), which is OK."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme correct "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_PRIVATE
-msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme privé {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme privé "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_RESERVED
-msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
-msgstr "La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme réservé {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme réservé "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNASSIGNED
-msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
-msgstr "La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme non assigné {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme non "
+"assigné {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNKNOWN
 msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
-msgstr "La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme inconnu."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme inconnu."
 
 #: DNSSEC:COMMON_KEYTAGS
 msgid  "There are both DS and DNSKEY records with key tags {keytags}."
-msgstr "Il y a des enregistrements de type \"DS\" et \"DNSKEY\" partageant les mêmes tag de clé {keytags}."
+msgstr ""
+"Il y a des enregistrements de type \"DS\" et \"DNSKEY\" partageant les mêmes "
+"tag de clé {keytags}."
+
+#: DNSSEC:DELEGATION_NOT_SIGNED
+msgid  "Delegation from parent to child is not properly signed {reason}."
+msgstr ""
+"L'enregistrement DS dans la zone parente n'est pas correctement signé: "
+"{reason}."
+
+#: DNSSEC:DELEGATION_SIGNED
+msgid  "Delegation from parent to child is properly signed."
+msgstr "L'enregistrement DS dans la zone parente est correctement signé."
 
 #: DNSSEC:DNSKEY_AND_DS
 msgid  "{parent} sent a DS record, and {child} a DNSKEY record."
-msgstr "La zone parente retourne un enregistrement de type \"DS\" et les serveurs de noms de la zone, un enregistrement de type \"DNSKEY\"."
+msgstr ""
+"La zone parente retourne un enregistrement de type \"DS\" et les serveurs de "
+"noms de la zone, un enregistrement de type \"DNSKEY\"."
 
 #: DNSSEC:DNSKEY_BUT_NOT_DS
 msgid  "{child} sent a DNSKEY record, but {parent} did not send a DS record."
-msgstr "Les serveurs de noms de la zone retournent un enregistrement de type \"DNSKEY\", mais aucun enregistrement de type \"DS\" n'a été trouvé dans la zone parente."
+msgstr ""
+"Les serveurs de noms de la zone retournent un enregistrement de type \"DNSKEY"
+"\", mais aucun enregistrement de type \"DS\" n'a été trouvé dans la zone "
+"parente."
 
 #: DNSSEC:DNSKEY_NOT_SIGNED
 msgid  "The apex DNSKEY RRset was not correctly signed."
-msgstr "L'ensemble des clés de l'apex (DNSKEY RRset) n'est pas signé correctement."
+msgstr ""
+"L'ensemble des clés de l'apex (DNSKEY RRset) n'est pas signé correctement."
 
 #: DNSSEC:DNSKEY_SIGNATURE_NOT_OK
-msgid  "Signature for DNSKEY with tag {signature} failed to verify with error '{error}'."
-msgstr "La vérification de la signature de la clé avec le tag {signature} a échoué en retournant l'erreur '{error}'."
+msgid  ""
+"Signature for DNSKEY with tag {signature} failed to verify with error "
+"'{error}'."
+msgstr ""
+"La vérification de la signature de la clé avec le tag {signature} a échoué "
+"en retournant l'erreur '{error}'."
 
 #: DNSSEC:DNSKEY_SIGNATURE_OK
 msgid  "A signature for DNSKEY with tag {signature} was correctly signed."
@@ -387,55 +592,97 @@ msgstr "L'ensemble des clés de l'apex (DNSKEY RRset) est signé correctement."
 
 #: DNSSEC:DS_BUT_NOT_DNSKEY
 msgid  "{parent} sent a DS record, but {child} did not send a DNSKEY record."
-msgstr "La zone parente retourne un enregistrement de type \"DS\" mais les serveurs de noms de la zone ne retournent pas d'enregistrement de type \"DNSKEY\"."
+msgstr ""
+"La zone parente retourne un enregistrement de type \"DS\" mais les serveurs "
+"de noms de la zone ne retournent pas d'enregistrement de type \"DNSKEY\"."
 
 #: DNSSEC:DS_DIGTYPE_NOT_OK
 msgid  "DS record with keytag {keytag} uses forbidden digest type {digtype}."
-msgstr "L'enregistrement de type \"DS\" avec le tag de clé {keytag} utilise un type de condensat (digest) interdit {digtype}."
+msgstr ""
+"L'enregistrement de type \"DS\" avec le tag de clé {keytag} utilise un type "
+"de condensat (digest) interdit {digtype}."
 
 #: DNSSEC:DS_DIGTYPE_OK
 msgid  "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
-msgstr "L'enregistrement de type \"DS\" avec le tag de clé {keytag} utilise un type de condensat (digest) correct."
+msgstr ""
+"L'enregistrement de type \"DS\" avec le tag de clé {keytag} utilise un type "
+"de condensat (digest) correct."
 
 #: DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
-msgstr "L'enregistrement de type \"DS\" avec le tag de clé {keytag} et de type de condensat \"{digtype}\" ne correspond à l'enregistrement de type \"DNSKEY\" ayant le même tag."
-
-#: DNSSEC:DS_MATCHES_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY with the same tag."
-msgstr "L'enregistrement de type \"DS\" avec le tag de clé {keytag} et de type de condensat \"{digtype}\" correspond à l'enregistrement de type \"DNSKEY\" ayant le même tag."
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} does not match the "
+"DNSKEY with the same tag."
+msgstr ""
+"L'enregistrement de type \"DS\" avec le tag de clé {keytag} et de type de "
+"condensat \"{digtype}\" ne correspond à l'enregistrement de type \"DNSKEY\" "
+"ayant le même tag."
 
 #: DNSSEC:DS_FOUND
 msgid  "Found DS records with tags {keytags}."
-msgstr "Des enregistrements de type \"DS\" ont été trouvés avec les tags suivants {keytags}."
+msgstr ""
+"Des enregistrements de type \"DS\" ont été trouvés avec les tags suivants "
+"{keytags}."
+
+#: DNSSEC:DS_MATCHES_DNSKEY
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
+"with the same tag."
+msgstr ""
+"L'enregistrement de type \"DS\" avec le tag de clé {keytag} et de type de "
+"condensat \"{digtype}\" correspond à l'enregistrement de type \"DNSKEY\" "
+"ayant le même tag."
 
 #: DNSSEC:DS_MATCH_FOUND
 msgid  "At least one DS record with a matching DNSKEY record was found."
-msgstr "Au moins un enregistrement de type \"DS\" avec un enregistrement de type \"DNSKEY\" correspondant a été trouvé."
+msgstr ""
+"Au moins un enregistrement de type \"DS\" avec un enregistrement de type "
+"\"DNSKEY\" correspondant a été trouvé."
 
 #: DNSSEC:DS_MATCH_NOT_FOUND
 msgid  "No DS record with a matching DNSKEY record was found."
-msgstr "Aucun enregistrement de type \"DS\" avec un enregistrement de type \"DNSKEY\" correspondant n'a été trouvé."
+msgstr ""
+"Aucun enregistrement de type \"DS\" avec un enregistrement de type \"DNSKEY"
+"\" correspondant n'a été trouvé."
 
 #: DNSSEC:DS_RFC4509_NOT_VALID
-msgid  "Existing DS with digest type 2, while they do not match DNSKEY records, prevent use of DS with digest type 1 (RFC4509, section 3)."
-msgstr "Un condensat de type 2 existe (mais il ne correspond pas à un enregistrement de type \"DNSKEY\" existant) et conformément au RFC4509 (section 3) cela pourrait empêcher la validation."
+msgid  ""
+"Existing DS with digest type 2, while they do not match DNSKEY records, "
+"prevent use of DS with digest type 1 (RFC4509, section 3)."
+msgstr ""
+"Un condensat de type 2 existe (mais il ne correspond pas à un enregistrement "
+"de type \"DNSKEY\" existant) et conformément au RFC4509 (section 3) cela "
+"pourrait empêcher la validation."
 
 #: DNSSEC:DURATION_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is too long."
-msgstr "La signature (RRSIG) avec la clé de tag {tag} et couvrant les enregistrements de type(s) \"{types}\" a une durée de {duration} secondes, ce qui est trop long."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is too long."
+msgstr ""
+"La signature (RRSIG) avec la clé de tag {tag} et couvrant les "
+"enregistrements de type(s) \"{types}\" a une durée de {duration} secondes, "
+"ce qui est trop long."
 
 #: DNSSEC:DURATION_OK
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
-msgstr "La signature (RRSIG) avec la clé de tag {tag} et couvrant les enregistrements de type(s) \"{types}\" a une durée de {duration} secondes, ce qui est raisonnable."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is just fine."
+msgstr ""
+"La signature (RRSIG) avec la clé de tag {tag} et couvrant les "
+"enregistrements de type(s) \"{types}\" a une durée de {duration} secondes, "
+"ce qui est raisonnable."
 
 #: DNSSEC:EXTRA_PROCESSING_BROKEN
-msgid  "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
-msgstr "Le serveur de noms {server} retourne des clés (DNSKEY) {keys}, et les signatures (RRSIG) {sigs}."
+msgid  ""
+"Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
+msgstr ""
+"Le serveur de noms {server} retourne des clés (DNSKEY) {keys}, et les "
+"signatures (RRSIG) {sigs}."
 
 #: DNSSEC:EXTRA_PROCESSING_OK
 msgid  "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Le serveur de noms {server} retourne des clés (DNSKEY) {keys} et les signatures (RRSIG) {sigs}."
+msgstr ""
+"Le serveur de noms {server} retourne des clés (DNSKEY) {keys} et les "
+"signatures (RRSIG) {sigs}."
 
 #: DNSSEC:HAS_NSEC
 msgid  "The zone has NSEC records."
@@ -447,27 +694,40 @@ msgstr "La zone a des enregistrements de type \"NSEC3\"."
 
 #: DNSSEC:HAS_NSEC3_OPTOUT
 msgid  "The zone has NSEC3 opt-out records."
-msgstr "L'opt-out est mis en oeuvre pour des enregistrements de type \"NSEC3\"."
+msgstr ""
+"L'opt-out est mis en oeuvre pour des enregistrements de type \"NSEC3\"."
 
 #: DNSSEC:INVALID_NAME_RCODE
-msgid  "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
-msgstr "Lors d'une requête sur un nom de domaine qui ne devrait pas exister, on obtient une réponse avec le code retour (RCODE) {rcode}."
+msgid  ""
+"When asked for the name {name}, which must not exist, the response had RCODE "
+"{rcode}."
+msgstr ""
+"Lors d'une requête sur un nom de domaine qui ne devrait pas exister, on "
+"obtient une réponse avec le code retour (RCODE) {rcode}."
 
 #: DNSSEC:ITERATIONS_OK
 msgid  "The number of NSEC3 iterations is {count}, which is OK."
-msgstr "Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est correct."
+msgstr ""
+"Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est correct."
 
 #: DNSSEC:KEY_DETAILS
-msgid  "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
-msgstr "Quelques détails pour la clé (DNSKEY) avec le tag {keytag} : Size = {keysize}, Flags ({sep}, {rfc5011})."
+msgid  ""
+"Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
+"{rfc5011})."
+msgstr ""
+"Quelques détails pour la clé (DNSKEY) avec le tag {keytag} : Size = "
+"{keysize}, Flags ({sep}, {rfc5011})."
 
 #: DNSSEC:MANY_ITERATIONS
 msgid  "The number of NSEC3 iterations is {count}, which is on the high side."
-msgstr "Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est élevé."
+msgstr ""
+"Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est élevé."
 
 #: DNSSEC:NEITHER_DNSKEY_NOR_DS
 msgid  "There are neither DS nor DNSKEY records for the zone."
-msgstr "Il n'y a pas enregistrements de type \"DS\", ni de type \"DNSKEY\" pour la zone."
+msgstr ""
+"Il n'y a pas enregistrements de type \"DS\", ni de type \"DNSKEY\" pour la "
+"zone."
 
 #: DNSSEC:NOT_SIGNED
 msgid  "The zone is not signed with DNSSEC."
@@ -475,7 +735,9 @@ msgstr "La zone n'est pas signée avec DNSSEC."
 
 #: DNSSEC:NO_COMMON_KEYTAGS
 msgid  "No DS record had a DNSKEY with a matching keytag."
-msgstr "Aucun enregistrement de type \"DS\" n'a d'enregistrement de type \"DNSKEY\" correspondant (avec le même tag de clé)."
+msgstr ""
+"Aucun enregistrement de type \"DS\" n'a d'enregistrement de type \"DNSKEY\" "
+"correspondant (avec le même tag de clé)."
 
 #: DNSSEC:NO_DNSKEY
 msgid  "No DNSKEYs were returned."
@@ -483,19 +745,33 @@ msgstr "Aucun enregistrement de type \"DNSKEY\" n'a été retourné."
 
 #: DNSSEC:NO_DS
 msgid  "{from} returned no DS records for {zone}."
-msgstr "Le serveur de noms {from} ne retourne aucun enregistrement de type \"DS\" pour la zone '{zone}'."
+msgstr ""
+"Le serveur de noms {from} ne retourne aucun enregistrement de type \"DS\" "
+"pour la zone '{zone}'."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS
-msgid  "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Impossible de tester les signatures des clés (DNSKEY) car nous obtenons {keys} enregistrements de type \"DNSKEY\" et {sigs} enregistrements de type \"RRSIG\"."
+msgid  ""
+"Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
+"{sigs} RRSIG records."
+msgstr ""
+"Impossible de tester les signatures des clés (DNSKEY) car nous obtenons "
+"{keys} enregistrements de type \"DNSKEY\" et {sigs} enregistrements de type "
+"\"RRSIG\"."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-msgid  "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} RRSIG records and {soas} SOA records."
-msgstr "Impossible de tester les signatures des enregistrements de type \"SOA\" car nous obtenons {keys} enregistrements de type \"DNSKEY\", {sigs} enregistrements de type \"RRSIG\" et {soas} enregistrements de type \"SOA\"."
+msgid  ""
+"Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
+"RRSIG records and {soas} SOA records."
+msgstr ""
+"Impossible de tester les signatures des enregistrements de type \"SOA\" car "
+"nous obtenons {keys} enregistrements de type \"DNSKEY\", {sigs} "
+"enregistrements de type \"RRSIG\" et {soas} enregistrements de type \"SOA\"."
 
 #: DNSSEC:NO_NSEC3PARAM
 msgid  "{server} returned no NSEC3PARAM records."
-msgstr "Le serveur de noms {server} ne retourne pas d'enregistrements de type \"NSEC3PARAM\"."
+msgstr ""
+"Le serveur de noms {server} ne retourne pas d'enregistrements de type "
+"\"NSEC3PARAM\"."
 
 #: DNSSEC:NSEC3_COVERS
 msgid  "NSEC3 record covers {name}."
@@ -507,15 +783,21 @@ msgstr "NSEC3 ne couvre pas le nom {name}."
 
 #: DNSSEC:NSEC3_NOT_SIGNED
 msgid  "No signature correctly signed the NSEC3 RRset."
-msgstr "Aucune signature correcte ne signe l'ensemble des enregistrements de type \"NSEC3\"."
+msgstr ""
+"Aucune signature correcte ne signe l'ensemble des enregistrements de type "
+"\"NSEC3\"."
 
 #: DNSSEC:NSEC3_SIGNED
 msgid  "At least one signature correctly signed the NSEC3 RRset."
-msgstr "Au moins une signature correcte signe l'ensemble des enregistrements de type \"NSEC3\"."
+msgstr ""
+"Au moins une signature correcte signe l'ensemble des enregistrements de type "
+"\"NSEC3\"."
 
 #: DNSSEC:NSEC3_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Une erreur '{error}' a été obtenue en essayant de vérifier l'ensemble des enregistrements de type \"NSEC3\" avec la RRSIG {sig}."
+msgstr ""
+"Une erreur '{error}' a été obtenue en essayant de vérifier l'ensemble des "
+"enregistrements de type \"NSEC3\" avec la RRSIG {sig}."
 
 #: DNSSEC:NSEC_COVERS
 msgid  "NSEC covers {name}."
@@ -527,99 +809,212 @@ msgstr "NSEC ne couvre pas le nom {name}."
 
 #: DNSSEC:NSEC_NOT_SIGNED
 msgid  "No signature correctly signed the NSEC RRset."
-msgstr "Aucune signature correcte ne signe l'ensemble des enregistrements de type \"NSEC\"."
+msgstr ""
+"Aucune signature correcte ne signe l'ensemble des enregistrements de type "
+"\"NSEC\"."
 
 #: DNSSEC:NSEC_SIGNED
 msgid  "At least one signature correctly signed the NSEC RRset."
-msgstr "Au moins une signature (RRSIG) correcte signe l'ensemble des enregistrements de type \"NSEC\"."
+msgstr ""
+"Au moins une signature (RRSIG) correcte signe l'ensemble des enregistrements "
+"de type \"NSEC\"."
 
 #: DNSSEC:NSEC_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Une erreur '{error}' a été obtenue en essayant de vérifier l'ensemble des enregistrements de type \"NSEC\" avec la signature {sig}."
+msgstr ""
+"Une erreur '{error}' a été obtenue en essayant de vérifier l'ensemble des "
+"enregistrements de type \"NSEC\" avec la signature {sig}."
 
 #: DNSSEC:REMAINING_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
-msgstr "La signature (RRSIG) avec la clé de tag {tag} et couvrant les enregistrements de type(s) \"{types}\" a une durée de validitée restante de {duration} secondes, ce qui est trop long."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too long."
+msgstr ""
+"La signature (RRSIG) avec la clé de tag {tag} et couvrant les "
+"enregistrements de type(s) \"{types}\" a une durée de validitée restante de "
+"{duration} secondes, ce qui est trop long."
 
 #: DNSSEC:REMAINING_SHORT
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
-msgstr "La signature (RRSIG) avec la clé de tag {tag} et couvrant les enregistrements de type(s) \"{types}\" a une durée de validitée restante de {duration} secondes, ce qui est trop court."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too short."
+msgstr ""
+"La signature (RRSIG) avec la clé de tag {tag} et couvrant les "
+"enregistrements de type(s) \"{types}\" a une durée de validitée restante de "
+"{duration} secondes, ce qui est trop court."
 
 #: DNSSEC:RRSIG_EXPIRATION
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
-msgstr "La signature (RRSIG) avec la champ keytag {tag} et couvrant les enregistrements de type(s) \"{types}\" expire à la date suivante : {date}."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+msgstr ""
+"La signature (RRSIG) avec la champ keytag {tag} et couvrant les "
+"enregistrements de type(s) \"{types}\" expire à la date suivante : {date}."
 
 #: DNSSEC:RRSIG_EXPIRED
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
-msgstr "La signature (RRSIG) avec la champ keytag {tag} et couvrant les enregistrements de type(s) \"{types}\" a expiré (date d'expiration: {expiration})."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has already expired "
+"(expiration is: {expiration})."
+msgstr ""
+"La signature (RRSIG) avec la champ keytag {tag} et couvrant les "
+"enregistrements de type(s) \"{types}\" a expiré (date d'expiration: "
+"{expiration})."
 
 #: DNSSEC:SOA_NOT_SIGNED
 msgid  "No RRSIG correctly signed the SOA RRset."
-msgstr "Aucune signature correcte ne signe l'ensemble des enregistrements de type \"SOA\"."
+msgstr ""
+"Aucune signature correcte ne signe l'ensemble des enregistrements de type "
+"\"SOA\"."
 
 #: DNSSEC:SOA_SIGNATURE_NOT_OK
-msgid  "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
-msgstr "Une erreur '{error}' a été obtenue en essayant de vérifier l'ensemble des enregistrements de type \"SOA\" avec la signature {sig}."
+msgid  ""
+"Trying to verify SOA RRset with signature {signature} gave error '{error}'."
+msgstr ""
+"Une erreur '{error}' a été obtenue en essayant de vérifier l'ensemble des "
+"enregistrements de type \"SOA\" avec la signature {sig}."
 
 #: DNSSEC:SOA_SIGNATURE_OK
 msgid  "RRSIG {signature} correctly signs SOA RRset."
-msgstr "La signature (RRSIG) {signature} signe correctement l'enregistrement de type \"SOA\"."
+msgstr ""
+"La signature (RRSIG) {signature} signe correctement l'enregistrement de type "
+"\"SOA\"."
 
 #: DNSSEC:SOA_SIGNED
 msgid  "At least one RRSIG correctly signs the SOA RRset."
-msgstr "Au moins une signature (RRSIG) correcte signe correctement l'enregistrement de type \"SOA\"."
+msgstr ""
+"Au moins une signature (RRSIG) correcte signe correctement l'enregistrement "
+"de type \"SOA\"."
 
 #: DNSSEC:TOO_MANY_ITERATIONS
-msgid  "The number of NSEC3 iterations is {count}, which is too high for key length {keylength}."
-msgstr "Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est trop élevé pour une clé de cette taille {keylength}."
-
-#: DNSSEC:DELEGATION_NOT_SIGNED
-msgid  "Delegation from parent to child is not properly signed {reason}."
-msgstr "L'enregistrement DS dans la zone parente n'est pas correctement signé: {reason}."
-
-#: DNSSEC:DELEGATION_SIGNED
-msgid  "Delegation from parent to child is properly signed."
-msgstr "L'enregistrement DS dans la zone parente est correctement signé."
+msgid  ""
+"The number of NSEC3 iterations is {count}, which is too high for key length "
+"{keylength}."
+msgstr ""
+"Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est trop élevé "
+"pour une clé de cette taille {keylength}."
 
 #: EXAMPLE:EXAMPLE_TAG
 msgid  "This is an example tag."
 msgstr "Ceci est un tag d'exemple."
 
 #: NAMESERVER:AAAA_WELL_PROCESSED
-msgid  "The following nameservers answer AAAA queries without problems : {names}."
-msgstr "Les serveurs de noms suivants répondent correctement aux requêtes de type \"AAAA\" : {names}."
+msgid  ""
+"The following nameservers answer AAAA queries without problems : {names}."
+msgstr ""
+"Les serveurs de noms suivants répondent correctement aux requêtes de type "
+"\"AAAA\" : {names}."
 
 #: NAMESERVER:ANSWER_BAD_RCODE
-msgid  "Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode})."
-msgstr "Le serveur de noms {ns}/{address} a répondu à une requête de type \"AAAA\" avec un code retour inattendu ({rcode})."
+msgid  ""
+"Nameserver {ns}/{address} answered AAAA query with an unexpected rcode "
+"({rcode})."
+msgstr ""
+"Le serveur de noms {ns}/{address} a répondu à une requête de type \"AAAA\" "
+"avec un code retour inattendu ({rcode})."
 
 #: NAMESERVER:AXFR_AVAILABLE
 msgid  "Nameserver {ns}/{address} allow zone transfer using AXFR."
-msgstr "Il est possible de réaliser un transfert de zone depuis le serveur de noms {ns}/{address}."
+msgstr ""
+"Il est possible de réaliser un transfert de zone depuis le serveur de noms "
+"{ns}/{address}."
 
 #: NAMESERVER:AXFR_FAILURE
 msgid  "AXFR not available on nameserver {ns}/{address}."
-msgstr "Il n'est pas  possible de réaliser un transfert de zone depuis le serveur de noms {ns}/{address}."
+msgstr ""
+"Il n'est pas  possible de réaliser un transfert de zone depuis le serveur de "
+"noms {ns}/{address}."
 
 #: NAMESERVER:CAN_BE_RESOLVED
 msgid  "All nameservers succeeded to resolve to an IP address."
-msgstr "Il a été possible de trouver au moins une adresse IP pour tous les serveurs de noms."
+msgstr ""
+"Il a été possible de trouver au moins une adresse IP pour tous les serveurs "
+"de noms."
 
 #: NAMESERVER:CAN_NOT_BE_RESOLVED
 msgid  "The following nameservers failed to resolve to an IP address : {names}."
-msgstr "Aucune adresse IP n'a pu être trouvée pour les serveurs de noms suivants : {names}."
+msgstr ""
+"Aucune adresse IP n'a pu être trouvée pour les serveurs de noms suivants : "
+"{names}."
+
+#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers do not reply consistently."
+msgstr ""
+"Lors d'une requête de type {type} pour la ressource \"{query}\" avec des "
+"casses différentes, tous les serveurs ne répondent pas de manière "
+"consistante."
+
+#: NAMESERVER:CASE_QUERIES_RESULTS_OK
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers reply consistently."
+msgstr ""
+"Lors d'une requête de type {type} pour la ressource \"{query}\" avec des "
+"casses différentes, tous les serveurs retournent les mêmes résultats."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different answers."
+msgstr ""
+"Lors d'une requête de type {type} pour les ressources \"{query1}\" et "
+"\"{query2}\", le serveur de noms {ns}/{address} ne répond pas la même chose."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+msgstr ""
+"Lors d'une requête de type {type} pour les ressources \"{query1}\" et "
+"\"{query2}\", le serveur de noms {ns}/{address} ne renvoie pas le même code "
+"de retour (\"{rcode1}\" vs \"{rcode2}\")."
+
+#: NAMESERVER:CASE_QUERY_NO_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query}\", nameserver {ns}/{address} "
+"returns nothing."
+msgstr ""
+"Lors d'une requête de type {type} pour la ressource\"{query}\", le serveur "
+"de noms {ns}/{address} ne répond pas."
+
+#: NAMESERVER:CASE_QUERY_SAME_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same answers."
+msgstr ""
+"Lors d'une requête de type {type} pour les ressources \"{query1}\" et "
+"\"{query2}\", le serveur de noms {ns}/{address} répond la même chose."
+
+#: NAMESERVER:CASE_QUERY_SAME_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same RCODE \"{rcode}\"."
+msgstr ""
+"Lors d'une requête de type {type} pour les ressources \"{query1}\" et "
+"\"{query2}\", le serveur de noms {ns}/{address} renvoie le même code de "
+"retour \"{rcode}\"."
 
 #: NAMESERVER:DIFFERENT_SOURCE_IP
-msgid  "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
-msgstr "Le serveur de noms {ns}/{address} répond depuis une autre adresse que celle à laquelle la requête a été envoyée."
+msgid  ""
+"Nameserver {ns}/{address} replies on a SOA query with a different source "
+"address ({source})."
+msgstr ""
+"Le serveur de noms {ns}/{address} répond depuis une autre adresse que celle "
+"à laquelle la requête a été envoyée."
 
 #: NAMESERVER:EDNS0_BAD_ANSWER
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
-msgstr "Le serveur de noms {ns}/{address} ne supporte pas EDNS0 (pas d'enregistrement OPT dans la réponse)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne supporte pas EDNS0 (pas "
+"d'enregistrement OPT dans la réponse)."
 
 #: NAMESERVER:EDNS0_BAD_QUERY
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
-msgstr "Le serveur de noms {ns}/{address} ne supporte pas EDNS0 (retourne le code FORMERR)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne supporte pas EDNS0 (retourne le code "
+"FORMERR)."
 
 #: NAMESERVER:EDNS0_SUPPORT
 msgid  "The following nameservers support EDNS0 : {names}."
@@ -627,127 +1022,152 @@ msgstr "Les serveurs de noms suivants supportent EDNS0 : {names}."
 
 #: NAMESERVER:IS_A_RECURSOR
 msgid  "Nameserver {ns}/{address} is a recursor."
-msgstr "Le serveur de noms {ns}/{address} retourne le code NXDOMAIN lors d'une requête de type \"SOA\" sur le nom de domaine '{dname}'. Il est récursif."
+msgstr ""
+"Le serveur de noms {ns}/{address} retourne le code NXDOMAIN lors d'une "
+"requête de type \"SOA\" sur le nom de domaine '{dname}'. Il est récursif."
 
 #: NAMESERVER:NO_RECURSOR
 msgid  "None of the following nameservers is a recursor : {names}."
 msgstr "Aucun des serveurs de noms suivants n'est récursif : {names}."
 
-#: NAMESERVER:RECURSIVITY_UNDEF
-msgid  "Cannot determine if the following servers are recursive nameservers or not: {names}."
-msgstr "Impossible de déterminer si les serveurs suivants sont récursifs ou non : {names}."
-
 #: NAMESERVER:NO_RESOLUTION
 msgid  "No nameservers succeeded to resolve to an IP address."
-msgstr "Il a été impossible de trouver une adresse IP pour les serveurs de noms."
-
-#: NAMESERVER:QUERY_DROPPED
-msgid  "Nameserver {ns}/{address} dropped AAAA query."
-msgstr "Le serveur de noms {ns}/{address} ne répond pas aux requêtes portant sur le type \"AAAA\"."
-
-#: NAMESERVER:SAME_SOURCE_IP
-msgid  "All nameservers reply with same IP used to query them."
-msgstr "Tous les serveurs de noms répondent avec la même adresse IP que celle utilisée lors de leur requêtage."
-
-#: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
-msgid  "Upward referral tests skipped for root zone."
-msgstr "Les tests de type \"Upward Referral\" n'ont pas de sens pour la racine '.'."
-
-#: NAMESERVER:UPWARD_REFERRAL
-msgid  "Nameserver {ns}/{address} returns an upward referral."
-msgstr "Le serveur de noms {ns}/{address} répond à la requête de type \"NS\" sur la racine '.' (upward referral)."
+msgstr ""
+"Il a été impossible de trouver une adresse IP pour les serveurs de noms."
 
 #: NAMESERVER:NO_UPWARD_REFERRAL
 msgid  "None of the following nameservers returns an upward referral : {names}."
-msgstr "Aucun des serveurs de noms suivants ne répond à la requête de type \"NS\" sur la racine '.' (upward referral) : {names}."
+msgstr ""
+"Aucun des serveurs de noms suivants ne répond à la requête de type \"NS\" "
+"sur la racine '.' (upward referral) : {names}."
+
+#: NAMESERVER:QNAME_CASE_INSENSITIVE
+msgid  ""
+"Nameserver {ns}/{address} does not preserve original case of queried names."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne conserve pas la casse des noms requêtés "
+"dans les réponses '{dname}'."
 
 #: NAMESERVER:QNAME_CASE_SENSITIVE
 msgid  "Nameserver {ns}/{address} preserves original case of queried names."
-msgstr "Le serveur de noms {ns}/{address} conserve la casse des noms requêtés dans les réponses '{dname}'."
+msgstr ""
+"Le serveur de noms {ns}/{address} conserve la casse des noms requêtés dans "
+"les réponses '{dname}'."
 
-#: NAMESERVER:QNAME_CASE_INSENSITIVE
-msgid  "Nameserver {ns}/{address} does not preserve original case of queried names."
-msgstr "Le serveur de noms {ns}/{address} ne conserve pas la casse des noms requêtés dans les réponses '{dname}'."
+#: NAMESERVER:QUERY_DROPPED
+msgid  "Nameserver {ns}/{address} dropped AAAA query."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne répond pas aux requêtes portant sur le "
+"type \"AAAA\"."
 
-#: NAMESERVER:CASE_QUERY_SAME_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-msgstr "Lors d'une requête de type {type} pour les ressources \"{query1}\" et \"{query2}\", le serveur de noms {ns}/{address} répond la même chose."
+#: NAMESERVER:RECURSIVITY_UNDEF
+msgid  ""
+"Cannot determine if the following servers are recursive nameservers or not: "
+"{names}."
+msgstr ""
+"Impossible de déterminer si les serveurs suivants sont récursifs ou non : "
+"{names}."
 
-#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-msgstr "Lors d'une requête de type {type} pour les ressources \"{query1}\" et \"{query2}\", le serveur de noms {ns}/{address} ne répond pas la même chose."
+#: NAMESERVER:SAME_SOURCE_IP
+msgid  "All nameservers reply with same IP used to query them."
+msgstr ""
+"Tous les serveurs de noms répondent avec la même adresse IP que celle "
+"utilisée lors de leur requêtage."
 
-#: NAMESERVER:CASE_QUERY_SAME_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "Lors d'une requête de type {type} pour les ressources \"{query1}\" et \"{query2}\", le serveur de noms {ns}/{address} renvoie le même code de retour \"{rcode}\"."
+#: NAMESERVER:UPWARD_REFERRAL
+msgid  "Nameserver {ns}/{address} returns an upward referral."
+msgstr ""
+"Le serveur de noms {ns}/{address} répond à la requête de type \"NS\" sur la "
+"racine '.' (upward referral)."
 
-#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "Lors d'une requête de type {type} pour les ressources \"{query1}\" et \"{query2}\", le serveur de noms {ns}/{address} ne renvoie pas le même code de retour (\"{rcode1}\" vs \"{rcode2}\")."
-
-#: NAMESERVER:CASE_QUERY_NO_ANSWER
-msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-msgstr "Lors d'une requête de type {type} pour la ressource\"{query}\", le serveur de noms {ns}/{address} ne répond pas."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_OK
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-msgstr "Lors d'une requête de type {type} pour la ressource \"{query}\" avec des casses différentes, tous les serveurs retournent les mêmes résultats."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
-msgstr "Lors d'une requête de type {type} pour la ressource \"{query}\" avec des casses différentes, tous les serveurs ne répondent pas de manière consistante."
+#: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
+msgid  "Upward referral tests skipped for root zone."
+msgstr ""
+"Les tests de type \"Upward Referral\" n'ont pas de sens pour la racine '.'."
 
 #: SYNTAX:DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Le nom de domaine '{name}' contient un label avec un double tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+msgid  ""
+"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Le nom de domaine '{name}' contient un label avec un double tiret ('--') en "
+"positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #: SYNTAX:INITIAL_HYPHEN
-msgid  "Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
-msgstr "Le nom de domaine '{name}' contient un label commençant par un tiret ('-')."
+msgid  ""
+"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+msgstr ""
+"Le nom de domaine '{name}' contient un label commençant par un tiret ('-')."
 
 #: SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
-msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Le serveur maître défini dans le SOA, 'mname' ({name}), contient un label ({label}) avec un double tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+msgid  ""
+"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' ({name}), contient un label "
+"({label}) avec un double tiret ('--') en positions 3 et 4 (avec un préfixe "
+"différent de 'xn--')."
 
 #: SYNTAX:MNAME_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in SOA MNAME ({name})."
-msgstr "Des caractèrs interdits ont été trouvés dans le nom du serveur maître défini dans le SOA, 'mname' ({name})."
+msgstr ""
+"Des caractèrs interdits ont été trouvés dans le nom du serveur maître défini "
+"dans le SOA, 'mname' ({name})."
 
 #: SYNTAX:MNAME_NUMERIC_TLD
 msgid  "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Le serveur maître défini dans le SOA, 'mname' ({name}), se trouve dans un TLD 'numeric only' ({tld})."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' ({name}), se trouve dans un "
+"TLD 'numeric only' ({tld})."
 
 #: SYNTAX:MNAME_SYNTAX_OK
 msgid  "SOA MNAME ({name}) syntax is valid."
-msgstr "La syntaxe du nom du serveur maître défini dans le SOA, 'mname' ({name}) est valide."
+msgstr ""
+"La syntaxe du nom du serveur maître défini dans le SOA, 'mname' ({name}) est "
+"valide."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Le relais de messagerie ({name}) contient un label ({label}) avec un double tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+msgid  ""
+"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Le relais de messagerie ({name}) contient un label ({label}) avec un double "
+"tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #: SYNTAX:MX_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in MX ({name})."
-msgstr "Des caractèrs interdits ont été trouvés dans le nom du relais de messagerie ({name})."
+msgstr ""
+"Des caractèrs interdits ont été trouvés dans le nom du relais de messagerie "
+"({name})."
 
 #: SYNTAX:MX_NUMERIC_TLD
 msgid  "Domain name MX ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Le relais de messagerie ({name}) se trouve dans un TLD 'numeric only' ({tld})."
+msgstr ""
+"Le relais de messagerie ({name}) se trouve dans un TLD 'numeric "
+"only' ({tld})."
 
 #: SYNTAX:MX_SYNTAX_OK
 msgid  "Domain name MX ({name}) syntax is valid."
 msgstr "La syntaxe du nom du relais de messagerie ({name}) est valide."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
-msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Le serveur de noms ({name}) contient un label ({label}) avec un double tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+msgid  ""
+"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Le serveur de noms ({name}) contient un label ({label}) avec un double tiret "
+"('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the nameserver ({name})."
-msgstr "Des caractèrs interdits ont été trouvés dans le nom du serveur de noms ({name})."
+msgstr ""
+"Des caractèrs interdits ont été trouvés dans le nom du serveur de noms "
+"({name})."
 
 #: SYNTAX:NAMESERVER_NUMERIC_TLD
 msgid  "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Le serveur de noms ({name}) se trouve dans un TLD 'numeric only' ({tld})."
+msgstr ""
+"Le serveur de noms ({name}) se trouve dans un TLD 'numeric only' ({tld})."
 
 #: SYNTAX:NAMESERVER_SYNTAX_OK
 msgid  "Nameserver ({name}) syntax is valid."
@@ -755,15 +1175,22 @@ msgstr "La syntaxe du nom du serveur de noms ({name}) est valide."
 
 #: SYNTAX:NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the domain name ({name})."
-msgstr "Des caractèrs interdits ont été trouvés dans le nom de domaine '{name}'."
+msgstr ""
+"Des caractèrs interdits ont été trouvés dans le nom de domaine '{name}'."
 
 #: SYNTAX:NO_DOUBLE_DASH
-msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Le nom de domaine '{name}' n'a aucun label contenant un double tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+msgid  ""
+"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
+"and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Le nom de domaine '{name}' n'a aucun label contenant un double tiret ('--') "
+"en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #: SYNTAX:NO_ENDING_HYPHENS
 msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
-msgstr "Aucune des extrémités des labels du nom de domain '{name}' n'est un tiret '-'."
+msgstr ""
+"Aucune des extrémités des labels du nom de domain '{name}' n'est un tiret "
+"'-'."
 
 #: SYNTAX:NO_RESPONSE_MX_QUERY ZONE:NO_RESPONSE_MX_QUERY
 msgid  "No response from nameserver(s) on MX queries."
@@ -778,8 +1205,10 @@ msgid  "No illegal characters in the domain name ({name})."
 msgstr "Le nom de domaine '{name}' ne contient aucun caractère interdit."
 
 #: SYNTAX:RNAME_MISUSED_AT_SIGN
-msgid  "There must be no misused '@' character in the SOA RNAME field ({rname})."
-msgstr "Il ne doit pas y avoir de caractère '@' dans le champ RNAME ({rname}) du SOA."
+msgid  ""
+"There must be no misused '@' character in the SOA RNAME field ({rname})."
+msgstr ""
+"Il ne doit pas y avoir de caractère '@' dans le champ RNAME ({rname}) du SOA."
 
 #: SYNTAX:RNAME_NO_AT_SIGN
 msgid  "There is no misused '@' character in the SOA RNAME field ({rname})."
@@ -787,23 +1216,33 @@ msgstr "Il n'y a aucun caractère '@' dans le champ RNAME ({rname}) du SOA."
 
 #: SYNTAX:RNAME_RFC822_INVALID
 msgid  "There must be no illegal characters in the SOA RNAME field ({rname})."
-msgstr "Il ne doit pas y avoir de caractères interdits dans le champ RNAME ({rname}) du SOA."
+msgstr ""
+"Il ne doit pas y avoir de caractères interdits dans le champ RNAME ({rname}) "
+"du SOA."
 
 #: SYNTAX:RNAME_RFC822_VALID
 msgid  "The SOA RNAME field ({rname}) is compliant with RFC2822."
-msgstr "Le champ RNAME ({rname}) du SOA est conforme aux règles définies dans le RFC2822."
+msgstr ""
+"Le champ RNAME ({rname}) du SOA est conforme aux règles définies dans le "
+"RFC2822."
 
 #: SYNTAX:TERMINAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) ending with an hyphen ('-')."
-msgstr "Le nom de domaine '{name}' contient un label ({label}) se terminant par un tiret '-'."
+msgstr ""
+"Le nom de domaine '{name}' contient un label ({label}) se terminant par un "
+"tiret '-'."
 
 #: SYSTEM:ADDED_FAKE_DELEGATION
 msgid  "Added a fake delegation for domain {domain} to name server {ns}."
-msgstr "Ajout d'une fausse délégation pour le domaine {domaine} pour le serveur de nom {ns}."
+msgstr ""
+"Ajout d'une fausse délégation pour le domaine {domaine} pour le serveur de "
+"nom {ns}."
 
 #: SYSTEM:CANNOT_CONTINUE
 msgid  "Not enough data about {zone} was found to be able to run tests."
-msgstr "Pas assez d'informations obtenues sur la zone '{zone}' pour permettre la poursuite des tests."
+msgstr ""
+"Pas assez d'informations obtenues sur la zone '{zone}' pour permettre la "
+"poursuite des tests."
 
 #: SYSTEM:CONFIG_FILE
 msgid  "Configuration was read from {name}."
@@ -813,33 +1252,53 @@ msgstr "La configuration a été lue depuis le fichier {name}."
 msgid  "Using prerequisite module {name} version {version}."
 msgstr "Utilisation du module prérequis {name} version {version}."
 
-#: SYSTEM:GLOBAL_VERSION
-msgid  "Using version {version} of the Zonemaster engine."
-msgstr "Utilisation de la version {version} du moteur Zonemaster."
-
 #: SYSTEM:FAKE_DELEGATION
 msgid  "Followed a fake delegation."
 msgstr "Utilisation d'une configuration DNS alternative (fake delegation)."
 
-#: SYSTEM:FAKE_DELEGATION_TO_SELF
-msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Refus d'ajout de configuration DNS alternative au serveur de nom {ns} pour le domaine '{domain}' sur lui-même."
-
 #: SYSTEM:FAKE_DELEGATION_IN_ZONE_NO_IP
-msgid  "The fake delegation of domain {domain} includes an in-zone name server {ns} without mandatory glue (without IP address)."
-msgstr "Ajout de configuration DNS alternative (fake delegation) pour le domaine '{domain}' au serveur de nom 'in-bailiwick' {ns} sans adresse IP."
+msgid  ""
+"The fake delegation of domain {domain} includes an in-zone name server {ns} "
+"without mandatory glue (without IP address)."
+msgstr ""
+"Ajout de configuration DNS alternative (fake delegation) pour le domaine "
+"'{domain}' au serveur de nom 'in-bailiwick' {ns} sans adresse IP."
 
 #: SYSTEM:FAKE_DELEGATION_NO_IP
-msgid  "The fake delegation of domain {domain} includes a name server {ns} that cannot be resolved to any IP address."
-msgstr "Ajout de configuration DNS alternative (fake delegation) pour le domaine '{domain}' au serveur de nom {ns} sans adresse IP."
+msgid  ""
+"The fake delegation of domain {domain} includes a name server {ns} that "
+"cannot be resolved to any IP address."
+msgstr ""
+"Ajout de configuration DNS alternative (fake delegation) pour le domaine "
+"'{domain}' au serveur de nom {ns} sans adresse IP."
+
+#: SYSTEM:FAKE_DELEGATION_TO_SELF
+msgid  ""
+"Name server {ns} not adding fake delegation for domain {domain} to itself."
+msgstr ""
+"Refus d'ajout de configuration DNS alternative au serveur de nom {ns} pour "
+"le domaine '{domain}' sur lui-même."
+
+#: SYSTEM:GLOBAL_VERSION
+msgid  "Using version {version} of the Zonemaster engine."
+msgstr "Utilisation de la version {version} du moteur Zonemaster."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
-msgstr "L'appel au système de log (Callback) s'est terminé avec l'erreur suivante: {exception}"
+msgstr ""
+"L'appel au système de log (Callback) s'est terminé avec l'erreur suivante: "
+"{exception}"
 
 #: SYSTEM:LOOKUP_ERROR
-msgid  "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
-msgstr "La requête DNS {name}/{type}/{class} au serveur de noms {ns} a échoué avec le message d'erreur suivant: {message}"
+msgid  ""
+"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+msgstr ""
+"La requête DNS {name}/{type}/{class} au serveur de noms {ns} a échoué avec "
+"le message d'erreur suivant: {message}"
+
+#: SYSTEM:MODULE_END
+msgid  "Module {module} finished running."
+msgstr "Exécution du module {module} terminée."
 
 #: SYSTEM:MODULE_ERROR
 msgid  "Fatal error in {module}: {msg}"
@@ -849,13 +1308,17 @@ msgstr "Erreur fatale dans le module {module}: {msg}"
 msgid  "Using module {module} version {version}."
 msgstr "Utilisation du module {module} version {version}."
 
-#: SYSTEM:MODULE_END
-msgid  "Module {module} finished running."
-msgstr "Exécution du module {module} terminée."
-
 #: SYSTEM:NO_NETWORK
 msgid  "Both IPv4 and IPv6 are disabled."
 msgstr "IPv6 et IPv4 sont désactivés."
+
+#: SYSTEM:PACKET_BIG
+msgid  ""
+"Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try "
+"with \"{command}\")."
+msgstr ""
+"La taille du paquet ({size} octets) dépasse le maximum communément utilisé "
+"de {maxsize} octets (tester avec la commande \"{command}\")."
 
 #: SYSTEM:POLICY_DISABLED
 msgid  "The module {name} was disabled by the policy."
@@ -875,55 +1338,85 @@ msgstr "IPv6 est désactivé, aucune requête envoyée au serveur de noms {ns}."
 
 #: SYSTEM:UNKNOWN_METHOD
 msgid  "Request to run unknown method {method} in module {module}."
-msgstr "Demande d'exécuter une méthode inconnue {method} pour le module {module}."
+msgstr ""
+"Demande d'exécuter une méthode inconnue {method} pour le module {module}."
 
 #: SYSTEM:UNKNOWN_MODULE
-msgid  "Request to run {method} in unknown module {module}. Known modules: {known}."
-msgstr "Demande d'exécuter une méthode {method} pour le module inconnu {module}. Liste des modules connus: {known}."
-
-#: SYSTEM:PACKET_BIG
-msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
-msgstr "La taille du paquet ({size} octets) dépasse le maximum communément utilisé de {maxsize} octets (tester avec la commande \"{command}\")."
+msgid  ""
+"Request to run {method} in unknown module {module}. Known modules: {known}."
+msgstr ""
+"Demande d'exécuter une méthode {method} pour le module inconnu {module}. "
+"Liste des modules connus: {known}."
 
 #: ZONE:EXPIRE_LOWER_THAN_REFRESH
-msgid  "SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value ({refresh})."
-msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus petite que la valeur du champ 'refresh' ({refresh})."
+msgid  ""
+"SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value "
+"({refresh})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'expire' ({expire}) est plus petite que la "
+"valeur du champ 'refresh' ({refresh})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_LOWER
-msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({required_expire})."
-msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus petite que la valeur recommandée ({required_expire})."
+msgid  ""
+"SOA 'expire' value ({expire}) is less than the recommended one "
+"({required_expire})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'expire' ({expire}) est plus petite que la "
+"valeur recommandée ({required_expire})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
-msgstr "Dans le SOA, la valeur du champ 'expire' ({expire}) est plus grande que la valeur minimale recommandée ({required_expire}) et pas plus petite que la valeur du champ 'refresh' ({refresh})."
+msgid  ""
+"SOA 'expire' value ({expire}) is higher than the minimum recommended value "
+"({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'expire' ({expire}) est plus grande que la "
+"valeur minimale recommandée ({required_expire}) et pas plus petite que la "
+"valeur du champ 'refresh' ({refresh})."
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."
-msgstr "Aucune adresse IP trouvée pour le serveur maître défini dans le SOA, 'mname' ({mname})."
+msgstr ""
+"Aucune adresse IP trouvée pour le serveur maître défini dans le SOA, "
+"'mname' ({mname})."
 
 #: ZONE:MNAME_IS_AUTHORITATIVE
 msgid  "SOA 'mname' nameserver ({mname}) is authoritative for '{zone}' zone."
-msgstr "Le serveur maître défini dans le SOA, 'mname' ({mname}), fait autorité pour la zone '{zone}'."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' ({mname}), fait autorité pour "
+"la zone '{zone}'."
 
 #: ZONE:MNAME_IS_CNAME
 msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
-msgstr "Le serveur maître défini dans le SOA, 'mname' ({mname}), fait référence à un serveur de noms qui est un alias (CNAME)."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' ({mname}), fait référence à un "
+"serveur de noms qui est un alias (CNAME)."
 
 #: ZONE:MNAME_IS_NOT_CNAME
-msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
-msgstr "Le serveur maître défini dans le SOA, 'mname' ({mname}), fait référence à un serveur de noms qui n'est pas un alias (CNAME)."
+msgid  ""
+"SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' ({mname}), fait référence à un "
+"serveur de noms qui n'est pas un alias (CNAME)."
 
 #: ZONE:MNAME_NOT_AUTHORITATIVE
-msgid  "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
-msgstr "Le serveur maître défini dans le SOA, 'mname' {ns}/{address}, ne fait pas autorité pour la zone '{zone}'."
+msgid  ""
+"SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' {ns}/{address}, ne fait pas "
+"autorité pour la zone '{zone}'."
 
 #: ZONE:MNAME_NOT_IN_GLUE
-msgid  "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for tested zone ({ns})."
-msgstr "Le serveur maître défini dans le SOA, 'mname' ({mname}), ne fait pas partie des enregistrements de type \"NS\" listés par la zone parente ({ns})."
+msgid  ""
+"SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
+"tested zone ({ns})."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' ({mname}), ne fait pas partie "
+"des enregistrements de type \"NS\" listés par la zone parente ({ns})."
 
 #: ZONE:MNAME_NO_RESPONSE
 msgid  "SOA 'mname' nameserver {ns}/{address} does not respond."
-msgstr "Le serveur maître défini dans le SOA, 'mname' {ns}/{address}, ne répond pas."
+msgstr ""
+"Le serveur maître défini dans le SOA, 'mname' {ns}/{address}, ne répond pas."
 
 #: ZONE:MNAME_RECORD_DOES_NOT_EXIST
 msgid  "SOA 'mname' field does not exist"
@@ -931,53 +1424,95 @@ msgstr "Le champ 'mname' n'est pas présent dans le SOA."
 
 #: ZONE:MX_RECORD_EXISTS
 msgid  "Target ({info}) found to deliver e-mail for the domain name."
-msgstr "Information ({info}) trouvée pour faire parvenir un message à ce nom de domaine."
+msgstr ""
+"Information ({info}) trouvée pour faire parvenir un message à ce nom de "
+"domaine."
 
 #: ZONE:MX_RECORD_IS_CNAME
 msgid  "MX record for the domain is pointing to a CNAME."
-msgstr "L'enregistrement de type \"MX\" pour le domaine pointe sur un alias (CNAME)."
+msgstr ""
+"L'enregistrement de type \"MX\" pour le domaine pointe sur un alias (CNAME)."
 
 #: ZONE:MX_RECORD_IS_NOT_CNAME
 msgid  "MX record for the domain is not pointing to a CNAME."
-msgstr "L'enregistrement de type \"MX\" pour le domaine ne pointe pas sur un alias (CNAME)."
+msgstr ""
+"L'enregistrement de type \"MX\" pour le domaine ne pointe pas sur un alias "
+"(CNAME)."
 
 #: ZONE:NO_MX_RECORD
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
-msgstr "Aucune possibilité (enregistrement de type \"MX\", \"A\" ou \"AAAA\") de faire parvenir un message à ce nom de domaine."
+msgstr ""
+"Aucune possibilité (enregistrement de type \"MX\", \"A\" ou \"AAAA\") de "
+"faire parvenir un message à ce nom de domaine."
 
 #: ZONE:REFRESH_HIGHER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
-msgstr "Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus grande que la valeur du champ 'retry' ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus grande que la "
+"valeur du champ 'retry' ({retry})."
 
 #: ZONE:REFRESH_LOWER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value ({retry})."
-msgstr "Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus petite que la valeur du champ 'retry' ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus petite que la "
+"valeur du champ 'retry' ({retry})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_LOWER
-msgid  "SOA 'refresh' value ({refresh}) is less than the recommended one ({required_refresh})."
-msgstr "Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus petite que la valeur recommandée ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is less than the recommended one "
+"({required_refresh})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus petite que la "
+"valeur recommandée ({required_refresh})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_OK
-msgid  "SOA 'refresh' value ({refresh}) is higher than the minimum recommended value ({required_refresh})."
-msgstr "Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus grande que la valeur minimale recommandée ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the minimum recommended value "
+"({required_refresh})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'refresh' ({refresh}) est plus grande que la "
+"valeur minimale recommandée ({required_refresh})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_LOWER
-msgid  "SOA 'retry' value ({retry}) is less than the recommended one ({required_retry})."
-msgstr "Dans le SOA, la valeur du champ 'retry' ({retry}) est plus petite que la valeur recommandée ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is less than the recommended one "
+"({required_retry})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'retry' ({retry}) est plus petite que la "
+"valeur recommandée ({required_retry})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_OK
-msgid  "SOA 'retry' value ({retry}) is more than the minimum recommended value ({required_retry})."
-msgstr "Dans le SOA, la valeur du champ 'retry' ({retry}) est plus grande que la valeur minimale recommandée ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is more than the minimum recommended value "
+"({required_retry})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'retry' ({retry}) est plus grande que la "
+"valeur minimale recommandée ({required_retry})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_HIGHER
-msgid  "SOA 'minimum' value ({minimum}) is higher than the recommended one ({highest_minimum})."
-msgstr "Dans le SOA, la valeur du champ 'minimum' ({minimum}) est plus grande que la valeur recommandée ({highest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is higher than the recommended one "
+"({highest_minimum})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'minimum' ({minimum}) est plus grande que la "
+"valeur recommandée ({highest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_LOWER
-msgid  "SOA 'minimum' value ({minimum}) is less than the recommended one ({lowest_minimum})."
-msgstr "Dans le SOA, la valeur du champ 'minimum' ({minimum}) est plus petite que la valeur recommandée ({lowest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is less than the recommended one "
+"({lowest_minimum})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'minimum' ({minimum}) est plus petite que la "
+"valeur recommandée ({lowest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_OK
-msgid  "SOA 'minimum' value ({minimum}) is between the recommended ones ({lowest_minimum}/{highest_minimum})."
-msgstr "Dans le SOA, la valeur du champ 'minimum' ({minimum}) est comprise dans l'interval de valeurs recommandées ({lowest_minimum}/{highest_minimum})."
-
+msgid  ""
+"SOA 'minimum' value ({minimum}) is between the recommended ones "
+"({lowest_minimum}/{highest_minimum})."
+msgstr ""
+"Dans le SOA, la valeur du champ 'minimum' ({minimum}) est comprise dans "
+"l'interval de valeurs recommandées ({lowest_minimum}/{highest_minimum})."

--- a/share/sv.po
+++ b/share/sv.po
@@ -1,33 +1,40 @@
-msgid ""
+msgid  ""
 msgstr ""
-"Language: sv\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 1.0.0\n"
 "PO-Revision-Date: 2017-12-15\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
-## IMPORTANT ##
+# # IMPORTANT ##
 # Keep this file in sync with en.po
-##
-
+# #
 #: ADDRESS:NAMESERVERS_IP_WITH_REVERSE
 msgid  "Reverse DNS entry exist for all Nameserver IP addresses."
 msgstr "Bakåtuppslagning finns för varje namnserveradress."
 
 #: ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
-msgid  "Nameserver {ns} has an IP address ({address}) with prefix {prefix} referenced in {reference} as a '{name}'."
-msgstr "Namnservern {ns} har en IP-adress ({address}) med prefixet {prefix}, som {reference} klassificerar som '{name}'."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with prefix {prefix} "
+"referenced in {reference} as a '{name}'."
+msgstr ""
+"Namnservern {ns} har en IP-adress ({address}) med prefixet {prefix}, som "
+"{reference} klassificerar som '{name}'."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MATCH
 msgid  "All reverse DNS entry matches name server name."
 msgstr "Varje bakåtuppslagning stämmer med motsvarande namnservernamn."
 
 #: ADDRESS:NAMESERVER_IP_PTR_MISMATCH
-msgid  "Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names})."
-msgstr "Namnservern '{ns}' har en IP-adress ({address}) med en icke-matchande bakåtuppslagning ({names})."
+msgid  ""
+"Nameserver {ns} has an IP address ({address}) with mismatched PTR result "
+"({names})."
+msgstr ""
+"Namnservern '{ns}' har en IP-adress ({address}) med en icke-matchande "
+"bakåtuppslagning ({names})."
 
 #: ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
 msgid  "Nameserver {ns} has an IP address ({address}) without PTR configured."
@@ -35,7 +42,8 @@ msgstr "Namnservern '{ns}' har en IP-adress ({address}) utan bakåtuppslagning."
 
 #: ADDRESS:NO_IP_PRIVATE_NETWORK
 msgid  "All Nameserver addresses are in the routable public addressing space."
-msgstr "Alla namnserveradresser finns i den publikt routningsbara addressrymden."
+msgstr ""
+"Alla namnserveradresser finns i den publikt routningsbara addressrymden."
 
 #: ADDRESS:NO_RESPONSE_PTR_QUERY
 msgid  "No response from nameserver(s) on PTR query ({reverse})."
@@ -46,8 +54,10 @@ msgid  "Nameservers did not respond to A query."
 msgstr "Namnservern svarade inte på en A-fråga."
 
 #: BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-msgid  "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
-msgstr "Domändelen '{dlabel}' i domännamnet {dname} är för lång ({dlength}/{max})."
+msgid  ""
+"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+msgstr ""
+"Domändelen '{dlabel}' i domännamnet {dname} är för lång ({dlength}/{max})."
 
 #: BASIC:DOMAIN_NAME_TOO_LONG
 msgid  "Domain name is too long ({fqdnlength}/{max})."
@@ -67,23 +77,29 @@ msgstr "Namnservern '{ns}' gav dessa servrar som 'glue': {nsnlist}."
 
 #: BASIC:HAS_NAMESERVER_NO_WWW_A_TEST
 msgid  "Functional nameserver found. \"A\" query for www.{zname} test aborted."
-msgstr "En fungerande namnserver hittades. Skickade ingen fråga om 'A' för 'www.{zname}' (behövdes inte)."
+msgstr ""
+"En fungerande namnserver hittades. Skickade ingen fråga om 'A' för 'www."
+"{zname}' (behövdes inte)."
 
 #: BASIC:HAS_PARENT
 msgid  "Parent domain '{pname}' was found for the tested domain."
 msgstr "Moderdomänen '{pname}' till den testade domänen har identifierats."
 
-#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
+#: BASIC:IPV4_DISABLED CONNECTIVITY:IPV4_DISABLED CONSISTENCY:IPV4_DISABLED
+#: DELEGATION:IPV4_DISABLED NAMESERVER:IPV4_DISABLED
 msgid  "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv4 är avstängt. Skickar ingen fråga om '{rrtype}' till {ns}/{address}."
+msgstr ""
+"IPv4 är avstängt. Skickar ingen fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV4_ENABLED
 msgid  "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv4 är påslaget. Skickar fråga om '{rrtype}' till {ns}/{address}."
 
-#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
+#: BASIC:IPV6_DISABLED CONNECTIVITY:IPV6_DISABLED CONSISTENCY:IPV6_DISABLED
+#: DELEGATION:IPV6_DISABLED NAMESERVER:IPV6_DISABLED
 msgid  "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
-msgstr "IPv6 är avstängt. Skickar ingen fråga om '{rrtype}' till {ns}/{address}."
+msgstr ""
+"IPv6 är avstängt. Skickar ingen fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:IPV6_ENABLED
 msgid  "IPv6 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
@@ -91,11 +107,13 @@ msgstr "IPv6 är påslaget. Skickar fråga om '{rrtype}' till {ns}/{address}."
 
 #: BASIC:NO_A_RECORDS
 msgid  "Nameserver {ns}/{address} did not return A record(s) for {dname}."
-msgstr "Namnservern {ns}/{address} svarade inte med några A-poster för '{dname}'."
+msgstr ""
+"Namnservern {ns}/{address} svarade inte med några A-poster för '{dname}'."
 
 #: BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
 msgid  "No NS records for tested zone from parent. NS tests aborted."
-msgstr "Inga NS-poster för den testade zonen från föräldern. NS-tester hoppas över."
+msgstr ""
+"Inga NS-poster för den testade zonen från föräldern. NS-tester hoppas över."
 
 #: BASIC:NO_PARENT
 msgid  "No parent domain could be found for the tested domain."
@@ -103,11 +121,33 @@ msgstr "Ingen moderdomän kunde hittas för den testade domänen."
 
 #: BASIC:NS_FAILED
 msgid  "Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}."
-msgstr "Namnservern {ns}/{address} svarade inte med några NS-poster. RCODE var '{rcode}'."
+msgstr ""
+"Namnservern {ns}/{address} svarade inte med några NS-poster. RCODE var "
+"'{rcode}'."
 
 #: BASIC:NS_NO_RESPONSE
 msgid  "Nameserver {ns}/{address} did not respond to NS query."
 msgstr "Namnservern {ns}/{address} svarade inte på frågan om 'NS'."
+
+#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
+msgid  "[ASN:ANNOUNCE_BY] {address};{asn}"
+msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
+
+#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
+msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
+msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
+
+#: CONNECTIVITY:ASN_INFOS_RAW
+msgid  "[ASN:RAW] {address};{data}"
+msgstr "[ASN:RAW] {address};{data}"
+
+#: CONNECTIVITY:IPV4_ASN
+msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
+msgstr "Namnservrarna har IPv4-adresser i följande AS: {asn}."
+
+#: CONNECTIVITY:IPV6_ASN
+msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
+msgstr "Namnservrarna har IPv6-adresser i följande AS: {asn}."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_NO_AS
 msgid  "No IPv4 nameserver address is in an AS."
@@ -115,11 +155,14 @@ msgstr "Ingen namnserver har någon IPv4-adress i något AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
 msgid  "Authoritative IPv4 nameservers are in more than one AS."
-msgstr "IPv4-adresserna för de auktoritativa namnservrarna för domännamnet finns i mer än ett AS."
+msgstr ""
+"IPv4-adresserna för de auktoritativa namnservrarna för domännamnet finns i "
+"mer än ett AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV4_WITH_UNIQ_AS
 msgid  "All nameservers IPv4 addresses are in the same AS ({asn})."
-msgstr "Alla IPv4-adresser för namnservrarna i delegeringen finns i samma AS ({asn})."
+msgstr ""
+"Alla IPv4-adresser för namnservrarna i delegeringen finns i samma AS ({asn})."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
 msgid  "No IPv6 nameserver address is in an AS."
@@ -127,11 +170,14 @@ msgstr "Ingen namnserver har någon IPv6-adress i något AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_WITH_MULTIPLE_AS
 msgid  "Authoritative IPv6 nameservers are in more than one AS."
-msgstr "IPv6-adresserna för de auktoritativa namnservrarna för domännamnet finns i mer än ett AS."
+msgstr ""
+"IPv6-adresserna för de auktoritativa namnservrarna för domännamnet finns i "
+"mer än ett AS."
 
 #: CONNECTIVITY:NAMESERVERS_IPV6_WITH_UNIQ_AS
 msgid  "All nameservers IPv6 addresses are in the same AS ({asn})."
-msgstr "Alla IPv6-adresser för namnservrar i delegeringen finns i samma AS ({asn})."
+msgstr ""
+"Alla IPv6-adresser för namnservrar i delegeringen finns i samma AS ({asn})."
 
 #: CONNECTIVITY:NAMESERVERS_NO_AS
 msgid  "No nameserver address is in an AS."
@@ -139,7 +185,8 @@ msgstr "Ingen namnserver har någon adress i något AS."
 
 #: CONNECTIVITY:NAMESERVERS_WITH_MULTIPLE_AS
 msgid  "Domain's authoritative nameservers do not belong to the same AS."
-msgstr "IP-adresserna för domänens auktoritativa namnservrar finns i mer än ett AS."
+msgstr ""
+"IP-adresserna för domänens auktoritativa namnservrar finns i mer än ett AS."
 
 #: CONNECTIVITY:NAMESERVERS_WITH_UNIQ_AS
 msgid  "All nameservers are in the same AS ({asn})."
@@ -161,25 +208,25 @@ msgstr "Namnservern {ns}/{address} är inte åtkomlig över TCP på port 53."
 msgid  "Nameserver {ns}/{address} not accessible over UDP on port 53."
 msgstr "Namnservern {ns}/{address} är inte åtkomlig över UDP på port 53."
 
-#: CONNECTIVITY:IPV4_ASN
-msgid  "Name servers have IPv4 addresses in the following ASs: {asn}."
-msgstr "Namnservrarna har IPv4-adresser i följande AS: {asn}."
+#: CONSISTENCY:ADDRESSES_MATCH
+msgid  "Glue records are consistent between glue and authoritative data."
+msgstr ""
+"Glue-poster stämmer överens mellan delegering och auktoritativ data "
+"(dotterzon)."
 
-#: CONNECTIVITY:IPV6_ASN
-msgid  "Name servers have IPv6 addresses in the following ASs: {asn}."
-msgstr "Namnservrarna har IPv6-adresser i följande AS: {asn}."
+#: CONSISTENCY:EXTRA_ADDRESS_CHILD
+msgid  ""
+"Child has extra nameserver IP address(es) not listed at parent ({addresses})."
+msgstr ""
+"Dotterzonen har extra namnserver-IP-adress(er) som inte finns med i "
+"moderzonen ({addresses})."
 
-#: CONNECTIVITY:ASN_INFOS_RAW
-msgid  "[ASN:RAW] {address};{data}"
-msgstr "[ASN:RAW] {address};{data}"
-
-#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
-msgid  "[ASN:ANNOUNCE_BY] {address};{asn}"
-msgstr "[ASN:ANNOUNCE_BY] {address};{asn}"
-
-#: CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
-msgid  "[ASN:ANNOUNCE_IN] {address};{prefix}"
-msgstr "[ASN:ANNOUNCE_IN] {address};{prefix}"
+#: CONSISTENCY:EXTRA_ADDRESS_PARENT
+msgid  ""
+"Parent has extra nameserver IP address(es) not listed at child ({addresses})."
+msgstr ""
+"Moderzonen har extra namnserver-IP-adress(er) som inte finns med i "
+"dotterzonen ({addresses})."
 
 #: CONSISTENCY:MULTIPLE_NS_SET
 msgid  "Saw {count} NS set."
@@ -226,8 +273,12 @@ msgid  "A single SOA serial number was seen ({serial})."
 msgstr "Exakt ett SOA-serienummer hittades: ({serial})."
 
 #: CONSISTENCY:ONE_SOA_TIME_PARAMETER_SET
-msgid  "A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
-msgstr "Exakt en uppsättning SOA-tidsparametrar hittades: (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
+msgid  ""
+"A single SOA time parameter set was seen (REFRESH={refresh},RETRY={retry},"
+"EXPIRE={expire},MINIMUM={minimum})."
+msgstr ""
+"Exakt en uppsättning SOA-tidsparametrar hittades: (REFRESH={refresh},"
+"RETRY={retry},EXPIRE={expire},MINIMUM={minimum})."
 
 #: CONSISTENCY:SOA_RNAME
 msgid  "Saw SOA rname {rname} on following nameserver set : {servers}."
@@ -238,28 +289,28 @@ msgid  "Saw SOA serial number {serial} on following nameserver set : {servers}."
 msgstr "SOA-serienumret {serial} hittades på följande namnservrar: {servers}."
 
 #: CONSISTENCY:SOA_SERIAL_VARIATION
-msgid  "Difference between the smaller serial ({serial_min}) and the bigger one ({serial_max}) is greater than the maximum allowed ({max_variation})."
-msgstr "Spannet mellan högsta och lägsta SOA-serienumret är större än {max_variation}."
+msgid  ""
+"Difference between the smaller serial ({serial_min}) and the bigger one "
+"({serial_max}) is greater than the maximum allowed ({max_variation})."
+msgstr ""
+"Spannet mellan högsta och lägsta SOA-serienumret är större än "
+"{max_variation}."
 
 #: CONSISTENCY:SOA_TIME_PARAMETER_SET
-msgid  "Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) on following nameserver set : {servers}."
-msgstr "SOA-tidsparametrarna (REFRESH={refresh},RETRY={retry},EXPIRE={expire},MINIMUM={minimum}) hittades på följande namnservrar: {servers}."
-
-#: CONSISTENCY:EXTRA_ADDRESS_PARENT
-msgid  "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
-msgstr "Moderzonen har extra namnserver-IP-adress(er) som inte finns med i dotterzonen ({addresses})."
-
-#: CONSISTENCY:EXTRA_ADDRESS_CHILD
-msgid  "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
-msgstr "Dotterzonen har extra namnserver-IP-adress(er) som inte finns med i moderzonen ({addresses})."
+msgid  ""
+"Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},"
+"MINIMUM={minimum}) on following nameserver set : {servers}."
+msgstr ""
+"SOA-tidsparametrarna (REFRESH={refresh},RETRY={retry},EXPIRE={expire},"
+"MINIMUM={minimum}) hittades på följande namnservrar: {servers}."
 
 #: CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-msgid  "No common nameserver IP addresses between child ({child}) and parent ({glue})."
-msgstr "Det finns inga gemensamma namnserver-IP-adresser mellan moderzon ({glue}) och dotterzon ({child})."
-
-#: CONSISTENCY:ADDRESSES_MATCH
-msgid  "Glue records are consistent between glue and authoritative data."
-msgstr "Glue-poster stämmer överens mellan delegering och auktoritativ data (dotterzon)."
+msgid  ""
+"No common nameserver IP addresses between child ({child}) and parent "
+"({glue})."
+msgstr ""
+"Det finns inga gemensamma namnserver-IP-adresser mellan moderzon ({glue}) "
+"och dotterzon ({child})."
 
 #: DELEGATION:ARE_AUTHORITATIVE
 msgid  "All these nameservers are confirmed to be authoritative : {nsset}."
@@ -267,23 +318,36 @@ msgstr "Följande namnservrar är auktoritativa : {nsset}."
 
 #: DELEGATION:DISTINCT_IP_ADDRESS
 msgid  "All the IP addresses used by the nameservers are unique"
-msgstr "Varje namnserver har unika IP-adress som inte delas med andra namnservrar."
+msgstr ""
+"Varje namnserver har unika IP-adress som inte delas med andra namnservrar."
 
 #: DELEGATION:ENOUGH_NS
-msgid  "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta tillåtna antal är {minimum}."
+msgid  ""
+"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta "
+"tillåtna antal är {minimum}."
 
 #: DELEGATION:ENOUGH_NS_GLUE
-msgid  "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Delegeringen i moderzonen har tillräckligt många ({count}) namnservrar ({glue}). Minsta tillåtna antalet är {minimum}."
+msgid  ""
+"Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Delegeringen i moderzonen har tillräckligt många ({count}) namnservrar "
+"({glue}). Minsta tillåtna antalet är {minimum}."
 
 #: DELEGATION:EXTRA_NAME_CHILD
 msgid  "Child has nameserver(s) not listed at parent ({extra})."
-msgstr "Dotterzonen har en eller flera namnservrar som inte finns i delegeringen i moderzonen ({extra})."
+msgstr ""
+"Dotterzonen har en eller flera namnservrar som inte finns i delegeringen i "
+"moderzonen ({extra})."
 
 #: DELEGATION:EXTRA_NAME_PARENT
 msgid  "Parent has nameserver(s) not listed at the child ({extra})."
-msgstr "Delegeringen i moderzonen har en eller flera namnservrar som inte listas på dotterzonen ({extra})."
+msgstr ""
+"Delegeringen i moderzonen har en eller flera namnservrar som inte listas på "
+"dotterzonen ({extra})."
 
 #: DELEGATION:IS_NOT_AUTHORITATIVE
 msgid  "Nameserver {ns} response is not authoritative on {proto} port 53."
@@ -291,15 +355,25 @@ msgstr "Namnservern '{ns}' svarade inte auktoritativt på {proto} port 53."
 
 #: DELEGATION:NAMES_MATCH
 msgid  "All of the nameserver names are listed both at parent and child."
-msgstr "Alla namnservrar (NS-poster) finns både i delegeringen (moderzon) och i dotterzonen."
+msgstr ""
+"Alla namnservrar (NS-poster) finns både i delegeringen (moderzon) och i "
+"dotterzonen."
 
 #: DELEGATION:NOT_ENOUGH_NS
-msgid  "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}."
-msgstr "Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen ({count}). Minsta tillåtna antal är {minimum}."
+msgid  ""
+"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"{minimum}."
+msgstr ""
+"Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen "
+"({count}). Minsta tillåtna antal är {minimum}."
 
 #: DELEGATION:NOT_ENOUGH_NS_GLUE
-msgid  "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}."
-msgstr "Det finns inte tillräckligt många ({count}) namnservrar (NS-poster) i delegeringen (moderzonen). Minsta tillåtna antal är {minimum}."
+msgid  ""
+"Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
+"to {minimum}."
+msgstr ""
+"Det finns inte tillräckligt många ({count}) namnservrar (NS-poster) i "
+"delegeringen (moderzonen). Minsta tillåtna antal är {minimum}."
 
 #: DELEGATION:NS_RR_IS_CNAME
 msgid  "Nameserver {ns} {address_type} RR point to CNAME."
@@ -310,12 +384,20 @@ msgid  "No nameserver point to CNAME alias."
 msgstr "Inget namnservernamn har en CNAME-post."
 
 #: DELEGATION:REFERRAL_SIZE_LARGE
-msgid  "The smallest possible legal referral packet is larger than 512 octets (it is {size})."
-msgstr "Minsta möjliga giltiga hänvisningspaket är större än 512 byte (det är {size} byte)."
+msgid  ""
+"The smallest possible legal referral packet is larger than 512 octets (it is "
+"{size})."
+msgstr ""
+"Minsta möjliga giltiga hänvisningspaket är större än 512 byte (det är {size} "
+"byte)."
 
 #: DELEGATION:REFERRAL_SIZE_OK
-msgid  "The smallest possible legal referral packet is smaller than 513 octets (it is {size})."
-msgstr "Minsta möjliga giltiga hänvisningspaket är på 512 byte eller mindre (det är {size} byte)."
+msgid  ""
+"The smallest possible legal referral packet is smaller than 513 octets (it "
+"is {size})."
+msgstr ""
+"Minsta möjliga giltiga hänvisningspaket är på 512 byte eller mindre (det är "
+"{size} byte)."
 
 #: DELEGATION:SAME_IP_ADDRESS
 msgid  "IP {address} refers to multiple nameservers ({nss})."
@@ -327,63 +409,111 @@ msgstr "Alla namnservrar har en SOA-post."
 
 #: DELEGATION:SOA_NOT_EXISTS
 msgid  "A SOA query NOERROR response from {ns} was received empty."
-msgstr "En SOA-fråga fick ett svar med 'RCODE NOERROR' från {ns}, men svaret var tomt."
+msgstr ""
+"En SOA-fråga fick ett svar med 'RCODE NOERROR' från {ns}, men svaret var "
+"tomt."
 
 #: DELEGATION:TOTAL_NAME_MISMATCH
 msgid  "None of the nameservers listed at the parent are listed at the child."
-msgstr "Ingen av de namnservrar som finns i delegeringen (moderzonen) finns i dotterzonen."
+msgstr ""
+"Ingen av de namnservrar som finns i delegeringen (moderzonen) finns i "
+"dotterzonen."
 
 #: DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
 msgid  "No DNSKEYs found. Additional tests skipped."
 msgstr "Inga DNSKEY-poster hittades. Resterande DNSSEC-tester hoppas över."
 
 #: DNSSEC:ALGORITHM_DEPRECATED
-msgid  "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm nummmr med det utfasade algoritmnumret {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder en algoritm nummmr med det "
+"utfasade algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_OK
-msgid  "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/({description}), which is OK."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder det accepterade algoritm numret {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
+"({description}), which is OK."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder det accepterade algoritm numret "
+"{algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_PRIVATE
-msgid  "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det privata algoritmnumret {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder en algoritm med det privata "
+"algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_RESERVED
-msgid  "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det reserverade algoritmnumret {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder en algoritm med det reserverade "
+"algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNASSIGNED
-msgid  "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/({description})."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder en algoritm med det otilldelade algoritmnumret {algorithm}/({description})."
+msgid  ""
+"The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
+"({description})."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder en algoritm med det otilldelade "
+"algoritmnumret {algorithm}/({description})."
 
 #: DNSSEC:ALGORITHM_UNKNOWN
 msgid  "The DNSKEY with tag {keytag} uses unknown algorithm number {algorithm}."
-msgstr "DNSKEY-posten med 'tag' {keytag} använder algoritmen med det okända numret {algorithm}."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder algoritmen med det okända numret "
+"{algorithm}."
 
 #: DNSSEC:COMMON_KEYTAGS
 msgid  "There are both DS and DNSKEY records with key tags {keytags}."
 msgstr "Det finns både DS- and DNSKEY-poster med 'keytag' {keytags}."
 
+#: DNSSEC:DELEGATION_NOT_SIGNED
+msgid  "Delegation from parent to child is not properly signed {reason}."
+msgstr ""
+"Delegeringen från moderzonen till dotterzonens namnservrar är inte korrekt "
+"signerad ({reason})."
+
+#: DNSSEC:DELEGATION_SIGNED
+msgid  "Delegation from parent to child is properly signed."
+msgstr ""
+"Delegeringen från moderzonen till dotterzonens namnservrar är korrekt "
+"signerad."
+
 #: DNSSEC:DNSKEY_AND_DS
 msgid  "{parent} sent a DS record, and {child} a DNSKEY record."
-msgstr "Moderzonen '{parent}' skickade en DS-post, och dotterzonen '{child}' en DNSKEY-post."
+msgstr ""
+"Moderzonen '{parent}' skickade en DS-post, och dotterzonen '{child}' en "
+"DNSKEY-post."
 
 #: DNSSEC:DNSKEY_BUT_NOT_DS
 msgid  "{child} sent a DNSKEY record, but {parent} did not send a DS record."
-msgstr "Dotterzonen '{child}' skickade en DNSKEY-post, men moderzonen '{parent}' skickade inte någon DS-post."
+msgstr ""
+"Dotterzonen '{child}' skickade en DNSKEY-post, men moderzonen '{parent}' "
+"skickade inte någon DS-post."
 
 #: DNSSEC:DNSKEY_NOT_SIGNED
 msgid  "The apex DNSKEY RRset was not correctly signed."
 msgstr "DNSKEY-posterna i zontoppen var inte korrekt signerad."
 
 #: DNSSEC:DNSKEY_SIGNATURE_NOT_OK
-msgid  "Signature for DNSKEY with tag {signature} failed to verify with error '{error}'."
-msgstr "Verifiering av signaturen för DNSKEY-posten med 'keytag' {signature} misslyckades med felmeddelandet '{error}'."
+msgid  ""
+"Signature for DNSKEY with tag {signature} failed to verify with error "
+"'{error}'."
+msgstr ""
+"Verifiering av signaturen för DNSKEY-posten med 'keytag' {signature} "
+"misslyckades med felmeddelandet '{error}'."
 
 #: DNSSEC:DNSKEY_SIGNATURE_OK
 msgid  "A signature for DNSKEY with tag {signature} was correctly signed."
-msgstr "Verifiering av en signatur för DNSKEY-posten med 'keytag' {signature} lyckades."
+msgstr ""
+"Verifiering av en signatur för DNSKEY-posten med 'keytag' {signature} "
+"lyckades."
 
 #: DNSSEC:DNSKEY_SIGNED
 msgid  "The apex DNSKEY RRset was correcly signed."
@@ -391,27 +521,40 @@ msgstr "DNSKEY-posterna i zontoppen var korrekt signerad."
 
 #: DNSSEC:DS_BUT_NOT_DNSKEY
 msgid  "{parent} sent a DS record, but {child} did not send a DNSKEY record."
-msgstr "Moderzonen '{parent}' skickade en DS-post, men dotterzonen '{child}' skickade ingen DNSKEY-post."
+msgstr ""
+"Moderzonen '{parent}' skickade en DS-post, men dotterzonen '{child}' "
+"skickade ingen DNSKEY-post."
 
 #: DNSSEC:DS_DIGTYPE_NOT_OK
 msgid  "DS record with keytag {keytag} uses forbidden digest type {digtype}."
-msgstr "DS-posten med 'keytag' {keytag} använder den förbjudna digest-typen {digtype}."
+msgstr ""
+"DS-posten med 'keytag' {keytag} använder den förbjudna digest-typen "
+"{digtype}."
 
 #: DNSSEC:DS_DIGTYPE_OK
 msgid  "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
-msgstr "DS-posten med 'keytag' {keytag} använder den accepterade digest-typen {digtype}."
+msgstr ""
+"DS-posten med 'keytag' {keytag} använder den accepterade digest-typen "
+"{digtype}."
 
 #: DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} does not match the DNSKEY with the same tag."
-msgstr "DS-posten med 'keytag' {keytag} matchar inte DNSKEY-posten med samma 'keytag'."
-
-#: DNSSEC:DS_MATCHES_DNSKEY
-msgid  "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY with the same tag."
-msgstr "DS-posten med 'keytag' {keytag} matchar DNSKEY-posten med samma 'keytag'."
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} does not match the "
+"DNSKEY with the same tag."
+msgstr ""
+"DS-posten med 'keytag' {keytag} matchar inte DNSKEY-posten med samma "
+"'keytag'."
 
 #: DNSSEC:DS_FOUND
 msgid  "Found DS records with tags {keytags}."
 msgstr "Det finns DS-poster med keytaggarna {keytags}."
+
+#: DNSSEC:DS_MATCHES_DNSKEY
+msgid  ""
+"DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
+"with the same tag."
+msgstr ""
+"DS-posten med 'keytag' {keytag} matchar DNSKEY-posten med samma 'keytag'."
 
 #: DNSSEC:DS_MATCH_FOUND
 msgid  "At least one DS record with a matching DNSKEY record was found."
@@ -422,24 +565,41 @@ msgid  "No DS record with a matching DNSKEY record was found."
 msgstr "Det finns ingen DS-post med matchande DNSKEY-post."
 
 #: DNSSEC:DS_RFC4509_NOT_VALID
-msgid  "Existing DS with digest type 2, while they do not match DNSKEY records, prevent use of DS with digest type 1 (RFC4509, section 3)."
-msgstr "Befintlig DS med 'digest' typ 2 stämmer inte med DNSKEY-posten. Det finns en DS med 'digest' typ 1, men RFC 4509 (stycke 3) tillåter inte att den används när det finns en DS med 'digest' typ 2."
+msgid  ""
+"Existing DS with digest type 2, while they do not match DNSKEY records, "
+"prevent use of DS with digest type 1 (RFC4509, section 3)."
+msgstr ""
+"Befintlig DS med 'digest' typ 2 stämmer inte med DNSKEY-posten. Det finns en "
+"DS med 'digest' typ 1, men RFC 4509 (stycke 3) tillåter inte att den används "
+"när det finns en DS med 'digest' typ 2."
 
 #: DNSSEC:DURATION_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is too long."
-msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en livslängd på {duration} sekunder, vilket är för länge."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is too long."
+msgstr ""
+"RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en "
+"livslängd på {duration} sekunder, vilket är för länge."
 
 #: DNSSEC:DURATION_OK
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a duration of {duration} seconds, which is just fine."
-msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en livslängd på {duration} sekunder (accepterad livslängd)."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
+"{duration} seconds, which is just fine."
+msgstr ""
+"RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en "
+"livslängd på {duration} sekunder (accepterad livslängd)."
 
 #: DNSSEC:EXTRA_PROCESSING_BROKEN
-msgid  "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
-msgstr "Namnservern '{server}' skickade {keys} DNSKEY-poster, och {sigs} RRSIG-poster."
+msgid  ""
+"Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
+msgstr ""
+"Namnservern '{server}' skickade {keys} DNSKEY-poster, och {sigs} RRSIG-"
+"poster."
 
 #: DNSSEC:EXTRA_PROCESSING_OK
 msgid  "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Namnservern '{server}' skickade {keys} DNSKEY-poster och {sigs} RRSIG-poster."
+msgstr ""
+"Namnservern '{server}' skickade {keys} DNSKEY-poster och {sigs} RRSIG-poster."
 
 #: DNSSEC:HAS_NSEC
 msgid  "The zone has NSEC records."
@@ -454,16 +614,24 @@ msgid  "The zone has NSEC3 opt-out records."
 msgstr "Zonen har opt-out-flaggan satt för NSEC3."
 
 #: DNSSEC:INVALID_NAME_RCODE
-msgid  "When asked for the name {name}, which must not exist, the response had RCODE {rcode}."
-msgstr "Svaret på en fråga om namnet '{name}', som inte får existera, hade RCODE '{rcode}'."
+msgid  ""
+"When asked for the name {name}, which must not exist, the response had RCODE "
+"{rcode}."
+msgstr ""
+"Svaret på en fråga om namnet '{name}', som inte får existera, hade RCODE "
+"'{rcode}'."
 
 #: DNSSEC:ITERATIONS_OK
 msgid  "The number of NSEC3 iterations is {count}, which is OK."
 msgstr "Antalet NSEC3-iterationer är {count} (accepterad antal)."
 
 #: DNSSEC:KEY_DETAILS
-msgid  "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
-msgstr "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, {rfc5011})."
+msgid  ""
+"Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
+"{rfc5011})."
+msgstr ""
+"Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
+"{rfc5011})."
 
 #: DNSSEC:MANY_ITERATIONS
 msgid  "The number of NSEC3 iterations is {count}, which is on the high side."
@@ -490,12 +658,20 @@ msgid  "{from} returned no DS records for {zone}."
 msgstr "'{from}' skickade inga DS-poster för '{zone}'."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS
-msgid  "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and {sigs} RRSIG records."
-msgstr "Kan inte testa DNSKEY-signaturer, eftersom vi fick {keys} DNSKEY-poster och {sigs} RRSIG-poster."
+msgid  ""
+"Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
+"{sigs} RRSIG records."
+msgstr ""
+"Kan inte testa DNSKEY-signaturer, eftersom vi fick {keys} DNSKEY-poster och "
+"{sigs} RRSIG-poster."
 
 #: DNSSEC:NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-msgid  "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} RRSIG records and {soas} SOA records."
-msgstr "Kan inte testa DNSSEC-signaturer för SOA-posten, eftersom vi fick {keys} DNSKEY-poster, {sigs} RRSIG-poster och {soas} SOA-poster."
+msgid  ""
+"Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
+"RRSIG records and {soas} SOA records."
+msgstr ""
+"Kan inte testa DNSSEC-signaturer för SOA-posten, eftersom vi fick {keys} "
+"DNSKEY-poster, {sigs} RRSIG-poster och {soas} SOA-poster."
 
 #: DNSSEC:NO_NSEC3PARAM
 msgid  "{server} returned no NSEC3PARAM records."
@@ -519,7 +695,8 @@ msgstr "Det finns minst en signatur som korrekt signerar NSEC3-posterna."
 
 #: DNSSEC:NSEC3_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Försöket att verifiera NSEC3-posterna med RRSIG {sig} gav felet '{error}'."
+msgstr ""
+"Försöket att verifiera NSEC3-posterna med RRSIG {sig} gav felet '{error}'."
 
 #: DNSSEC:NSEC_COVERS
 msgid  "NSEC covers {name}."
@@ -539,31 +716,49 @@ msgstr "Det finns minst en korrekt signatur (RRSIG) för NSEC-posterna."
 
 #: DNSSEC:NSEC_SIG_VERIFY_ERROR
 msgid  "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
-msgstr "Försöket att verifiera NSEC-posterna med RRSIG {sig} gav felet '{error}'."
+msgstr ""
+"Försöket att verifiera NSEC-posterna med RRSIG {sig} gav felet '{error}'."
 
 #: DNSSEC:REMAINING_LONG
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too long."
-msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för länge."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too long."
+msgstr ""
+"RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en "
+"kvarvarande livslängd på {duration} sekunder, vilket är för länge."
 
 #: DNSSEC:REMAINING_SHORT
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has a remaining validity of {duration} seconds, which is too short."
-msgstr "RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en kvarvarande livslängd på {duration} sekunder, vilket är för kort."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
+"validity of {duration} seconds, which is too short."
+msgstr ""
+"RRSIG-posten med 'keytag' {tag} och täckande typerna {types} har en "
+"kvarvarande livslängd på {duration} sekunder, vilket är för kort."
 
 #: DNSSEC:RRSIG_EXPIRATION
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
-msgstr "RRSIG med 'keytag' {tag} täckande posttyp(er) {types} löper ut datum {date}."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
+msgstr ""
+"RRSIG med 'keytag' {tag} täckande posttyp(er) {types} löper ut datum {date}."
 
 #: DNSSEC:RRSIG_EXPIRED
-msgid  "RRSIG with keytag {tag} and covering type(s) {types} has already expired (expiration is: {expiration})."
-msgstr "RRSIG-posten med 'keytag' {tag} och täckande posttyperna {types} har redan löpt ut (utgångstiden är: {expiration})."
+msgid  ""
+"RRSIG with keytag {tag} and covering type(s) {types} has already expired "
+"(expiration is: {expiration})."
+msgstr ""
+"RRSIG-posten med 'keytag' {tag} och täckande posttyperna {types} har redan "
+"löpt ut (utgångstiden är: {expiration})."
 
 #: DNSSEC:SOA_NOT_SIGNED
 msgid  "No RRSIG correctly signed the SOA RRset."
 msgstr "Det finns ingen RRSIG som har korrekt signerat SOA-posten."
 
 #: DNSSEC:SOA_SIGNATURE_NOT_OK
-msgid  "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
-msgstr "Försöket att verifiera SOA-mängden med signatur {signature} gav felet '{error}'."
+msgid  ""
+"Trying to verify SOA RRset with signature {signature} gave error '{error}'."
+msgstr ""
+"Försöket att verifiera SOA-mängden med signatur {signature} gav felet "
+"'{error}'."
 
 #: DNSSEC:SOA_SIGNATURE_OK
 msgid  "RRSIG {signature} correctly signs SOA RRset."
@@ -574,28 +769,29 @@ msgid  "At least one RRSIG correctly signs the SOA RRset."
 msgstr "Det finns minst en RRSIG-post som korrekt signerar SOA-posten."
 
 #: DNSSEC:TOO_MANY_ITERATIONS
-msgid  "The number of NSEC3 iterations is {count}, which is too high for key length {keylength}."
-msgstr "Antalet NSEC3-iterationer är {count}, vilket är för många för nyckellängden {keylength}."
-
-#: DNSSEC:DELEGATION_NOT_SIGNED
-msgid  "Delegation from parent to child is not properly signed {reason}."
-msgstr "Delegeringen från moderzonen till dotterzonens namnservrar är inte korrekt signerad ({reason})."
-
-#: DNSSEC:DELEGATION_SIGNED
-msgid  "Delegation from parent to child is properly signed."
-msgstr "Delegeringen från moderzonen till dotterzonens namnservrar är korrekt signerad."
+msgid  ""
+"The number of NSEC3 iterations is {count}, which is too high for key length "
+"{keylength}."
+msgstr ""
+"Antalet NSEC3-iterationer är {count}, vilket är för många för nyckellängden "
+"{keylength}."
 
 #: EXAMPLE:EXAMPLE_TAG
 msgid  "This is an example tag."
 msgstr "Detta är en exempeletikett."
 
 #: NAMESERVER:AAAA_WELL_PROCESSED
-msgid  "The following nameservers answer AAAA queries without problems : {names}."
+msgid  ""
+"The following nameservers answer AAAA queries without problems : {names}."
 msgstr "Följande namnservrar svarade problemfritt på AAAA-frågor : {names}."
 
 #: NAMESERVER:ANSWER_BAD_RCODE
-msgid  "Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode})."
-msgstr "Namnservern {ns}/{address} besvarade en AAAA-fråga med den oväntade svarskoden '{rcode}'."
+msgid  ""
+"Nameserver {ns}/{address} answered AAAA query with an unexpected rcode "
+"({rcode})."
+msgstr ""
+"Namnservern {ns}/{address} besvarade en AAAA-fråga med den oväntade "
+"svarskoden '{rcode}'."
 
 #: NAMESERVER:AXFR_AVAILABLE
 msgid  "Nameserver {ns}/{address} allow zone transfer using AXFR."
@@ -611,18 +807,81 @@ msgstr "Alla namnservrar kunde slås upp till minst en IP-adress."
 
 #: NAMESERVER:CAN_NOT_BE_RESOLVED
 msgid  "The following nameservers failed to resolve to an IP address : {names}."
-msgstr "Följande namnservernamn kunde inte slås upp till någon IP-adresser: {names}."
+msgstr ""
+"Följande namnservernamn kunde inte slås upp till någon IP-adresser: {names}."
+
+#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers do not reply consistently."
+msgstr ""
+"Alla servrar svarar inte konsekvent när förfrågade om '{query}' med olika "
+"skiftlägen och posttypen '{type}'."
+
+#: NAMESERVER:CASE_QUERIES_RESULTS_OK
+msgid  ""
+"When asked for {type} records on \"{query}\" with different cases, all "
+"servers reply consistently."
+msgstr ""
+"Alla servrar svarar konsekvent när förfrågade om '{query}' med olika "
+"skiftlägen och posttypen '{type}'."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different answers."
+msgstr ""
+"Namnservern {ns}/{address} ger olika svar när frågan är '{query1}' resp. "
+"'{query2}' för posttypen '{type}'."
+
+#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
+msgstr ""
+"Namnservern {ns}/{address} ger olika RCODE ('{rcode1}' resp. '{rcode2}') när "
+"frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
+
+#: NAMESERVER:CASE_QUERY_NO_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query}\", nameserver {ns}/{address} "
+"returns nothing."
+msgstr ""
+"Nameserver {ns}/{address} svarar ingenting när den får frågan om '{query}' "
+"med posttypen '{type}'."
+
+#: NAMESERVER:CASE_QUERY_SAME_ANSWER
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same answers."
+msgstr ""
+"Namnservern {ns}/{address} ger samma svar när frågan är '{query1}' resp. "
+"'{query2}' för posttypen '{type}'."
+
+#: NAMESERVER:CASE_QUERY_SAME_RC
+msgid  ""
+"When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver "
+"{ns}/{address} returns same RCODE \"{rcode}\"."
+msgstr ""
+"Namnservern {ns}/{address} ger samma RCODE '{rcode}' när frågan är "
+"'{query1}' resp. '{query2}' för posttypen '{type}'."
 
 #: NAMESERVER:DIFFERENT_SOURCE_IP
-msgid  "Nameserver {ns}/{address} replies on a SOA query with a different source address ({source})."
-msgstr "Namnservern {ns}/{address} besvarade en SOA-fråga från en annan källadress ({source})."
+msgid  ""
+"Nameserver {ns}/{address} replies on a SOA query with a different source "
+"address ({source})."
+msgstr ""
+"Namnservern {ns}/{address} besvarade en SOA-fråga från en annan källadress "
+"({source})."
 
 #: NAMESERVER:EDNS0_BAD_ANSWER
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (OPT not set in reply)."
 msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (ingen 'OPT' i svaret)."
 
 #: NAMESERVER:EDNS0_BAD_QUERY
-msgid  "Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
+msgid  ""
+"Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR)."
 msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svarar med 'FORMERR')."
 
 #: NAMESERVER:EDNS0_SUPPORT
@@ -637,81 +896,77 @@ msgstr "Namnservern {ns}/{address} är en rekursiv resolver."
 msgid  "None of the following nameservers is a recursor : {names}."
 msgstr "Ingen av följande namnservrar är en rekursiv resolver: {names}."
 
-#: NAMESERVER:RECURSIVITY_UNDEF
-msgid  "Cannot determine if the following servers are recursive nameservers or not: {names}."
-msgstr "Det går inte att fastställa om namnservern är en rekursiv resolver eller inte: {names}."
-
 #: NAMESERVER:NO_RESOLUTION
 msgid  "No nameservers succeeded to resolve to an IP address."
 msgstr "Det gick inte att slå upp IP-adressen för någon namnserver."
+
+#: NAMESERVER:NO_UPWARD_REFERRAL
+msgid  "None of the following nameservers returns an upward referral : {names}."
+msgstr ""
+"Ingen av följande nameserverar skickar hänvisning till moderzonen: {names}."
+
+#: NAMESERVER:QNAME_CASE_INSENSITIVE
+msgid  ""
+"Nameserver {ns}/{address} does not preserve original case of queried names."
+msgstr ""
+"Nameservern {ns}/{address} bevarar inte skillnaden mellan versaler och "
+"gemener från frågan ({dname})."
+
+#: NAMESERVER:QNAME_CASE_SENSITIVE
+msgid  "Nameserver {ns}/{address} preserves original case of queried names."
+msgstr ""
+"Namnservern {ns}/{address} bevarade versaler och gemener från frågan "
+"({dname})."
 
 #: NAMESERVER:QUERY_DROPPED
 msgid  "Nameserver {ns}/{address} dropped AAAA query."
 msgstr "Namnservern {ns}/{address} besvarade inte AAAA-frågan."
 
+#: NAMESERVER:RECURSIVITY_UNDEF
+msgid  ""
+"Cannot determine if the following servers are recursive nameservers or not: "
+"{names}."
+msgstr ""
+"Det går inte att fastställa om namnservern är en rekursiv resolver eller "
+"inte: {names}."
+
 #: NAMESERVER:SAME_SOURCE_IP
 msgid  "All nameservers reply with same IP used to query them."
-msgstr "Alla namnservrar skickade svar från samma IP-adress som frågan ställdes till."
-
-#: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
-msgid  "Upward referral tests skipped for root zone."
-msgstr "Tester för hänvisning till moderzon stryks för root-zonen (det finns ingen moderzon)."
+msgstr ""
+"Alla namnservrar skickade svar från samma IP-adress som frågan ställdes till."
 
 #: NAMESERVER:UPWARD_REFERRAL
 msgid  "Nameserver {ns}/{address} returns an upward referral."
 msgstr "Nameservern {ns}/{address} skickade en hänvisning till moderzonen."
 
-#: NAMESERVER:NO_UPWARD_REFERRAL
-msgid  "None of the following nameservers returns an upward referral : {names}."
-msgstr "Ingen av följande nameserverar skickar hänvisning till moderzonen: {names}."
-
-#: NAMESERVER:QNAME_CASE_SENSITIVE
-msgid  "Nameserver {ns}/{address} preserves original case of queried names."
-msgstr "Namnservern {ns}/{address} bevarade versaler och gemener från frågan ({dname})."
-
-#: NAMESERVER:QNAME_CASE_INSENSITIVE
-msgid  "Nameserver {ns}/{address} does not preserve original case of queried names."
-msgstr "Nameservern {ns}/{address} bevarar inte skillnaden mellan versaler och gemener från frågan ({dname})."
-
-#: NAMESERVER:CASE_QUERY_SAME_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same answers."
-msgstr "Namnservern {ns}/{address} ger samma svar när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
-
-#: NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different answers."
-msgstr "Namnservern {ns}/{address} ger olika svar när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
-
-#: NAMESERVER:CASE_QUERY_SAME_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns same RCODE \"{rcode}\"."
-msgstr "Namnservern {ns}/{address} ger samma RCODE '{rcode}' när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
-
-#: NAMESERVER:CASE_QUERY_DIFFERENT_RC
-msgid  "When asked for {type} records on \"{query1}\" and \"{query2}\", nameserver {ns}/{address} returns different RCODE (\"{rcode1}\" vs \"{rcode2}\")."
-msgstr "Namnservern {ns}/{address} ger olika RCODE ('{rcode1}' resp. '{rcode2}') när frågan är '{query1}' resp. '{query2}' för posttypen '{type}'."
-
-#: NAMESERVER:CASE_QUERY_NO_ANSWER
-msgid  "When asked for {type} records on \"{query}\", nameserver {ns}/{address} returns nothing."
-msgstr "Nameserver {ns}/{address} svarar ingenting när den får frågan om '{query}' med posttypen '{type}'."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_OK
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers reply consistently."
-msgstr "Alla servrar svarar konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen '{type}'."
-
-#: NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
-msgid  "When asked for {type} records on \"{query}\" with different cases, all servers do not reply consistently."
-msgstr "Alla servrar svarar inte konsekvent när förfrågade om '{query}' med olika skiftlägen och posttypen '{type}'."
+#: NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
+msgid  "Upward referral tests skipped for root zone."
+msgstr ""
+"Tester för hänvisning till moderzon stryks för root-zonen (det finns ingen "
+"moderzon)."
 
 #: SYNTAX:DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet '{name}' har en domändel '{label}' med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
+msgid  ""
+"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domännamnet '{name}' har en domändel '{label}' med bindestreck i position 3 "
+"och 4, men börjar inte med 'xn--'."
 
 #: SYNTAX:INITIAL_HYPHEN
-msgid  "Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
-msgstr "Domännamnet '{name}' har en domändel '{label}' som börjar med ett bindestreck."
+msgid  ""
+"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+msgstr ""
+"Domännamnet '{name}' har en domändel '{label}' som börjar med ett "
+"bindestreck."
 
 #: SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
-msgid  "SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "SOA MNAME '{name}' har en domändel '{label}' med bindestreck i position 3 och 4, men börjar inte med 'xn--'."
+msgid  ""
+"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"SOA MNAME '{name}' har en domändel '{label}' med bindestreck i position 3 "
+"och 4, men börjar inte med 'xn--'."
 
 #: SYNTAX:MNAME_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in SOA MNAME ({name})."
@@ -726,8 +981,12 @@ msgid  "SOA MNAME ({name}) syntax is valid."
 msgstr "SOA MNAME '{name}' har tillåtet format."
 
 #: SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
-msgid  "Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domänens MX ({name}) har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
+msgid  ""
+"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domänens MX ({name}) har en domändel ({label}) med bindestreck i position 3 "
+"och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:MX_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in MX ({name})."
@@ -742,8 +1001,12 @@ msgid  "Domain name MX ({name}) syntax is valid."
 msgstr "MX-namnet '{name}' är giltigt."
 
 #: SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
-msgid  "Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Namnservern '{name}' har en domändel ({label}) med bindestreck i position 3 och 4, men börjar inte på 'xn--'."
+msgid  ""
+"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"position 3 and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Namnservern '{name}' har en domändel ({label}) med bindestreck i position 3 "
+"och 4, men börjar inte på 'xn--'."
 
 #: SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 msgid  "Found illegal characters in the nameserver ({name})."
@@ -762,12 +1025,17 @@ msgid  "Found illegal characters in the domain name ({name})."
 msgstr "Det finns otillåtna tecken i domännamnet '{name}'."
 
 #: SYNTAX:NO_DOUBLE_DASH
-msgid  "Domain name ({name}) has no label with a double hyphen ('--') in position 3 and 4 (with a prefix which is not 'xn--')."
-msgstr "Domännamnet '{name}' har ingen domändel med bindestreck i position 3 och 4."
+msgid  ""
+"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
+"and 4 (with a prefix which is not 'xn--')."
+msgstr ""
+"Domännamnet '{name}' har ingen domändel med bindestreck i position 3 och 4."
 
 #: SYNTAX:NO_ENDING_HYPHENS
 msgid  "Both ends of all labels of the domain name ({name}) have no hyphens."
-msgstr "Domännamnet '{name}' har ingen domändel som börjar eller slutar med ett bindestreck."
+msgstr ""
+"Domännamnet '{name}' har ingen domändel som börjar eller slutar med ett "
+"bindestreck."
 
 #: SYNTAX:NO_RESPONSE_MX_QUERY ZONE:NO_RESPONSE_MX_QUERY
 msgid  "No response from nameserver(s) on MX queries."
@@ -782,7 +1050,8 @@ msgid  "No illegal characters in the domain name ({name})."
 msgstr "Endast tillåtna tecken i namnet '{name}'."
 
 #: SYNTAX:RNAME_MISUSED_AT_SIGN
-msgid  "There must be no misused '@' character in the SOA RNAME field ({rname})."
+msgid  ""
+"There must be no misused '@' character in the SOA RNAME field ({rname})."
 msgstr "Felaktigt använt '@'-tecken i SOA RNAME ({rname})."
 
 #: SYNTAX:RNAME_NO_AT_SIGN
@@ -799,15 +1068,18 @@ msgstr "Adressen i SOA RNAME ({rname}) är giltig enligt RFC822."
 
 #: SYNTAX:TERMINAL_HYPHEN
 msgid  "Domain name ({name}) has a label ({label}) ending with an hyphen ('-')."
-msgstr "Domännamnet '{name}' har domändelen '{label}' som slutar med ett bindestreck."
+msgstr ""
+"Domännamnet '{name}' har domändelen '{label}' som slutar med ett bindestreck."
 
 #: SYSTEM:ADDED_FAKE_DELEGATION
 msgid  "Added a fake delegation for domain {domain} to name server {ns}."
-msgstr "Lade till en skapad delegering för domänen '{domain}' till namnserver '{ns}'."
+msgstr ""
+"Lade till en skapad delegering för domänen '{domain}' till namnserver '{ns}'."
 
 #: SYSTEM:CANNOT_CONTINUE
 msgid  "Not enough data about {zone} was found to be able to run tests."
-msgstr "Det finns inte tillräckligt med data om '{zone}' för att kunna köra tester."
+msgstr ""
+"Det finns inte tillräckligt med data om '{zone}' för att kunna köra tester."
 
 #: SYSTEM:CONFIG_FILE
 msgid  "Configuration was read from {name}."
@@ -817,33 +1089,52 @@ msgstr "Konfiguration lästes från '{name}'."
 msgid  "Using prerequisite module {name} version {version}."
 msgstr "Använder version {version} av modulen '{name}'."
 
-#: SYSTEM:GLOBAL_VERSION
-msgid "Using version {version} of the Zonemaster engine."
-msgstr "Använder version {version} av Zonemasters testmotor."
-
 #: SYSTEM:FAKE_DELEGATION
 msgid  "Followed a fake delegation."
 msgstr "Följde en skapad delegering."
 
-#: SYSTEM:FAKE_DELEGATION_TO_SELF
-msgid  "Name server {ns} not adding fake delegation for domain {domain} to itself."
-msgstr "Namnservern '{ns}' lade inte till en skapad delegering av domänen '{domain}' till sig själv."
-
 #: SYSTEM:FAKE_DELEGATION_IN_ZONE_NO_IP
-msgid  "The fake delegation of domain {domain} includes an in-zone name server {ns} without mandatory glue (without IP address)."
-msgstr "Försöksdelegering av domänen '{domain}' innehåller en namnservern '{ns}' som kräver en glue-post (kräver IP-adress)."
+msgid  ""
+"The fake delegation of domain {domain} includes an in-zone name server {ns} "
+"without mandatory glue (without IP address)."
+msgstr ""
+"Försöksdelegering av domänen '{domain}' innehåller en namnservern '{ns}' som "
+"kräver en glue-post (kräver IP-adress)."
 
 #: SYSTEM:FAKE_DELEGATION_NO_IP
-msgid  "The fake delegation of domain {domain} includes a name server {ns} that cannot be resolved to any IP address."
-msgstr "Försöksdelegering av domänen '{domain}' innehåller en namnservern '{ns}' som inte kan slås upp till någon IP-adress."
+msgid  ""
+"The fake delegation of domain {domain} includes a name server {ns} that "
+"cannot be resolved to any IP address."
+msgstr ""
+"Försöksdelegering av domänen '{domain}' innehåller en namnservern '{ns}' som "
+"inte kan slås upp till någon IP-adress."
+
+#: SYSTEM:FAKE_DELEGATION_TO_SELF
+msgid  ""
+"Name server {ns} not adding fake delegation for domain {domain} to itself."
+msgstr ""
+"Namnservern '{ns}' lade inte till en skapad delegering av domänen '{domain}' "
+"till sig själv."
+
+#: SYSTEM:GLOBAL_VERSION
+msgid  "Using version {version} of the Zonemaster engine."
+msgstr "Använder version {version} av Zonemasters testmotor."
 
 #: SYSTEM:LOGGER_CALLBACK_ERROR
 msgid  "Logger callback died with error: {exception}"
-msgstr "Callback-funktionen för log-modulen avbröt med felmeddelandet: '{exception}'"
+msgstr ""
+"Callback-funktionen för log-modulen avbröt med felmeddelandet: '{exception}'"
 
 #: SYSTEM:LOOKUP_ERROR
-msgid  "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
-msgstr "DNS-fråga till {ns} för {name}/{type}/{class} misslyckades med felet: '{message}'"
+msgid  ""
+"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+msgstr ""
+"DNS-fråga till {ns} för {name}/{type}/{class} misslyckades med felet: "
+"'{message}'"
+
+#: SYSTEM:MODULE_END
+msgid  "Module {module} finished running."
+msgstr "Modulen '{module}' avslutades."
 
 #: SYSTEM:MODULE_ERROR
 msgid  "Fatal error in {module}: {msg}"
@@ -853,13 +1144,17 @@ msgstr "Fatalt fel i '{module}': '{msg}'"
 msgid  "Using module {module} version {version}."
 msgstr "Använder version {version} av modulen '{module}'."
 
-#: SYSTEM:MODULE_END
-msgid  "Module {module} finished running."
-msgstr "Modulen '{module}' avslutades."
-
 #: SYSTEM:NO_NETWORK
 msgid  "Both IPv4 and IPv6 are disabled."
 msgstr "Både IPv4 och IPv6 är inaktiverade."
+
+#: SYSTEM:PACKET_BIG
+msgid  ""
+"Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try "
+"with \"{command}\")."
+msgstr ""
+"Paketstorleken ({size}) byte överskrider den normalt maximala storleken om "
+"{maxsize} byte. Försök med kommandot '{command}'."
 
 #: SYSTEM:POLICY_DISABLED
 msgid  "The module {name} was disabled by the policy."
@@ -879,27 +1174,39 @@ msgstr "IPv6 är inaktiverad. Skickar ingen DNS-fråga till '{ns}'."
 
 #: SYSTEM:UNKNOWN_METHOD
 msgid  "Request to run unknown method {method} in module {module}."
-msgstr "Begäran om att köra den okända metoden '{method}' i modulen '{module}'."
+msgstr ""
+"Begäran om att köra den okända metoden '{method}' i modulen '{module}'."
 
 #: SYSTEM:UNKNOWN_MODULE
-msgid  "Request to run {method} in unknown module {module}. Known modules: {known}."
-msgstr "Begäran om att köra metoden '{method}' i den okända modulen '{module}'. Kända moduler: '{known}'."
-
-#: SYSTEM:PACKET_BIG
-msgid  "Packet size ({size}) exceeds common maximum size of {maxsize} bytes (try with \"{command}\")."
-msgstr "Paketstorleken ({size}) byte överskrider den normalt maximala storleken om {maxsize} byte. Försök med kommandot '{command}'."
+msgid  ""
+"Request to run {method} in unknown module {module}. Known modules: {known}."
+msgstr ""
+"Begäran om att köra metoden '{method}' i den okända modulen '{module}'. "
+"Kända moduler: '{known}'."
 
 #: ZONE:EXPIRE_LOWER_THAN_REFRESH
-msgid  "SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value ({refresh})."
-msgstr "Värdet för SOA 'expire' ({expire}) är lägre än värdet för SOA 'refresh' ({refresh})."
+msgid  ""
+"SOA 'expire' value ({expire}) is lower than the SOA 'refresh' value "
+"({refresh})."
+msgstr ""
+"Värdet för SOA 'expire' ({expire}) är lägre än värdet för SOA "
+"'refresh' ({refresh})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_LOWER
-msgid  "SOA 'expire' value ({expire}) is less than the recommended one ({required_expire})."
-msgstr "Värdet för SOA 'expire' ({expire}) är lägre än rekommenderat ({required_expire})."
+msgid  ""
+"SOA 'expire' value ({expire}) is less than the recommended one "
+"({required_expire})."
+msgstr ""
+"Värdet för SOA 'expire' ({expire}) är lägre än rekommenderat "
+"({required_expire})."
 
 #: ZONE:EXPIRE_MINIMUM_VALUE_OK
-msgid  "SOA 'expire' value ({expire}) is higher than the minimum recommended value ({required_expire}) and not lower than the 'refresh' value ({refresh})."
-msgstr "SOA expire-värdet ligger i det rekommenderade spannet (högre än {required_expire} och inte lägre än refresh-värdet)."
+msgid  ""
+"SOA 'expire' value ({expire}) is higher than the minimum recommended value "
+"({required_expire}) and not lower than the 'refresh' value ({refresh})."
+msgstr ""
+"SOA expire-värdet ligger i det rekommenderade spannet (högre än "
+"{required_expire} och inte lägre än refresh-värdet)."
 
 #: ZONE:MNAME_HAS_NO_ADDRESS
 msgid  "No IP address found for SOA 'mname' nameserver ({mname})."
@@ -914,16 +1221,23 @@ msgid  "SOA 'mname' value ({mname}) refers to a NS which is an alias (CNAME)."
 msgstr "SOA MNAME ('{mname}') har en CNAME-post."
 
 #: ZONE:MNAME_IS_NOT_CNAME
-msgid  "SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
+msgid  ""
+"SOA 'mname' value ({mname}) refers to a NS which is not an alias (CNAME)."
 msgstr "SOA MNAME '{mname}' har ingen CNAME-post."
 
 #: ZONE:MNAME_NOT_AUTHORITATIVE
-msgid  "SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
-msgstr "Namnservern angiven som SOA MNAME ({ns}/{address}) är inte auktoritativ för zonen '{zone}'."
+msgid  ""
+"SOA 'mname' nameserver {ns}/{address} is not authoritative for '{zone}' zone."
+msgstr ""
+"Namnservern angiven som SOA MNAME ({ns}/{address}) är inte auktoritativ för "
+"zonen '{zone}'."
 
 #: ZONE:MNAME_NOT_IN_GLUE
-msgid  "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for tested zone ({ns})."
-msgstr "Namnservern i SOA MNAME finns inte i delegeringen från moderzonen ({ns})."
+msgid  ""
+"SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
+"tested zone ({ns})."
+msgstr ""
+"Namnservern i SOA MNAME finns inte i delegeringen från moderzonen ({ns})."
 
 #: ZONE:MNAME_NO_RESPONSE
 msgid  "SOA 'mname' nameserver {ns}/{address} does not respond."
@@ -947,41 +1261,76 @@ msgstr "MX-post för domänen pekar inte ut ett CNAME."
 
 #: ZONE:NO_MX_RECORD
 msgid  "No target (MX, A or AAAA record) to deliver e-mail for the domain name."
-msgstr "Inget mål att levera mail till (MX-, A- eller AAAA-post) är angivet för domänen."
+msgstr ""
+"Inget mål att levera mail till (MX-, A- eller AAAA-post) är angivet för "
+"domänen."
 
 #: ZONE:REFRESH_HIGHER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value ({retry})."
-msgstr "'refresh'-värdet i SOA-posten ({refresh}) är högre än SOA-postens 'retry'-värde ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"'refresh'-värdet i SOA-posten ({refresh}) är högre än SOA-postens 'retry'-"
+"värde ({retry})."
 
 #: ZONE:REFRESH_LOWER_THAN_RETRY
-msgid  "SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value ({retry})."
-msgstr "SOA-postens 'refresh'-värde ({refresh}) är lägre än dess 'retry'-värde ({retry})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is lower than the SOA 'retry' value "
+"({retry})."
+msgstr ""
+"SOA-postens 'refresh'-värde ({refresh}) är lägre än dess 'retry'-värde "
+"({retry})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_LOWER
-msgid  "SOA 'refresh' value ({refresh}) is less than the recommended one ({required_refresh})."
-msgstr "SOA-postens 'refresh'-värde ({refresh}) är lägre än rekommenderat ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is less than the recommended one "
+"({required_refresh})."
+msgstr ""
+"SOA-postens 'refresh'-värde ({refresh}) är lägre än rekommenderat "
+"({required_refresh})."
 
 #: ZONE:REFRESH_MINIMUM_VALUE_OK
-msgid  "SOA 'refresh' value ({refresh}) is higher than the minimum recommended value ({required_refresh})."
-msgstr "SOA-postens 'refresh'-värde ({refresh}) är högre än det lägsta rekommenderade värdet ({required_refresh})."
+msgid  ""
+"SOA 'refresh' value ({refresh}) is higher than the minimum recommended value "
+"({required_refresh})."
+msgstr ""
+"SOA-postens 'refresh'-värde ({refresh}) är högre än det lägsta "
+"rekommenderade värdet ({required_refresh})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_LOWER
-msgid  "SOA 'retry' value ({retry}) is less than the recommended one ({required_retry})."
-msgstr "SOA-postens 'retry'-värde ({retry}) är lägre än rekommenderat ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is less than the recommended one "
+"({required_retry})."
+msgstr ""
+"SOA-postens 'retry'-värde ({retry}) är lägre än rekommenderat "
+"({required_retry})."
 
 #: ZONE:RETRY_MINIMUM_VALUE_OK
-msgid  "SOA 'retry' value ({retry}) is more than the minimum recommended value ({required_retry})."
-msgstr "'retry'-värdet i SOA-posten ({retry}) är högre än det lägsta rekommenderade värdet ({required_retry})."
+msgid  ""
+"SOA 'retry' value ({retry}) is more than the minimum recommended value "
+"({required_retry})."
+msgstr ""
+"'retry'-värdet i SOA-posten ({retry}) är högre än det lägsta rekommenderade "
+"värdet ({required_retry})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_HIGHER
-msgid  "SOA 'minimum' value ({minimum}) is higher than the recommended one ({highest_minimum})."
-msgstr "SOA-postens 'minimum'-värde ({minimum}) är högre än rekommenderat ({highest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is higher than the recommended one "
+"({highest_minimum})."
+msgstr ""
+"SOA-postens 'minimum'-värde ({minimum}) är högre än rekommenderat "
+"({highest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_LOWER
-msgid  "SOA 'minimum' value ({minimum}) is less than the recommended one ({lowest_minimum})."
-msgstr "SOA-postens 'minimum'-värde ({minimum}) är lägre än rekommenderat ({lowest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is less than the recommended one "
+"({lowest_minimum})."
+msgstr ""
+"SOA-postens 'minimum'-värde ({minimum}) är lägre än rekommenderat "
+"({lowest_minimum})."
 
 #: ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_OK
-msgid  "SOA 'minimum' value ({minimum}) is between the recommended ones ({lowest_minimum}/{highest_minimum})."
+msgid  ""
+"SOA 'minimum' value ({minimum}) is between the recommended ones "
+"({lowest_minimum}/{highest_minimum})."
 msgstr "SOA minimum-värdet ligger i det rekommenderade spannet."
-

--- a/util/extract_po.pl
+++ b/util/extract_po.pl
@@ -1,37 +1,46 @@
 #!/usr/bin/env perl
-
 use 5.14.2;
+use strict;
 use warnings;
 
 use Zonemaster::Engine::Translator;
 
+# Let Zonemaster::Engine extract its own messages
 my $data = Zonemaster::Engine::Translator->new->data;
 
+# Determine msgid order and the tags of each msgid
+my @msgids;
+my %tags;
+for my $module ( sort keys %{$data} ) {
+    next if ref( $data->{$module} ) ne 'HASH';
+    for my $message ( sort keys %{ $data->{$module} } ) {
+        my $msgid = $data->{$module}{$message};
+        my $tag   = "$module:$message";
+        push @msgids, $msgid if !exists $tags{$msgid};    # register first occurrance of each msgid
+        push @{ $tags{$msgid} }, $tag;
+    }
+}
+
+# Print prelude
 print<<'PRELUDE';
-msgid ""
+msgid  ""
 msgstr ""
-"Language: en\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: 0.0.4\n"
 "PO-Revision-Date: 2014-08-28\n"
 "Last-Translator: calle@init.se\n"
 "Language-Team: Zonemaster Team\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 PRELUDE
 
-my %uniq;
-
-foreach my $m (sort keys %{$data}) {
-    next if ref($data->{$m}) ne 'HASH';
-    foreach my $t (sort keys %{$data->{$m}}) {
-        printf qq[#: %s:%s\n], $m, $t;
-        my $str = $data->{$m}{$t};
-        $str =~ s/\"/\\"/g;
-        next if exists $uniq{$str};
-        printf qq[msgid  "%s"\n], $str;
-        printf qq[msgstr "%s"\n\n], $str;
-        $uniq{$str} = 1;
-    }
+# Print messages
+for my $msgid ( @msgids ) {
+    my $msgid_esc = ( $msgid =~ s/\"/\\"/gr );
+    my $tag_string = join " ", @{ $tags{$msgid} };
+    printf qq[#: %s\n],         $tag_string;
+    printf qq[msgid  "%s"\n],   $msgid_esc;
+    printf qq[msgstr "%s"\n\n], $msgid_esc;
 }

--- a/util/update_po
+++ b/util/update_po
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Description:
+#
+#   Update PO files with fresh msgids from source.
+#
+#   It's just a frontend for util/extract_po.pl and msgmerge.
+#
+#   Note that the environment variable MSGMERGE_OPTS can be used to give additional arguments to msgmerge.
+#
+# Synopsis:
+#
+#   util/update_po share/*.po
+#
+#   MSGMERGE_OPTS=--no-fuzzy-matching util/update_po share/*.po
+
+
+# Abort if anything fails
+set -e
+
+# Create temp directory and make sure it gets cleaned up
+tempdir="$(mktemp -d)"
+trap "{ rm -rf $tempdir; }" EXIT
+
+# Create PO template for the (presumably) latest sources
+ref_pot="${tempdir}/ref.pot"
+perl -Ilib util/extract_po.pl > "${ref_pot}"
+
+# Loop over input file arguments
+while [ $# -ge 1 ] ; do
+    def_po="${1}" ; shift
+
+    # Update existing PO using new template
+    # (Using temp file to avoid truncating input file before reading it)
+    temp_po="${tempdir}/temp.po"
+    echo -n "${def_po}: "
+    msgmerge ${MSGMERGE_OPTS} "${def_po}" "${ref_pot}" | sed 's/^msgid "/msgid  "/' > "${temp_po}"
+    mv "${temp_po}" "${def_po}"
+done


### PR DESCRIPTION
This is an update to our translation tooling.

The main part of this PR is a new tool called util/update_po. It's basically a wrapper for util/extract_po.pl and msgmerge (from gettext). update_po updates po files in place making them use the new msgid values reported by extract_po.pl, but keeping the old msgstr values from the specified PO files (e.g. share/*.po). update_po allows customizing the arguments given to msgmerge using the MSGMERGE_OPTS environment variable.

In order for the above to work, extract_po.pl is updated to output `#: `-lines in a way that's consistent with gettext.

Lastly, this PR includes a rearrangement of existing PO files to match the output of update_po. Having this done makes the diff smaller once we start using update_po to make actual changes.