### PR TITLE
- Fix zonemaster/zonemaster-backend#476

### DIFF
--- a/lib/Zonemaster/Engine/Logger/Entry.pm
+++ b/lib/Zonemaster/Engine/Logger/Entry.pm
@@ -30,7 +30,7 @@ my $json = JSON::PP->new->allow_blessed->convert_blessed->canonical;
 has 'module'    => ( is => 'ro', isa => 'Str',                lazy_build => 1 );
 has 'tag'       => ( is => 'ro', isa => 'Str',                required   => 1 );
 has 'args'      => ( is => 'ro', isa => 'Maybe[HashRef]',     required   => 0 );
-has 'timestamp' => ( is => 'ro', isa => 'Num',                default    => sub { time() - $start_time } );
+has 'timestamp' => ( is => 'ro', isa => 'Num',                default    => sub { my $time = time() - $start_time; $time =~ s/,/\./; $time; } );
 has 'trace'     => ( is => 'ro', isa => 'ArrayRef[ArrayRef]', builder    => '_build_trace' );
 has 'level'     => ( is => 'ro', isa => 'Str',                lazy_build => 1, writer => '_set_level' );
 


### PR DESCRIPTION
Don't know (now) how to fix this stringification issue ( use a ',' instead of '.' ). It works with that hack but needto be checks with various versions of Perl.