### PR TITLE
 Maintenance of dependencies - part 2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,7 +29,7 @@ requires 'Moose'                 => 2.0401;
 requires 'Net::IP'               => 1.26;
 requires 'Readonly'              => 0;
 requires 'Text::CSV'             => 0;
-requires 'Zonemaster::LDNS'      => 1.0;
+requires 'Zonemaster::LDNS'      => 2.0;
 
 test_requires 'Pod::Coverage'     => 0;
 test_requires 'Test::Differences' => 0;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,11 +28,8 @@ requires 'Mail::RFC822::Address' => 0;
 requires 'Readonly'              => 0;
 requires 'Locale::TextDomain'    => 1.23;
 requires 'Text::CSV'             => 0;
-requires 'MIME::Base64'          => 0;
 requires 'Clone'                 => 0;
 requires 'JSON::PP'              => 0;
-requires 'Data::Dumper'          => 0;
-requires 'Digest::MD5'           => 0;
 
 test_requires 'Test::Fatal'       => 0;
 test_requires 'Test::Exception'   => 0;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,6 @@ requires 'Locale::TextDomain'    => 1.23;
 requires 'Text::CSV'             => 0;
 requires 'MIME::Base64'          => 0;
 requires 'Clone'                 => 0;
-requires 'JSON'                  => 0;
 requires 'JSON::PP'              => 0;
 requires 'Data::Dumper'          => 0;
 requires 'Digest::MD5'           => 0;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,25 +16,27 @@ all_from 'lib/Zonemaster/Engine.pm';
 
 configure_requires 'Locale::Msgfmt' => 0.15;
 
-requires 'Zonemaster::LDNS'      => 1.0;
-requires 'IO::Socket::INET6'     => 2.69;
-requires 'Moose'                 => 2.0401;
-requires 'Module::Find'          => 0.10;
+requires 'Clone'                 => 0;
+requires 'Data::Dumper'          => 0;
 requires 'File::ShareDir'        => 1.00;
 requires 'File::Slurp'           => 0;
-requires 'Net::IP'               => 1.26;
-requires 'List::MoreUtils'       => 0;
-requires 'Mail::RFC822::Address' => 0;
-requires 'Readonly'              => 0;
-requires 'Locale::TextDomain'    => 1.23;
-requires 'Text::CSV'             => 0;
-requires 'Clone'                 => 0;
+requires 'IO::Socket::INET6'     => 2.69;
 requires 'JSON::PP'              => 0;
+requires 'List::MoreUtils'       => 0;
+requires 'Locale::TextDomain'    => 1.23;
+requires 'Mail::RFC822::Address' => 0;
+requires 'MIME::Base64'          => 0;
+requires 'Module::Find'          => 0.10;
+requires 'Moose'                 => 2.0401;
+requires 'Net::IP'               => 1.26;
+requires 'Readonly'              => 0;
+requires 'Text::CSV'             => 0;
+requires 'Zonemaster::LDNS'      => 1.0;
 
-test_requires 'Test::Fatal'       => 0;
-test_requires 'Test::Exception'   => 0;
-test_requires 'Test::Differences' => 0;
 test_requires 'Pod::Coverage'     => 0;
+test_requires 'Test::Differences' => 0;
+test_requires 'Test::Exception'   => 0;
+test_requires 'Test::Fatal'       => 0;
 test_requires 'Test::Pod'         => 1.22;
 
 recommends 'Readonly::XS' => 0;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,6 @@ all_from 'lib/Zonemaster/Engine.pm';
 configure_requires 'Locale::Msgfmt' => 0.15;
 
 requires 'Clone'                 => 0;
-requires 'Data::Dumper'          => 0;
 requires 'File::ShareDir'        => 1.00;
 requires 'File::Slurp'           => 0;
 requires 'IO::Socket::INET6'     => 2.69;
@@ -25,7 +24,6 @@ requires 'JSON::PP'              => 0;
 requires 'List::MoreUtils'       => 0;
 requires 'Locale::TextDomain'    => 1.23;
 requires 'Mail::RFC822::Address' => 0;
-requires 'MIME::Base64'          => 0;
 requires 'Module::Find'          => 0.10;
 requires 'Moose'                 => 2.0401;
 requires 'Net::IP'               => 1.26;

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -33,13 +33,13 @@ This instruction covers the following operating systems:
 2) Install binary packages:
 
    ```sh
-   sudo yum install perl-core perl-ExtUtils-MakeMaker perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Readonly perl-Time-HiRes perl-YAML libidn-devel perl-Devel-CheckLib openssl-devel perl-Test-Fatal cpanminus
+   sudo yum install perl-core perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Readonly perl-YAML libidn-devel perl-Devel-CheckLib openssl-devel perl-Test-Fatal cpanminus
    ```
 
 3) Install packages from CPAN:
 
    ```sh
-   sudo cpanm Locale::TextDomain Hash::Merge Net::IP Moose Test::More
+   sudo cpanm Locale::TextDomain Net::IP Moose Test::More
    ```
 
 4) Install Zonemaster::LDNS and Zonemaster::Engine:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -33,13 +33,13 @@ This instruction covers the following operating systems:
 2) Install binary packages:
 
    ```sh
-   sudo yum install cpanminus libidn-devel openssl-devel perl-core perl-Devel-CheckLib perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Readonly-XS perl-Test-Fatal perl-YAML
+   sudo yum install cpanminus libidn-devel openssl-devel perl-Clone perl-core perl-Devel-CheckLib perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Pod-Coverage perl-Readonly-XS perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-Pod perl-YAML
    ```
 
 3) Install packages from CPAN:
 
    ```sh
-   sudo cpanm Locale::TextDomain Moose Net::IP Test::More
+   sudo cpanm Locale::Msgfmt Locale::TextDomain Mail::RFC822::Address Module::Find Module::Install Module::Install::XSUtil Moose Net::IP Test::More Text::CSV
    ```
 
 4) Install Zonemaster::LDNS and Zonemaster::Engine:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -39,7 +39,7 @@ This instruction covers the following operating systems:
 3) Install packages from CPAN:
 
    ```sh
-   sudo cpanm Locale::TextDomain Hash::Merge Net::IP::XS Moose Test::More
+   sudo cpanm Locale::TextDomain Hash::Merge Net::IP Moose Test::More
    ```
 
 4) Install Zonemaster::LDNS and Zonemaster::Engine:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -33,7 +33,7 @@ This instruction covers the following operating systems:
 2) Install binary packages:
 
    ```sh
-   sudo yum install cpanminus libidn-devel openssl-devel perl-core perl-Devel-CheckLib perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Readonly perl-Test-Fatal perl-YAML
+   sudo yum install cpanminus libidn-devel openssl-devel perl-core perl-Devel-CheckLib perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Readonly-XS perl-Test-Fatal perl-YAML
    ```
 
 3) Install packages from CPAN:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -33,13 +33,13 @@ This instruction covers the following operating systems:
 2) Install binary packages:
 
    ```sh
-   sudo yum install perl-core perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Readonly perl-YAML libidn-devel perl-Devel-CheckLib openssl-devel perl-Test-Fatal cpanminus
+   sudo yum install cpanminus libidn-devel openssl-devel perl-core perl-Devel-CheckLib perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Readonly perl-Test-Fatal perl-YAML
    ```
 
 3) Install packages from CPAN:
 
    ```sh
-   sudo cpanm Locale::TextDomain Net::IP Moose Test::More
+   sudo cpanm Locale::TextDomain Moose Net::IP Test::More
    ```
 
 4) Install Zonemaster::LDNS and Zonemaster::Engine:

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -3,7 +3,7 @@ use strict;
 use warnings FATAL   => 'all';
 use Test::More tests => 29;
 
-use JSON;
+use JSON::PP;
 use Readonly;
 use Test::Differences;
 use Test::Exception;


### PR DESCRIPTION
This will aid future maintenance of dependencies:
* By listing dependencies in alphabetical order,
* By removing unused modules,
* By removing core modules (except where we have minimum version requirements),
* By adding forgotten modules (all of `configure_requires`, `requires`, `test_requires` and `recommends`), and
* By preferring RPM to CPAN in the installation instruction.

Note that this PR only regards itself with the CentOS part of the installation instruction.