### PR TITLE
Align tests and impl for boolean properties with documentation

### DIFF
--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -222,10 +222,10 @@ sub _set {
 
         # Boolean
         if ( $profile_properties_details{$property_name}->{type} eq q{Bool} ) {
-            if ( $from eq q{DIRECT} and ($value eq q{0} or $value eq q{false}) ) {
+            if ( $from eq q{DIRECT} and !$value ) {
                 $value = JSON::PP::false;
             }
-            elsif ( $from eq q{DIRECT} and ($value eq q{1} or $value eq q{true}) ) {
+            elsif ( $from eq q{DIRECT} and $value ) {
                 $value = JSON::PP::true;
             }
             elsif ( $from eq q{JSON} and $value_type and $value == JSON::PP::false ) {


### PR DESCRIPTION
There's been some confusion regarding what values to accept for booleans by the `Profile::set` method.

This PR updates the implementation and unit tests to match the documentation. In other words, any defined value is accepted, and the value is interpreted according to the Perl rules for boolean context.

Without this PR the string `"false"` is interpreted as false by `Profile::set` while at the same time being interpreted as true by Perl.