### PR TITLE
Provide configure-time-deps for Zonemaster::LDNS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install:
     - eval $(curl https://travis-perl.github.io/init) --auto
     - local-lib
     - git clone --depth=1 --branch=develop https://github.com/zonemaster/zonemaster-ldns.git
-    - cpan-install --deps Devel::CheckLib ./zonemaster-ldns
+    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil ./zonemaster-ldns


### PR DESCRIPTION
I expect Travis to start failing for Engine once zonemaster/zonemaster-ldns#72 is merged. This PR should pass both before and after merging zonemaster/zonemaster-ldns#72.

Edit: This PR passes its checks as expected and #500 fails as expected. Until this is merged, all other PRs will fail just like #500.