### PR TITLE
Make Engine master branch depend on the LDNS master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ perl:
 before_install:
     - eval $(curl https://travis-perl.github.io/init) --auto
     - local-lib
-    - git clone --depth=1 --branch=develop https://github.com/zonemaster/zonemaster-ldns.git
+    - git clone --depth=1 --branch=$TRAVIS_BRANCH https://github.com/zonemaster/zonemaster-ldns.git
     - cpan-install --deps Devel::CheckLib ./zonemaster-ldns


### PR DESCRIPTION
This PR is just a test. It should not be merged.

Make Engine master branch depend on the LDNS master branch.

This is the same change as #509, but against the master branch.