### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ perl:
     - "5.16"
 
 before_install:
+    - sudo apt-get install -y libidn11-dev
     - eval $(curl https://travis-perl.github.io/init) --auto
     - local-lib
     - git clone --depth=1 --branch=$TRAVIS_BRANCH https://github.com/zonemaster/zonemaster-ldns.git


### PR DESCRIPTION
Travis has started failing on everything. It seems that previously libidn11-dev got installed by default on the Travis machines, but for some reason that is no longer the case and we have to install it explicitly.

This is a sister PR to zonemaster/zonemaster-cli#114.