### PR TITLE
Partial fix for translation on FreeBSD 11

### DIFF
--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -76,6 +76,10 @@ sub translate_tag {
         return $entry->string;
     }
 
+    # Partial workaround for FreeBSD 11. It works once, but then translation
+    # gets stuck on that locale.
+    local $ENV{LC_ALL} = $self->{locale};
+
     return __x( $string, %{ $entry->printable_args } );
 }
 

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -123,6 +123,12 @@ Zonemaster::Engine::Translator - translation support for Zonemaster
     my $trans = Zonemaster::Engine::Translator->new({ locale => 'sv_SE.UTF-8' });
     say $trans->to_string($entry);
 
+A side effect of constructing an object of this class is that the program's
+underlying locale for message catalogs (a.k.a. LC_MESSAGES) is updated.
+
+It does not make sense to create more than one object of this class because of
+the globally stateful nature of the locale attribute.
+
 =head1 ATTRIBUTES
 
 =over
@@ -133,6 +139,9 @@ The locale that should be used to find translation data. If not
 explicitly provided, defaults to (in order) the contents of the
 environment variable LANG, LC_ALL, LC_MESSAGES or, if none of them are
 set, to C<en_US.UTF-8>.
+
+Updating this attribute also causes an analogous update of the program's
+underlying LC_MESSAGES.
 
 =item data
 

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -13,7 +13,7 @@ use Zonemaster::Engine;
 use POSIX qw[setlocale LC_MESSAGES];
 use Locale::TextDomain qw[Zonemaster-Engine]; # This must be the same name as "name" in Makefile.PL
 
-has 'locale' => ( is => 'rw', isa => 'Str',     lazy => 1, builder => '_get_locale' );
+has 'locale' => ( is => 'rw', isa => 'Str' );
 has 'data'   => ( is => 'ro', isa => 'HashRef', lazy => 1, builder => '_load_data' );
 
 ###
@@ -23,7 +23,8 @@ has 'data'   => ( is => 'ro', isa => 'HashRef', lazy => 1, builder => '_load_dat
 sub BUILD {
     my ( $self ) = @_;
 
-    $self->locale;
+    my $locale = $self->{locale} // _get_locale();
+    $self->locale( $locale );
 
     return $self;
 }

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -28,9 +28,18 @@ sub BUILD {
     return $self;
 }
 
+# Get the program's underlying LC_MESSAGES.
+#
+# Side effect: Updates the program's underlying LC_MESSAGES to the returned
+# value.
 sub _get_locale {
-    my $locale = $ENV{LANG} || $ENV{LC_ALL} || $ENV{LC_MESSAGES} || 'en_US.UTF-8';
-    setlocale( LC_MESSAGES, $locale );
+    my $locale = setlocale( LC_MESSAGES, "" );
+
+    # C locale is not an option since our msgid and msgstr strings are sometimes
+    # different in C and en_US.UTF-8.
+    if ( $locale eq 'C' ) {
+        $locale = 'en_US.UTF-8';
+    }
 
     return $locale;
 }


### PR DESCRIPTION
The first commit is a partial fix for #546. It makes it possible to select translation for a single locale, but once you do that, translations stuck on that locale and you cannot switch to another. This is good enough for applications like Zonemaster CLI, but not Zonemaster Backend RPCAPI (which I believe reuses the same process for multiple requests).

The remaining commits are just other improvements I came up with while working on #546.