### PR TITLE
Make it possible to `use Zonemaster::Engine` in development context

### DIFF
--- a/lib/Zonemaster/Engine/Constants.pm
+++ b/lib/Zonemaster/Engine/Constants.pm
@@ -12,7 +12,7 @@ use English qw( -no_match_vars ) ;
 use parent 'Exporter';
 use Zonemaster::Engine::Net::IP;
 use Text::CSV;
-use File::ShareDir qw[dist_dir dist_file];
+use Zonemaster::Engine::Util qw( dist_file );
 
 use Readonly;
 

--- a/lib/Zonemaster/Engine/Util.pm
+++ b/lib/Zonemaster/Engine/Util.pm
@@ -9,13 +9,15 @@ use parent 'Exporter';
 use strict;
 use warnings;
 
-use Zonemaster::Engine;
-use Zonemaster::Engine::DNSName;
+use English;
+use File::ShareDir;
 use Pod::Simple::SimpleTree;
+use Zonemaster::Engine::DNSName;
+use Zonemaster::Engine;
 
 ## no critic (Modules::ProhibitAutomaticExportation)
 our @EXPORT      = qw[ ns info name pod_extract_for scramble_case ];
-our @EXPORT_OK   = qw[ ns info name pod_extract_for policy scramble_case ];
+our @EXPORT_OK   = qw[ ns info name pod_extract_for policy scramble_case dist_file ];
 our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 
 ## no critic (Subroutines::RequireArgUnpacking)
@@ -133,6 +135,22 @@ sub supports_ipv6 {
     return;
 }
 
+sub dist_file {
+    my ( $dist, $file ) = @_;
+
+    eval { File::ShareDir::dist_dir( $dist ) };
+
+    if ( $EVAL_ERROR ) {
+        my @dirs = File::Spec->splitdir( __FILE__ );
+        my $dev_path = File::Spec->catdir( @dirs[ 0 .. $#dirs - 4 ], 'share', $file );
+        if ( -f $dev_path && -r $dev_path ) {
+            return $dev_path;
+        }
+    }
+
+    return File::ShareDir::dist_file( $dist, $file );
+}
+
 1;
 
 =head1 NAME
@@ -185,5 +203,13 @@ This routine provides a special effect: sCraMBliNg tHe CaSe
 =item supports_ipv6
 
 Check if ZOnemaster hosting server supports IPv6.
+
+=item dist_file
+
+A wrapper around L<File::ShareDir/dist_file>.
+
+It takes two arguments: B<$dist> and B<$file>.
+
+The difference from L<File::ShareDir/dist_file> is that it falls back to locating B<$file> within the source repo (that is assumed to be located relative to B<__FILE__>) unless B<$dist> is installed according to L<File::ShareDir/dist_dir>.
 
 =back


### PR DESCRIPTION
Fixes #457.