### PR TITLE
Maintenance of dependencies - part 3

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -125,7 +125,6 @@ The command is expected to take a few seconds and print some results about the d
 * For a [JSON-RPC API], follow the [Zonemaster::Backend installation] instruction.
 * For a Perl API, see the [Zonemaster::Engine API] documentation.
 
--------
 
 [Declaration of prerequisites]: https://github.com/zonemaster/zonemaster#prerequisites
 [EPEL]: https://fedoraproject.org/wiki/EPEL
@@ -139,10 +138,3 @@ The command is expected to take a few seconds and print some results about the d
 [Zonemaster::CLI installation]: https://github.com/zonemaster/zonemaster-cli/blob/master/docs/Installation.md
 [Zonemaster::Engine API]: http://search.cpan.org/~znmstr/Zonemaster-Engine/lib/Zonemaster/Engine/Overview.pod
 [Zonemaster::GUI installation]: https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md
-
-Copyright (c) 2013 - 2017, IIS (The Internet Foundation in Sweden)\
-Copyright (c) 2013 - 2017, AFNIC\
-Creative Commons Attribution 4.0 International License
-
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -24,25 +24,31 @@ This instruction covers the following operating systems:
 
 ### Installation on CentOS
 
-1) Make sure the development environment is installed.
+1) Install the [EPEL 7][EPEL] repository:
+
+   ```sh
+   sudo yum --enablerepo=extras install epel-release
+   ```
+
+2) Make sure the development environment is installed:
 
    ```sh
    sudo yum groupinstall "Development Tools"
    ```
 
-2) Install binary packages:
+3) Install binary packages:
 
    ```sh
-   sudo yum install cpanminus libidn-devel openssl-devel perl-Clone perl-core perl-Devel-CheckLib perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Pod-Coverage perl-Readonly-XS perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-Pod perl-YAML
+   sudo yum install cpanminus libidn-devel openssl-devel perl-Clone perl-core perl-Devel-CheckLib perl-File-ShareDir perl-File-Slurp perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Module-Find perl-Moose perl-Net-IP perl-Pod-Coverage perl-Readonly-XS perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-Pod perl-YAML
    ```
 
-3) Install packages from CPAN:
+4) Install packages from CPAN:
 
    ```sh
-   sudo cpanm Locale::Msgfmt Locale::TextDomain Mail::RFC822::Address Module::Find Module::Install Module::Install::XSUtil Moose Net::IP Test::More Text::CSV
+   sudo cpanm Locale::Msgfmt Locale::TextDomain Mail::RFC822::Address Module::Install Module::Install::XSUtil Test::More Text::CSV
    ```
 
-4) Install Zonemaster::LDNS and Zonemaster::Engine:
+5) Install Zonemaster::LDNS and Zonemaster::Engine:
 
    ```sh
    sudo cpanm Zonemaster::LDNS Zonemaster::Engine
@@ -122,6 +128,7 @@ The command is expected to take a few seconds and print some results about the d
 -------
 
 [Declaration of prerequisites]: https://github.com/zonemaster/zonemaster#prerequisites
+[EPEL]: https://fedoraproject.org/wiki/EPEL
 [Installation on CentOS]: #installation-on-centos
 [Installation on Debian]: #installation-on-debian
 [Installation on FreeBSD]: #installation-on-freebsd


### PR DESCRIPTION
This adds access to the [EPEL] repository for CentOS. At the moment for Engine this only relieves us from two CPAN dependencies, but it does give us some more options to find replacements for other CPAN dependencies. Having it in the Engine installation instruction allows us to use EPEL dependencies in CLI and Backend as well, and I expect the easy wins will be greater for those components.

This is directly related to #451, which at the moment is inaccurate in its details and needs to be updated.

[EPEL]: https://fedoraproject.org/wiki/EPEL