### PR TITLE
Verify absence of fuzzy translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ perl:
     - "5.20"
     - "5.16"
 
-env: PERL_CPANM_OPT="--verbose --notest --force --skip-satisfied"
+# PERL5LIB is needed for Perl 5.16 and 5.20 when we invoke perl from share/Makefile
+env:
+    - PERL5LIB="/home/travis/perl5/lib/perl5" PERL_CPANM_OPT="--verbose --notest --force --skip-satisfied"
 
 before_install:
     - sudo apt-get install -y libidn11-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,18 @@ perl:
     - "5.20"
     - "5.16"
 
+env: PERL_CPANM_OPT="--verbose --notest --force --skip-satisfied"
+
 before_install:
     - sudo apt-get install -y libidn11-dev
-    - eval $(curl https://travis-perl.github.io/init) --auto
-    - local-lib
+    - cpanm Devel::CheckLib Module::Install Module::Install::XSUtil
     - git clone --depth=1 --branch=$TRAVIS_BRANCH https://github.com/zonemaster/zonemaster-ldns.git
-    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil ./zonemaster-ldns
+    - cpanm ./zonemaster-ldns
+    - rm -rf zonemaster-ldns
+
+install:
+    - cpanm --installdeps .
+
+script:
+    - perl Makefile.PL
+    - make test

--- a/share/Makefile
+++ b/share/Makefile
@@ -3,6 +3,7 @@ MOFILES := $(POFILES:.po=.mo)
 POTFILE = Zonemaster-Engine.pot
 PMFILES = $(shell find ../lib -type f -name '*.pm')
 TESTMODULEFILES = $(shell find ../lib/Zonemaster/Engine/Test -type f -name '*.pm')
+NON_FUZZY_POFILES := $(shell echo $(POFILES) $(FUZZY_POFILES) | tr ' ' '\n' | sort | uniq -c | sed '/2/d;s/.* //')
 
 .PHONY: all update-po extract-pot
 
@@ -15,18 +16,21 @@ all: ${MOFILES} modules.txt
 update-po: extract-pot $(POFILES)
 
 extract-pot:
-	xgettext --output $(POTFILE) --sort-output --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)
+	@xgettext --output $(POTFILE) --sort-output --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)
 
 $(POTFILE): extract-pot
 
 %.po: $(POTFILE)
-	msgmerge --update --backup=none --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
+	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
 
 %.mo: %.po
 	@mkdir -p locale/$*/LC_MESSAGES
 	@# It must be 'Zonemaster-Engine' because that is defined in "name" in Makefile.PL
 	@perl -e 'use Locale::Msgfmt; msgfmt({in => $$ARGV[0], out => $$ARGV[1]});' $< locale/$*/LC_MESSAGES/Zonemaster-Engine.mo
 	@echo locale/$*/LC_MESSAGES/Zonemaster-Engine.mo
+
+show-fuzzy: $(NON_FUZZY_POFILES)
+	@for f in $(NON_FUZZY_POFILES) ; do msgattrib --only-fuzzy $$f ; done
 
 modules.txt: $(TESTMODULEFILES)
 	echo $(TESTMODULEFILES) | xargs basename -s .pm -a | grep -vE '^Basic$$' | sort > modules.txt

--- a/t/po-files.t
+++ b/t/po-files.t
@@ -1,0 +1,35 @@
+#!perl
+use v5.14.2;
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 1;
+
+use File::Basename qw( dirname );
+
+chdir dirname( dirname( __FILE__ ) ) or BAIL_OUT( "chdir: $!" );
+chdir 'share' or BAIL_OUT( "chdir: $!" );
+
+sub make {
+    my @make_args = @_;
+
+    my $command = join( ' ', 'make', @make_args );
+    warn "$command";
+    my $output = `$command`;
+
+    if ( $? == -1 ) {
+        BAIL_OUT( "failed to execute: $!" );
+    }
+    elsif ( $? & 127 ) {
+        BAIL_OUT( "child died with signal %d, %s coredump\n", ( $? & 127 ), ( $? & 128 ) ? 'with' : 'without' );
+    }
+
+    return $output, $? >> 8;
+}
+
+subtest "no fuzzy marks" => sub {
+    my @fuzzy_po_files = qw( da.po fr.po sv.po );
+    my ( $output, $status ) = make "show-fuzzy", sprintf( "FUZZY_POFILES='%s'", join( " ", @fuzzy_po_files ) );
+    is $status, 0,  'make show-fuzzy exits with value 0';
+    is $output, "", 'make show-fuzzy gives empty output';
+};

--- a/t/po-files.t
+++ b/t/po-files.t
@@ -13,8 +13,7 @@ chdir 'share' or BAIL_OUT( "chdir: $!" );
 sub make {
     my @make_args = @_;
 
-    my $command = join( ' ', 'make', @make_args );
-    warn "$command";
+    my $command = join( ' ', 'make', '--silent', '--no-print-directory', @make_args );
     my $output = `$command`;
 
     if ( $? == -1 ) {


### PR DESCRIPTION
This adds a new unit test ensuring that we don't accept [fuzzy markings](https://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html) in PO files into the develop branch.

Three out of four PO files do contain fuzzy entries, so they have been added to a whitelist to be opted out of this check. For each one there is an issue to clean up the PO file:
* #598 for `sv.po`
* #599 for `fr.po`
* #600 for `da.po`

There is also an issue (#597) to clean up the whitelist mechanism once all PO files have been removed from the whitelist.