### PR TITLE
Updated "dotse" to "zonemaster" in files

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,8 +9,8 @@ name 'Zonemaster-Engine';
 # share/Makefile
 
 
-repository 'https://github.com/dotse/zonemaster-engine';
-bugtracker 'https://github.com/dotse/zonemaster-engine/issues';
+repository 'https://github.com/zonemaster/zonemaster-engine';
+bugtracker 'https://github.com/zonemaster/zonemaster-engine/issues';
 
 all_from 'lib/Zonemaster/Engine.pm';
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Zonemaster Engine
-[![Build Status](https://travis-ci.org/dotse/zonemaster-engine.svg?branch=master)](https://travis-ci.org/dotse/zonemaster-engine)
+[![Build Status](https://travis-ci.org/zonemaster/zonemaster-engine.svg?branch=master)](https://travis-ci.org/zonemaster/zonemaster-engine)
 [![CPAN version](https://badge.fury.io/pl/Zonemaster-Engine.svg)](https://badge.fury.io/pl/Zonemaster-Engine)
 
 ## Purpose
 
 This repository holds one of the components of the Zonemaster product. For an
 overview of the Zonemaster software, please see the
-[Zonemaster main repository](https://github.com/dotse/zonemaster).
+[Zonemaster main repository](https://github.com/zonemaster/zonemaster).
 
 This Git repository contains the *Zonemaster Engine testing framework*,
 and contains all code needed to perform the full suite of Zonemaster
@@ -15,7 +15,7 @@ tests.
 ## Prerequisites
 
 For supported processor architectures, operating systems and Perl versions see 
-[Zonemaster/README.md](https://github.com/dotse/zonemaster/blob/master/README.md).
+[Zonemaster/README.md](https://github.com/zonemaster/zonemaster/blob/master/README.md).
 
 ## Installation
 
@@ -38,15 +38,15 @@ a new language, implementing a new test and the log entries under the directory
 ## Participation, Contact and Bug reporting
 
 For [participation], [contact] and [bug reporting], please see 
-[Zonemaster/README.md](https://github.com/dotse/zonemaster/blob/master/README.md).
+[Zonemaster/README.md](https://github.com/zonemaster/zonemaster/blob/master/README.md).
 
 
 ## License
 
 The software is released under the 2-clause BSD license. See separate LICENSE file.
 
-[participation]: https://github.com/dotse/zonemaster/blob/master/README.md#participation
-[contact]: https://github.com/dotse/zonemaster/blob/master/README.md#contact
-[bug reporting]: https://github.com/dotse/zonemaster/blob/master/README.md#bug-reporting
+[participation]: https://github.com/zonemaster/zonemaster/blob/master/README.md#participation
+[contact]: https://github.com/zonemaster/zonemaster/blob/master/README.md#contact
+[bug reporting]: https://github.com/zonemaster/zonemaster/blob/master/README.md#bug-reporting
 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -145,17 +145,17 @@ The command is expected to take a few seconds and print some results about the d
 
 -------
 
-[Declaration of prerequisites]: https://github.com/dotse/zonemaster#prerequisites
+[Declaration of prerequisites]: https://github.com/zonemaster/zonemaster#prerequisites
 [Installation on CentOS]: #installation-on-centos
 [Installation on Debian]: #installation-on-debian
 [Installation on FreeBSD]: #installation-on-freebsd
 [Installation on Ubuntu]: #installation-on-ubuntu
-[JSON-RPC API]: https://github.com/dotse/zonemaster-backend/blob/master/docs/API.md
-[Main Zonemaster Repository]: https://github.com/dotse/zonemaster
-[Zonemaster::Backend installation]: https://github.com/dotse/zonemaster-backend/blob/master/docs/Installation.md
-[Zonemaster::CLI installation]: https://github.com/dotse/zonemaster-cli/blob/master/docs/Installation.md
+[JSON-RPC API]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md
+[Main Zonemaster Repository]: https://github.com/zonemaster/zonemaster
+[Zonemaster::Backend installation]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md
+[Zonemaster::CLI installation]: https://github.com/zonemaster/zonemaster-cli/blob/master/docs/Installation.md
 [Zonemaster::Engine API]: http://search.cpan.org/~znmstr/Zonemaster-Engine/lib/Zonemaster/Engine/Overview.pod
-[Zonemaster::GUI installation]: https://github.com/dotse/zonemaster-gui/blob/master/docs/Installation.md
+[Zonemaster::GUI installation]: https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md
 
 Copyright (c) 2013 - 2017, IIS (The Internet Foundation in Sweden)\
 Copyright (c) 2013 - 2017, AFNIC\

--- a/lib/Zonemaster/Engine/Overview.pod
+++ b/lib/Zonemaster/Engine/Overview.pod
@@ -49,7 +49,7 @@ If you want to develop a test module of your own, the L<Zonemaster::Engine::Test
 
 As an entry point to the "inside" of the Zonemaster framework, you want to read L<Zonemaster::Engine::Zone> and follow references from there. Of particular interest after the zone class should be the L<Zonemaster::Engine::Nameserver> and possibly L<Zonemaster::Engine::Recursor> classes.
 
-If you do write your own test module, I would very much appreciate feedback on which parts were tricky to figure out, because I'm honestly not sure what I need to explain here. So please, if there's somethat that you think really needs to be written about, add an issue about at L<https://github.com/dotse/zonemaster-engine/issues>.
+If you do write your own test module, I would very much appreciate feedback on which parts were tricky to figure out, because I'm honestly not sure what I need to explain here. So please, if there's somethat that you think really needs to be written about, add an issue about at L<https://github.com/zonemaster/zonemaster-engine/issues>.
 
 =head2 For developers of the Zonemaster Test Framework
 
@@ -87,7 +87,7 @@ Adding a new message tag is more work than it first looks, since it needs to be 
 
 =over
 
-=item L<https://github.com/dotse/zonemaster>
+=item L<https://github.com/zonemaster/zonemaster>
 
 Main repository, holding among other things our test specifications.
 

--- a/t/nameserver.t
+++ b/t/nameserver.t
@@ -123,7 +123,7 @@ my $ns_test = new_ok( 'Zonemaster::Engine::Nameserver' => [ { name => 'ns.nic.se
 is($ns_test->dns->source, '127.0.0.1', 'Source address set.');
 
 Zonemaster::Engine->config->no_network( 0 );
-# Address was 127.0.0.17 (https://github.com/dotse/zonemaster-engine/issues/219).
+# Address was 127.0.0.17 (https://github.com/zonemaster/zonemaster-engine/issues/219).
 # 192.0.2.17 is part of TEST-NET-1 IP address range (See RFC6890) and should be reserved
 # for documentation.
 my $fail_ns = Zonemaster::Engine::Nameserver->new( { name => 'fail', address => '192.0.2.17' } );


### PR DESCRIPTION
Updated all "dotse/zonemaster" in Github links to "zonemaster/zonemaster" to reflect the move from one Github organization to another.