### PR TITLE
Release 3.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ perl:
 before_install:
     - eval $(curl https://travis-perl.github.io/init) --auto
     - local-lib
-    - git clone --depth=1 --branch=develop https://github.com/zonemaster/zonemaster-ldns.git
+    - git clone --depth=1 --branch=$TRAVIS_BRANCH https://github.com/zonemaster/zonemaster-ldns.git
     - cpan-install --deps Devel::CheckLib ./zonemaster-ldns

--- a/Changes
+++ b/Changes
@@ -1,8 +1,19 @@
 Release history for Zonemaster component Zonemaster-Engine
 
+v3.0.2 2019-03-14 (pre-release version)
+
+ - Status
+   - This is a pre-release version not fully tested on all supported
+     OS's and Perl versions. This version will not be available on
+     CPAN.
+ - Fixes
+   - Never serialize numeric profile properties as JSON strings (#505)
+   - Add a forgotten dependency to the installation instruction.
+
+
 v3.0.1 2019-01-31 (pre-release version)
 
-- Status
+ - Status
    - This is a pre-release version not fully tested on all supported
      OS's and Perl versions. This version will not be available on
      CPAN.

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -249,6 +249,8 @@ sub _set {
             if ( exists $profile_properties_details{$property_name}->{max} and $value > $profile_properties_details{$property_name}->{max} ) {
                 die "Property $property_name value is out of limit (bigger)";
             }
+
+            $value = 0+ $value;    # Make sure JSON::PP doesn't serialize it as a JSON string
         }
     }
     else {


### PR DESCRIPTION
With 3.0.1 a unit test fails if you have an older version of JSON::PP or if you have the PERL_JSON_PP_USE_B environment variable set. This fixes that (#505).

This also adds libmodule-install-perl to the Debian installation instruction. This change was mistakenly merged to the master branch instead of the develop branch.

Edit: I've added a commit that makes Travis use the LDNS master branch for PRs against the Engine master branch. I verified that it works using #508 (Engine master uses LDNS master) and #509 (Engine develop uses LDNS develop). Fixes #507.