### PR TITLE
- Fixes zonemaster/zonemaster-engine#545

### DIFF
--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -215,7 +215,7 @@ sub delegation01 {
     my @child_ns_ipv4 = uniq map { $_->name->string } grep { $_->address->version == 4 } @child_ns;
     my @child_ns_ipv6 = uniq map { $_->name->string } grep { $_->address->version == 6 } @child_ns;
     my @child_ns_ipv4_addrs = uniq map { $_->address->ip } grep { $_->address->version == 4 } @child_ns;
-    my @child_ns_ipv6_addrs = uniq map { $_->address->short } grep { $_->address->version == 4 } @child_ns;
+    my @child_ns_ipv6_addrs = uniq map { $_->address->short } grep { $_->address->version == 6 } @child_ns;
 
     my $child_ns_ipv4_args = {
         count   => scalar( @child_ns_ipv4 ),


### PR DESCRIPTION
The message has been fixed.

From :

**ERROR     Child does not list enough (1) nameservers that resolve to IPv6 addresses (46.253.202.186;79.99.1.90;82.102.5.100). Lower limit set to 2.**

To :

**ERROR     Child does not list enough (1) nameservers that resolve to IPv6 addresses (2a02:750:7::4c6). Lower limit set to 2.**