### PR TITLE
- Fixes zonemaster/zonemaster-engine#102

### DIFF
--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -1,6 +1,6 @@
 package Zonemaster::Engine::Test::Basic;
 
-use version; our $VERSION = version->declare("v1.0.11");
+use version; our $VERSION = version->declare("v1.0.12");
 
 use strict;
 use warnings;
@@ -149,7 +149,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     HAS_NAMESERVERS => sub {
         __x    # HAS_NAMESERVERS
-          'Nameserver {ns} listed these servers as glue: {nsnlist}.', @_;
+          'Nameserver {ns}/{address} listed these servers as glue: {nsnlist}.', @_;
     },
     NO_GLUE_PREVENTS_NAMESERVER_TESTS => sub {
         __x    # NO_GLUE_PREVENTS_NAMESERVER_TESTS

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -1,6 +1,6 @@
 package Zonemaster::Engine::Test::Delegation;
 
-use version; our $VERSION = version->declare("v1.0.13");
+use version; our $VERSION = version->declare("v1.0.14");
 
 use strict;
 use warnings;
@@ -168,7 +168,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ENOUGH_NS_CHILD => sub {
         __x    # ENOUGH_NS_CHILD
-          "Child lists enough ({count}) nameservers ({ns}). Lower limit set to {minimum}.", @_;
+          "Child lists enough ({count}) nameservers ({nss}). Lower limit set to {minimum}.", @_;
     },
     ENOUGH_NS_DEL => sub {
         __x    # ENOUGH_NS_DEL
@@ -224,7 +224,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NOT_ENOUGH_NS_CHILD => sub {
         __x    # NOT_ENOUGH_NS_CHILD
-          "Child does not list enough ({count}) nameservers ({ns}). Lower limit set to {minimum}.", @_;
+          "Child does not list enough ({count}) nameservers ({nss}). Lower limit set to {minimum}.", @_;
     },
     NOT_ENOUGH_NS_DEL => sub {
         __x    # NOT_ENOUGH_NS_DEL
@@ -326,7 +326,7 @@ sub delegation01 {
     my $child_nsnames_args = {
         count   => scalar( @child_nsnames ),
         minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        ns      => join( q{;}, sort @child_nsnames ),
+        nss     => join( q{;}, sort @child_nsnames ),
     };
 
     # Check child NS names

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -1,6 +1,6 @@
 package Zonemaster::Engine::Test::Zone;
 
-use version; our $VERSION = version->declare("v1.0.7");
+use version; our $VERSION = version->declare("v1.0.8");
 
 use strict;
 use warnings;
@@ -195,7 +195,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MNAME_NOT_IN_GLUE => sub {
         __x    # MNAME_NOT_IN_GLUE
-          'SOA \'mname\' nameserver ({mname}) is not listed in "parent" NS records for tested zone ({ns}).', @_;
+          'SOA \'mname\' nameserver ({mname}) is not listed in "parent" NS records for tested zone ({nss}).', @_;
     },
     REFRESH_LOWER_THAN_RETRY => sub {
         __x    # REFRESH_LOWER_THAN_RETRY
@@ -294,7 +294,7 @@ sub zone01 {
                   info(
                     MNAME_NOT_IN_GLUE => {
                         mname => $soa_mname,
-                        ns    => join( q{;}, @{ Zonemaster::Engine::TestMethods->method2( $zone ) } ),
+                        nss   => join( q{;}, @{ Zonemaster::Engine::TestMethods->method2( $zone ) } ),
                     }
                   );
             }

--- a/share/da.po
+++ b/share/da.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-25 18:32+0200\n"
+"POT-Creation-Date: 2019-10-03 23:11+0200\n"
 "PO-Revision-Date: 2019-07-08\n"
 "Last-Translator: Niels Haarbo <haarbo@dk-hostmaster.dk>\n"
 "Language-Team: Zonemaster Team\n"
@@ -12,19 +12,25 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. SOA_NOT_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:277
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:283
 #, perl-brace-format
 msgid "A SOA query NOERROR response from {ns} was received empty."
 msgstr ""
 "En SOA-forespørgsel med RCODE NOERROR fra {ns} returnerede et tomt svar."
 
 #. DNSKEY_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:419
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:460
 #, perl-brace-format
 msgid "A signature for DNSKEY with tag {signature} was correctly signed."
 msgstr ""
 "Verificering af en signatur for DNSKEY-recorden med keytag {signature} "
 "lykkedes."
+
+#. ONE_SOA_MNAME
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:187
+#, fuzzy, perl-brace-format
+msgid "A single SOA mname value was seen ({mname})"
+msgstr "Et enkelt SOA RNAME blev returneret ({rname})"
 
 #. ONE_SOA_RNAME
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:191
@@ -101,7 +107,7 @@ msgid "All nameservers succeeded to resolve to an IP address."
 msgstr "Alle navneservere kan oversættes til en IP-adresse."
 
 #. NAMES_MATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:193
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:199
 msgid "All of the nameserver names are listed both at parent and child."
 msgstr "Alle navneservere listet findes både hos forælder og barn."
 
@@ -111,38 +117,50 @@ msgid "All reverse DNS entry matches name server name."
 msgstr "Alle PTR-records matcher navneservernavne."
 
 #. DISTINCT_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:137
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:143
 msgid "All the IP addresses used by the nameservers are unique"
 msgstr "Alle navneservernes IP-adresser er unikke."
 
+#. CHILD_DISTINCT_NS_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:127
+#, fuzzy
+msgid "All the IP addresses used by the nameservers in child are unique."
+msgstr "Alle navneservernes IP-adresser er unikke."
+
+#. DEL_DISTINCT_NS_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:135
+#, fuzzy
+msgid "All the IP addresses used by the nameservers in parent are unique."
+msgstr "Alle navneservernes IP-adresser er unikke."
+
 #. SOA_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:273
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:279
 msgid "All the nameservers have SOA record."
 msgstr "Alle navneservere har en SOA-record."
 
 #. ARE_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:117
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:123
 #, perl-brace-format
 msgid "All these nameservers are confirmed to be authoritative : {nsset}."
 msgstr "Alle disse navneservere er autoritative : {nsset}."
 
 #. DS_MATCH_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:451
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:492
 msgid "At least one DS record with a matching DNSKEY record was found."
 msgstr "Mindst en DS-record med med en matchende DNSKEY-record blev fundet."
 
 #. SOA_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:627
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:676
 msgid "At least one RRSIG correctly signs the SOA RRset."
 msgstr "Mindst en RRSIG-record signerer SOA RRset korrekt."
 
 #. NSEC_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:587
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:636
 msgid "At least one signature correctly signed the NSEC RRset."
 msgstr "Mindst en signatur signerede NSEC RRset korrekt."
 
 #. NSEC3_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:567
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:616
 msgid "At least one signature correctly signed the NSEC3 RRset."
 msgstr "Mindst en signatur signerede NSEC3 RRset korrekt."
 
@@ -170,7 +188,7 @@ msgstr ""
 "bindestreg."
 
 #. NO_KEYS_OR_NO_SIGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:529
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:578
 #, perl-brace-format
 msgid ""
 "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
@@ -180,7 +198,7 @@ msgstr ""
 "{sigs} RRSIG-records."
 
 #. NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:533
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:582
 #, perl-brace-format
 msgid ""
 "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
@@ -190,11 +208,31 @@ msgstr ""
 "RRSIG-records og {soas} SOA-records."
 
 #. NOT_ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
-#, perl-brace-format
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:227
+#, fuzzy, perl-brace-format
 msgid ""
-"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child does not list enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
+msgstr ""
+"Barnet returnerer ikke tilstrækkeligt antal ({count}) navneservere ({nss}). "
+"Mindsteværdi er sat til {minimum}."
+
+#. NOT_ENOUGH_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:203
+#, fuzzy, perl-brace-format
+msgid ""
+"Child does not list enough ({count}) nameservers that resolve to IPv4 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Barnet returnerer ikke tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi er sat til {minimum}."
+
+#. NOT_ENOUGH_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:215
+#, fuzzy, perl-brace-format
+msgid ""
+"Child does not list enough ({count}) nameservers that resolve to IPv6 "
+"addresses ({addrs}). Lower limit set to {minimum}."
 msgstr ""
 "Barnet returnerer ikke tilstrækkeligt antal ({count}) navneservere ({ns}). "
 "Mindsteværdi er sat til {minimum}."
@@ -209,7 +247,7 @@ msgstr ""
 "({addresses})."
 
 #. EXTRA_NAME_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:173
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:179
 #, perl-brace-format
 msgid "Child has nameserver(s) not listed at parent ({extra})."
 msgstr ""
@@ -217,14 +255,50 @@ msgstr ""
 "({extra})."
 
 #. ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
-#, perl-brace-format
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:171
+#, fuzzy, perl-brace-format
 msgid ""
-"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child lists enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
+msgstr ""
+"Barnet returnerer tilstrækkeligt antal ({count}) navneservere ({nss}). "
+"Mindsteværdi sat til {minimum}."
+
+#. ENOUGH_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:147
+#, fuzzy, perl-brace-format
+msgid ""
+"Child lists enough ({count}) nameservers that resolve to IPv4 addresses "
+"({addrs}). Lower limit set to {minimum}."
 msgstr ""
 "Barnet returnerer tilstrækkeligt antal ({count}) navneservere ({ns}). "
 "Mindsteværdi sat til {minimum}."
+
+#. ENOUGH_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:159
+#, fuzzy, perl-brace-format
+msgid ""
+"Child lists enough ({count}) nameservers that resolve to IPv6 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Barnet returnerer tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi sat til {minimum}."
+
+#. NO_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:235
+#, perl-brace-format
+msgid ""
+"Child lists no nameserver that resolves to an IPv4 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
+
+#. NO_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:247
+#, perl-brace-format
+msgid ""
+"Child lists no nameserver that resolves to an IPv6 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
 
 #. LOOKUP_ERROR
 #: ../lib/Zonemaster/Engine/Translator.pm:49
@@ -236,7 +310,7 @@ msgstr ""
 "{message}"
 
 #. DS_DOES_NOT_MATCH_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:439
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:480
 #, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} does not match the "
@@ -246,7 +320,7 @@ msgstr ""
 "recorden med samme keytag."
 
 #. DS_MATCHES_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:447
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:488
 #, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
@@ -256,7 +330,7 @@ msgstr ""
 "recorden med samme keytag."
 
 #. DS_DIGTYPE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:435
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:476
 #, perl-brace-format
 msgid "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
 msgstr ""
@@ -264,23 +338,79 @@ msgstr ""
 "OK."
 
 #. DS_DIGTYPE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:431
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:472
 #, perl-brace-format
 msgid "DS record with keytag {keytag} uses forbidden digest type {digtype}."
 msgstr ""
 "DS-recorden med keytag {keytag} anvender en illegal digest-type {digtype}."
 
+#. NOT_ENOUGH_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:209
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation does not list enough ({count}) nameservers that resolve to IPv4 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Barnet returnerer ikke tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi er sat til {minimum}."
+
+#. NOT_ENOUGH_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation does not list enough ({count}) nameservers that resolve to IPv6 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Barnet returnerer ikke tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi er sat til {minimum}."
+
 #. DELEGATION_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:395
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:436
 #, perl-brace-format
 msgid "Delegation from parent to child is not properly signed {reason}."
 msgstr ""
 "Delegeringen fra forælder- til børnezone er ikke korrekt signeret ({reason})."
 
 #. DELEGATION_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:399
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:440
 msgid "Delegation from parent to child is properly signed."
 msgstr "Delegeringen fra forælder- til børnezonen er korrekt signeret."
+
+#. ENOUGH_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:153
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation lists enough ({count}) nameservers that resolve to IPv4 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Barnet returnerer tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi sat til {minimum}."
+
+#. ENOUGH_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation lists enough ({count}) nameservers that resolve to IPv6 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Barnet returnerer tilstrækkeligt antal ({count}) navneservere ({ns}). "
+"Mindsteværdi sat til {minimum}."
+
+#. NO_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:241
+#, perl-brace-format
+msgid ""
+"Delegation lists no nameserver that resolves to an IPv4 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
+
+#. NO_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
+#, perl-brace-format
+msgid ""
+"Delegation lists no nameserver that resolves to an IPv6 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
 
 #. SOA_SERIAL_VARIATION
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:213
@@ -375,8 +505,14 @@ msgstr "Domænenavnet er for langt ({fqdnlength}/{max})."
 msgid "Domain's authoritative nameservers do not belong to the same AS."
 msgstr "Domænets navneservere er i flere AS'er."
 
+#. NS_ERROR
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:309
+#, fuzzy, perl-brace-format
+msgid "Erroneous response from nameserver {ns}/{address}."
+msgstr "Intet svar på NS-forespørgsel fra nameserveren {ns}/{address}."
+
 #. DS_RFC4509_NOT_VALID
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:459
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:500
 msgid ""
 "Existing DS with digest type 2, while they do not match DNSKEY records, "
 "prevent use of DS with digest type 1 (RFC4509, section 3)."
@@ -396,7 +532,7 @@ msgid "Followed a fake delegation."
 msgstr "Fulgte en falsk delegering."
 
 #. DS_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:443
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:484
 #, perl-brace-format
 msgid "Found DS records with tags {keytags}."
 msgstr "Fandt DS-records med tags {keytags}."
@@ -438,18 +574,31 @@ msgstr ""
 msgid "Glue records are consistent between glue and authoritative data."
 msgstr "Glue-records er konsistente mellem forælder og barn."
 
+#. CHILD_NS_SAME_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:131
+#, fuzzy, perl-brace-format
+msgid "IP {address} in child refers to multiple nameservers ({nss})."
+msgstr "IP-adressen {address} refererer til flere navneservere ({nss})."
+
+#. DEL_NS_SAME_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:139
+#, fuzzy, perl-brace-format
+msgid "IP {address} in parent refers to multiple nameservers ({nss})."
+msgstr "IP-adressen {address} refererer til flere navneservere ({nss})."
+
 #. SAME_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:269
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:275
 #, perl-brace-format
 msgid "IP {address} refers to multiple nameservers ({nss})."
 msgstr "IP-adressen {address} refererer til flere navneservere ({nss})."
 
 #. IPV4_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:144
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:181
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:187
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:273
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:542
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
 #, perl-brace-format
 msgid "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr ""
@@ -470,11 +619,12 @@ msgstr ""
 "IPv4 er aktiveret, kan udføre \"{rrtype}\"-forespørgsel til {ns}/{address}."
 
 #. IPV6_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:148
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:185
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:191
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:277
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:546
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
 #, perl-brace-format
 msgid "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr ""
@@ -505,7 +655,7 @@ msgstr ""
 "forespørgsel via EDNS (version 0) efter {dname}."
 
 #. KEY_DETAILS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:505
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:554
 #, perl-brace-format
 msgid ""
 "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
@@ -538,25 +688,25 @@ msgid "Module {module} finished running."
 msgstr "Modulet {module} afsluttede."
 
 #. NSEC_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:579
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:628
 #, perl-brace-format
 msgid "NSEC covers {name}."
 msgstr "NSEC dækker {name}."
 
 #. NSEC_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:575
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:624
 #, perl-brace-format
 msgid "NSEC does not cover {name}."
 msgstr "NSEC dækker ikke {name}."
 
 #. NSEC3_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:559
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:608
 #, perl-brace-format
 msgid "NSEC3 record covers {name}."
 msgstr "NSEC3-record dækker {name}."
 
 #. NSEC3_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:555
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:604
 #, perl-brace-format
 msgid "NSEC3 record does not cover {name}."
 msgstr "NSEC3-record dækker ikke {name}."
@@ -630,23 +780,23 @@ msgid "Nameserver {ns} has an IP address ({address}) without PTR configured."
 msgstr ""
 "Navneserveren {ns} har en IP-adresse ({address}) uden konfigureret PTR."
 
-#. HAS_NAMESERVERS
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
-#, perl-brace-format
-msgid "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr "Navneserveren {ns} returnerede disse servere som glue: {nsnlist}."
-
 #. IS_NOT_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:189
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:195
 #, perl-brace-format
 msgid "Nameserver {ns} response is not authoritative on {proto} port 53."
 msgstr "Navneserveren {ns} svarede ikke autoritativt på {proto} port 53."
 
 #. NS_RR_IS_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:259
 #, perl-brace-format
 msgid "Nameserver {ns} {address_type} RR point to CNAME."
 msgstr "På navneservern {ns} returnerer {address_type} et CNAME."
+
+#. UNSUPPORTED_EDNS_VER
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:333
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} accepts an unsupported EDNS version."
+msgstr "Navneserveren {ns}/{address} er ikke rekursiv."
 
 #. NAMESERVER_HAS_TCP_53
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:128
@@ -684,7 +834,7 @@ msgstr "Navneserveren {ns}/{address} svarede ikke på en NS-forespørgsel."
 
 #. NO_RESPONSE
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:167
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:547
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:596
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} did not respond."
 msgstr "Navneserveren {ns}/{address} svarede ikke."
@@ -724,6 +874,12 @@ msgstr "Navneserveren {ns}/{address} understøtter ikke EDNS0 (svarer FORMERR)."
 msgid "Nameserver {ns}/{address} dropped AAAA query."
 msgstr "Navneserveren {ns}/{address} mistede en AAAA-forespørgsel."
 
+#. Z_FLAGS_NOTCLEAR
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:345
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} has one or more unknown EDNS Z flag bits set."
+msgstr "Navneserveren {ns}/{address} svarede ikke på en NS-forespørgsel."
+
 #. IS_A_RECURSOR
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:281
 #, perl-brace-format
@@ -735,6 +891,12 @@ msgstr "Navneserveren {ns}/{address} er rekursiv."
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} is not a recursor."
 msgstr "Navneserveren {ns}/{address} er ikke rekursiv."
+
+#. HAS_NAMESERVERS
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} listed these servers as glue: {nsnlist}."
+msgstr "Navneserveren {ns}/{address} returnerede disse servere som glue: {nsnlist}."
 
 #. NAMESERVER_NO_TCP_53
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:136
@@ -766,6 +928,28 @@ msgstr ""
 "Navneserveren {ns}/{address} svarede på en SOA-forespørgsel fra en anden "
 "kilde ({source})."
 
+#. MISSING_OPT_IN_TRUNCATED
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:285
+#, fuzzy, perl-brace-format
+msgid ""
+"Nameserver {ns}/{address} replies on an EDNS query with a truncated response "
+"without EDNS."
+msgstr ""
+"Navneserveren {ns}/{address} svarede på en SOA-forespørgsel fra en anden "
+"kilde ({source})."
+
+#. NO_RESPONSE_DNSKEY
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:592
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} responded with no DNSKEY record(s)."
+msgstr "Navneserveren {ns}/{address} svarede ikke på en NS-forespørgsel."
+
+#. UNKNOWN_OPTION_CODE
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:329
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} responds with an unknown ENDS OPTION-CODE."
+msgstr "Navneserveren {ns}/{address} svarede ikke på en NS-forespørgsel."
+
 #. HAS_A_RECORDS
 #: ../lib/Zonemaster/Engine/Test/Basic.pm:144
 #, fuzzy, perl-brace-format
@@ -785,22 +969,22 @@ msgid "Nameservers did not respond to A query."
 msgstr "Navneserverne svarede ikke på en A-forespørgsel."
 
 #. ADDITIONAL_DNSKEY_SKIPPED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:353
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:398
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr "Ingen DNSKEY-records fundet. Yderligere tests ignoreret."
 
 #. NO_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:521
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:570
 msgid "No DNSKEYs were returned."
 msgstr "Ingen DNSKEY-records blev returneret."
 
 #. NO_COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:517
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:566
 msgid "No DS record had a DNSKEY with a matching keytag."
 msgstr "Ingen DS-record havde en DNSKEY-record med matchende keytag."
 
 #. DS_MATCH_NOT_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:455
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:496
 msgid "No DS record with a matching DNSKEY record was found."
 msgstr "Ingen DS-record med en matchende DNSKEY-record blev fundet."
 
@@ -827,7 +1011,7 @@ msgstr ""
 "Ingen NS-records for den testede zone fra forælderzonen. NS-test afbrydes."
 
 #. SOA_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:615
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:664
 msgid "No RRSIG correctly signed the SOA RRset."
 msgstr "Ingen RRSIG signerede SOA RRset korrekt."
 
@@ -853,7 +1037,7 @@ msgid "No nameserver address is in an AS."
 msgstr "Ingen navneserver har en adresse i et AS."
 
 #. NS_RR_NO_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:257
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:263
 msgid "No nameserver point to CNAME alias."
 msgstr "Ingen NS-record peger på et CNAME-alias."
 
@@ -898,6 +1082,14 @@ msgstr "Intet svar fra navneserverne på PTR-forespørgsel ({reverse})."
 msgid "No response from nameserver(s) on SOA queries."
 msgstr "Intet svar fra navneserver(ne) på forespørgsel på SOA-record."
 
+#. NO_RESPONSE
+#: ../lib/Zonemaster/Engine/Test/Syntax.pm:213
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:301
+#, fuzzy, perl-brace-format
+msgid "No response from {ns}/{address} asking for {dname}."
+msgstr ""
+"Intet svar fra {ns}/{address} når EDNS er brugt i forespørgslen på {dname}."
+
 #. BREAKS_ON_EDNS
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:208
 #, perl-brace-format
@@ -908,12 +1100,12 @@ msgstr ""
 "Intet svar fra {ns}/{address} når EDNS er brugt i forespørgslen på {dname}."
 
 #. NSEC_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:583
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:632
 msgid "No signature correctly signed the NSEC RRset."
 msgstr "Ingen signatur signerede NSEC RRset korrekt."
 
 #. NSEC3_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:563
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:612
 msgid "No signature correctly signed the NSEC3 RRset."
 msgstr "Ingen signatur signerede NSEC3 RRset korrekt."
 
@@ -932,7 +1124,7 @@ msgstr ""
 "{names}."
 
 #. TOTAL_NAME_MISMATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:281
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:287
 msgid "None of the nameservers listed at the parent are listed at the child."
 msgstr "Ingen af de navneservere som listes hos forælderen listes hos barnet."
 
@@ -955,7 +1147,7 @@ msgstr ""
 "bytes (prøv med \"{command}\")."
 
 #. NOT_ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:225
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:231
 #, perl-brace-format
 msgid ""
 "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
@@ -980,7 +1172,7 @@ msgstr ""
 "({addresses})."
 
 #. EXTRA_NAME_PARENT
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:177
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:183
 #, perl-brace-format
 msgid "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr ""
@@ -988,7 +1180,7 @@ msgstr ""
 "({extra})."
 
 #. ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:169
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:175
 #, perl-brace-format
 msgid ""
 "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
@@ -1004,14 +1196,14 @@ msgid "Profile was read from {name}."
 msgstr "Profile blev hentet fra {name}."
 
 #. RRSIG_EXPIRATION
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:607
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:656
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
 msgstr "RRSIG med keytag {tag} dækkende typerne {types} udløber : {date}."
 
 #. DURATION_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:471
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:512
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1021,7 +1213,7 @@ msgstr ""
 "på {duration} sekunder, hvilket er OK."
 
 #. DURATION_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:465
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:506
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1031,7 +1223,7 @@ msgstr ""
 "på {duration} sekunder, hvilket er for længe."
 
 #. REMAINING_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:595
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:644
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1041,7 +1233,7 @@ msgstr ""
 "gyldighed på {duration} sekunder, hvilket er for længe."
 
 #. REMAINING_SHORT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:601
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:650
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1051,7 +1243,7 @@ msgstr ""
 "gyldighed på {duration} sekunder, hvilket er for lidt."
 
 #. RRSIG_EXPIRED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:611
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:660
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has already expired "
@@ -1061,7 +1253,7 @@ msgstr ""
 "(udløbsdato er: {expiration})."
 
 #. SOA_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:623
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:672
 #, perl-brace-format
 msgid "RRSIG {signature} correctly signs SOA RRset."
 msgstr "RRSIG {signature} signerer SOA RRset korrekt."
@@ -1169,10 +1361,10 @@ msgstr "SOA 'MNAME'-navneserveren ({mname}) er autoritativ for zonen '{zone}'."
 
 #. MNAME_NOT_IN_GLUE
 #: ../lib/Zonemaster/Engine/Test/Zone.pm:198
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
-"tested zone ({ns})."
+"tested zone ({nss})."
 msgstr ""
 "Navneserveren i SOA 'MNAME' ({mname}) er ikke blandt de NS-records ({ns}) "
 "som angivet i forælderzonen \"parent\"."
@@ -1319,6 +1511,12 @@ msgstr ""
 msgid "Saw {count} NS set."
 msgstr "Fandt {count} NS-sæt."
 
+#. MULTIPLE_SOA_MNAMES
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:151
+#, fuzzy, perl-brace-format
+msgid "Saw {count} SOA mname."
+msgstr "Så {count} forskellige SOA RNAME."
+
 #. MULTIPLE_SOA_RNAMES
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:155
 #, perl-brace-format
@@ -1338,7 +1536,7 @@ msgid "Saw {count} SOA time parameter set."
 msgstr "Så {count} forskellige konfigurationer af SOA-tidsparametre."
 
 #. EXTRA_PROCESSING_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:481
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:522
 #, perl-brace-format
 msgid "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
 msgstr ""
@@ -1346,7 +1544,7 @@ msgstr ""
 "records."
 
 #. EXTRA_PROCESSING_BROKEN
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:477
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:518
 #, perl-brace-format
 msgid ""
 "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
@@ -1355,7 +1553,7 @@ msgstr ""
 "records."
 
 #. DNSKEY_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:415
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:456
 #, perl-brace-format
 msgid ""
 "Signature for DNSKEY with tag {signature} failed to verify with error "
@@ -1370,8 +1568,18 @@ msgstr ""
 msgid "Target ({info}) found to deliver e-mail for the domain name."
 msgstr "Adressen ({info}) modtager e-mail for domænenavnet."
 
+#. ALGORITHM_NOT_ZONE_SIGN
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
+#, fuzzy, perl-brace-format
+msgid ""
+"The DNSKEY with tag {keytag} uses algorithm number not meant for zone "
+"signing{algorithm}/({description})."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender den private algoritme med nummer "
+"{algorithm}/({description})."
+
 #. ALGORITHM_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:375
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:416
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
@@ -1380,8 +1588,18 @@ msgstr ""
 "DNSKEY-recorden med tag {keytag} anvender algoritme nummer {algorithm}/"
 "({description}), hvilket er OK."
 
+#. ALGORITHM_NOT_RECOMMENDED
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:406
+#, fuzzy, perl-brace-format
+msgid ""
+"The DNSKEY with tag {keytag} uses an algorithm number {algorithm}/"
+"({description} which which is not recommended to be used."
+msgstr ""
+"DNSKEY-recorden med tag {keytag} anvender algoritme nummer {algorithm}/"
+"({description}), hvilket er OK."
+
 #. ALGORITHM_DEPRECATED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:361
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:402
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
@@ -1391,7 +1609,7 @@ msgstr ""
 "{algorithm}/({description})."
 
 #. ALGORITHM_PRIVATE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:379
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:420
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
@@ -1401,7 +1619,7 @@ msgstr ""
 "{algorithm}/({description})."
 
 #. ALGORITHM_RESERVED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:383
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:424
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
@@ -1411,7 +1629,7 @@ msgstr ""
 "{algorithm}/({description})."
 
 #. ALGORITHM_UNASSIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:387
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:428
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
@@ -1426,13 +1644,21 @@ msgstr ""
 msgid "The SOA RNAME field ({rname}) is compliant with RFC2822."
 msgstr "SOA RNAME værdi ({rname}) overholder RFC2822."
 
+#. RNAME_MAIL_DOMAIN_INVALID
+#: ../lib/Zonemaster/Engine/Test/Syntax.pm:229
+#, perl-brace-format
+msgid ""
+"The SOA RNAME mail domain ({domain}) cannot be resolved to a mail server "
+"with an IP address."
+msgstr ""
+
 #. DNSKEY_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:423
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:464
 msgid "The apex DNSKEY RRset was correcly signed."
 msgstr "DNSKEY RRset i zonetoppen var korrekt signeret."
 
 #. DNSKEY_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:452
 msgid "The apex DNSKEY RRset was not correctly signed."
 msgstr "DNSKEY RRset i zonetoppen var ikke korrekt signeret."
 
@@ -1484,19 +1710,19 @@ msgid "The module {name} was disabled by the policy."
 msgstr "Modulet {name} var deaktiveret i politikken."
 
 #. ITERATIONS_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:501
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:550
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is OK."
 msgstr "Antallet af NSEC3-iterationer er {count}, hvilket er OK."
 
 #. MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:509
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:558
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is on the high side."
 msgstr "Antallet af NSEC3-iterationer er {count}, hvilket er højt."
 
 #. TOO_MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:631
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:680
 #, perl-brace-format
 msgid ""
 "The number of NSEC3 iterations is {count}, which is too high for key length "
@@ -1506,7 +1732,7 @@ msgstr ""
 "nøglelængden {keylength}."
 
 #. REFERRAL_SIZE_TOO_LARGE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:261
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:267
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is larger than 512 octets (it is "
@@ -1516,7 +1742,7 @@ msgstr ""
 "oktetter ({size})."
 
 #. REFERRAL_SIZE_OK
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:265
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:271
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is smaller than 513 octets (it "
@@ -1526,33 +1752,33 @@ msgstr ""
 "eller lig med 512 oktetter ({size})."
 
 #. HAS_NSEC
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:493
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:534
 msgid "The zone has NSEC records."
 msgstr "Zonen indeholder NSEC-records."
 
 #. HAS_NSEC3_OPTOUT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:485
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:526
 msgid "The zone has NSEC3 opt-out records."
 msgstr "Zonen indeholder NSEC3 opt-out records."
 
 #. HAS_NSEC3
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:489
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:530
 msgid "The zone has NSEC3 records."
 msgstr "Zonen indeholder NSEC3-records."
 
 #. NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:551
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:600
 msgid "The zone is not signed with DNSSEC."
 msgstr "Zonen er ikke signeret med DNSSEC."
 
 #. COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:391
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:432
 #, perl-brace-format
 msgid "There are both DS and DNSKEY records with key tags {keytags}."
 msgstr "Der findes både DS- and DNSKEY-records med keytag {keytags}."
 
 #. NEITHER_DNSKEY_NOR_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:513
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:562
 msgid "There are neither DS nor DNSKEY records for the zone."
 msgstr "Zonen indeholder hverken DS- eller DNSKEY-records."
 
@@ -1576,7 +1802,7 @@ msgid ""
 msgstr "'@' må ikke anvendes i SOA RNAME ({rname})."
 
 #. NSEC_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:591
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:640
 #, perl-brace-format
 msgid "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 msgstr ""
@@ -1584,7 +1810,7 @@ msgstr ""
 "'{error}'."
 
 #. NSEC3_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:571
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:620
 #, perl-brace-format
 msgid "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
 msgstr ""
@@ -1592,7 +1818,7 @@ msgstr ""
 "'{error}'."
 
 #. SOA_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:619
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:668
 #, perl-brace-format
 msgid ""
 "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
@@ -1624,7 +1850,7 @@ msgid "Using version {version} of the Zonemaster engine."
 msgstr "Anvender version {version} af Zonemasters testmotor."
 
 #. INVALID_NAME_RCODE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:497
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:538
 #, perl-brace-format
 msgid ""
 "When asked for the name {name}, which must not exist, the response had RCODE "
@@ -1723,7 +1949,7 @@ msgid "[ASN:RAW] {address};{data}"
 msgstr "[ASN:RAW] {address};{data}"
 
 #. DNSKEY_BUT_NOT_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:407
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:448
 #, perl-brace-format
 msgid "{child} sent a DNSKEY record, but {parent} did not send a DS record."
 msgstr ""
@@ -1731,19 +1957,19 @@ msgstr ""
 "record."
 
 #. NO_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:525
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:574
 #, perl-brace-format
 msgid "{from} returned no DS records for {zone}."
 msgstr "{from} returnerede ingen DS-records for {zone}."
 
 #. DNSKEY_AND_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:403
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:444
 #, perl-brace-format
 msgid "{parent} sent a DS record, and {child} a DNSKEY record."
 msgstr "{parent} returnerede en DS-record, og {child} en DNSKEY-record."
 
 #. DS_BUT_NOT_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:427
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:468
 #, perl-brace-format
 msgid "{parent} sent a DS record, but {child} did not send a DNSKEY record."
 msgstr ""
@@ -1751,7 +1977,7 @@ msgstr ""
 "record."
 
 #. NO_NSEC3PARAM
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:539
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:588
 #, perl-brace-format
 msgid "{server} returned no NSEC3PARAM records."
 msgstr "{server} returnerede ingen NSEC3PARAM-records."

--- a/share/en.po
+++ b/share/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-25 18:32+0200\n"
+"POT-Creation-Date: 2019-10-03 23:11+0200\n"
 "PO-Revision-Date: 2017-12-18\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
@@ -12,13 +12,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. SOA_NOT_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:277
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:283
 #, perl-brace-format
 msgid "A SOA query NOERROR response from {ns} was received empty."
 msgstr "Empty NOERROR response to SOA query was received from {ns}."
 
 #. DNSKEY_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:419
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:460
 #, perl-brace-format
 msgid "A signature for DNSKEY with tag {signature} was correctly signed."
 msgstr "A signature for DNSKEY with tag {signature} was correctly signed."
@@ -105,7 +105,7 @@ msgid "All nameservers succeeded to resolve to an IP address."
 msgstr "All nameservers succeeded to resolve to an IP address."
 
 #. NAMES_MATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:193
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:199
 msgid "All of the nameserver names are listed both at parent and child."
 msgstr "All of the nameserver names are listed both at parent and child."
 
@@ -115,48 +115,48 @@ msgid "All reverse DNS entry matches name server name."
 msgstr "Every reverse DNS entry matches name server name."
 
 #. DISTINCT_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:137
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:143
 msgid "All the IP addresses used by the nameservers are unique"
 msgstr "All the IP addresses used by the nameservers are unique"
 
 #. CHILD_DISTINCT_NS_IP
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:121
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:127
 msgid "All the IP addresses used by the nameservers in child are unique."
 msgstr "All the IP addresses used by the nameservers in child are unique."
 
 #. DEL_DISTINCT_NS_IP
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:129
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:135
 msgid "All the IP addresses used by the nameservers in parent are unique."
 msgstr "All the IP addresses used by the nameservers in parent are unique."
 
 #. SOA_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:273
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:279
 msgid "All the nameservers have SOA record."
 msgstr "All the nameservers have SOA record."
 
 #. ARE_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:117
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:123
 #, perl-brace-format
 msgid "All these nameservers are confirmed to be authoritative : {nsset}."
 msgstr "All these nameservers are confirmed to be authoritative : {nsset}."
 
 #. DS_MATCH_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:451
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:492
 msgid "At least one DS record with a matching DNSKEY record was found."
 msgstr "At least one DS record with a matching DNSKEY record was found."
 
 #. SOA_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:627
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:676
 msgid "At least one RRSIG correctly signs the SOA RRset."
 msgstr "At least one RRSIG correctly signs the SOA RRset."
 
 #. NSEC_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:587
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:636
 msgid "At least one signature correctly signed the NSEC RRset."
 msgstr "At least one signature correctly signed the NSEC RRset."
 
 #. NSEC3_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:567
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:616
 msgid "At least one signature correctly signed the NSEC3 RRset."
 msgstr "At least one signature correctly signed the NSEC3 RRset."
 
@@ -182,7 +182,7 @@ msgid "Both ends of all labels of the domain name ({name}) have no hyphens."
 msgstr "Neither end of any label in the domain name ({name}) has a hyphen."
 
 #. NO_KEYS_OR_NO_SIGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:529
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:578
 #, perl-brace-format
 msgid ""
 "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
@@ -192,7 +192,7 @@ msgstr ""
 "{sigs} RRSIG records."
 
 #. NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:533
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:582
 #, perl-brace-format
 msgid ""
 "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
@@ -202,17 +202,17 @@ msgstr ""
 "RRSIG records and {soas} SOA records."
 
 #. NOT_ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
-#, perl-brace-format
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:227
+#, fuzzy, perl-brace-format
 msgid ""
-"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child does not list enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
 msgstr ""
-"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child does not list enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
 
 #. NOT_ENOUGH_IPV4_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:197
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:203
 #, perl-brace-format
 msgid ""
 "Child does not list enough ({count}) nameservers that resolve to IPv4 "
@@ -222,7 +222,7 @@ msgstr ""
 "addresses ({addrs}). Lower limit set to {minimum}."
 
 #. NOT_ENOUGH_IPV6_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:209
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:215
 #, perl-brace-format
 msgid ""
 "Child does not list enough ({count}) nameservers that resolve to IPv6 "
@@ -240,23 +240,23 @@ msgstr ""
 "Child has extra nameserver IP address(es) not listed at parent ({addresses})."
 
 #. EXTRA_NAME_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:173
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:179
 #, perl-brace-format
 msgid "Child has nameserver(s) not listed at parent ({extra})."
 msgstr "Child has nameserver(s) not listed at parent ({extra})."
 
 #. ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
-#, perl-brace-format
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:171
+#, fuzzy, perl-brace-format
 msgid ""
-"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child lists enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
 msgstr ""
-"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child lists enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
 
 #. ENOUGH_IPV4_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:141
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:147
 #, perl-brace-format
 msgid ""
 "Child lists enough ({count}) nameservers that resolve to IPv4 addresses "
@@ -266,7 +266,7 @@ msgstr ""
 "({addrs}). Lower limit set to {minimum}."
 
 #. ENOUGH_IPV6_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:153
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:159
 #, perl-brace-format
 msgid ""
 "Child lists enough ({count}) nameservers that resolve to IPv6 addresses "
@@ -276,7 +276,7 @@ msgstr ""
 "({addrs}). Lower limit set to {minimum}."
 
 #. NO_IPV4_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:229
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:235
 #, perl-brace-format
 msgid ""
 "Child lists no nameserver that resolves to an IPv4 address. If any were "
@@ -286,7 +286,7 @@ msgstr ""
 "present, the minimum allowed would be {minimum}."
 
 #. NO_IPV6_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:241
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:247
 #, perl-brace-format
 msgid ""
 "Child lists no nameserver that resolves to an IPv6 address. If any were "
@@ -304,7 +304,7 @@ msgstr ""
 "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
 
 #. DS_DOES_NOT_MATCH_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:439
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:480
 #, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} does not match the "
@@ -314,7 +314,7 @@ msgstr ""
 "DNSKEY with the same tag."
 
 #. DS_MATCHES_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:447
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:488
 #, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
@@ -324,20 +324,20 @@ msgstr ""
 "with the same tag."
 
 #. DS_DIGTYPE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:435
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:476
 #, perl-brace-format
 msgid "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
 msgstr ""
 "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
 
 #. DS_DIGTYPE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:431
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:472
 #, perl-brace-format
 msgid "DS record with keytag {keytag} uses forbidden digest type {digtype}."
 msgstr "DS record with keytag {keytag} uses forbidden digest type {digtype}."
 
 #. NOT_ENOUGH_IPV4_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:203
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:209
 #, perl-brace-format
 msgid ""
 "Delegation does not list enough ({count}) nameservers that resolve to IPv4 "
@@ -347,7 +347,7 @@ msgstr ""
 "addresses ({addrs}). Lower limit set to {minimum}."
 
 #. NOT_ENOUGH_IPV6_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:215
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
 #, perl-brace-format
 msgid ""
 "Delegation does not list enough ({count}) nameservers that resolve to IPv6 "
@@ -357,18 +357,18 @@ msgstr ""
 "addresses ({addrs}). Lower limit set to {minimum}."
 
 #. DELEGATION_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:395
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:436
 #, perl-brace-format
 msgid "Delegation from parent to child is not properly signed {reason}."
 msgstr "Delegation from parent to child is not properly signed ({reason})."
 
 #. DELEGATION_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:399
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:440
 msgid "Delegation from parent to child is properly signed."
 msgstr "Delegation from parent to child is properly signed."
 
 #. ENOUGH_IPV4_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:147
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:153
 #, perl-brace-format
 msgid ""
 "Delegation lists enough ({count}) nameservers that resolve to IPv4 addresses "
@@ -378,7 +378,7 @@ msgstr ""
 "({addrs}). Lower limit set to {minimum}."
 
 #. ENOUGH_IPV6_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:159
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
 #, perl-brace-format
 msgid ""
 "Delegation lists enough ({count}) nameservers that resolve to IPv6 addresses "
@@ -388,7 +388,7 @@ msgstr ""
 "({addrs}). Lower limit set to {minimum}."
 
 #. NO_IPV4_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:235
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:241
 #, perl-brace-format
 msgid ""
 "Delegation lists no nameserver that resolves to an IPv4 address. If any were "
@@ -398,7 +398,7 @@ msgstr ""
 "present, the minimum allowed would be {minimum}."
 
 #. NO_IPV6_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:247
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
 #, perl-brace-format
 msgid ""
 "Delegation lists no nameserver that resolves to an IPv6 address. If any were "
@@ -505,7 +505,7 @@ msgid "Erroneous response from nameserver {ns}/{address}."
 msgstr "Erroneous response from nameserver {ns}/{address}."
 
 #. DS_RFC4509_NOT_VALID
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:459
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:500
 msgid ""
 "Existing DS with digest type 2, while they do not match DNSKEY records, "
 "prevent use of DS with digest type 1 (RFC4509, section 3)."
@@ -525,7 +525,7 @@ msgid "Followed a fake delegation."
 msgstr "Followed a fake delegation."
 
 #. DS_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:443
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:484
 #, perl-brace-format
 msgid "Found DS records with tags {keytags}."
 msgstr "Found DS records with tags {keytags}."
@@ -566,29 +566,30 @@ msgid "Glue records are consistent between glue and authoritative data."
 msgstr "Glue records are consistent between glue and authoritative data."
 
 #. CHILD_NS_SAME_IP
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:125
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:131
 #, perl-brace-format
 msgid "IP {address} in child refers to multiple nameservers ({nss})."
 msgstr "IP {address} in child refers to multiple nameservers ({nss})."
 
 #. DEL_NS_SAME_IP
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:133
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:139
 #, perl-brace-format
 msgid "IP {address} in parent refers to multiple nameservers ({nss})."
 msgstr "IP {address} in parent refers to multiple nameservers ({nss})."
 
 #. SAME_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:269
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:275
 #, perl-brace-format
 msgid "IP {address} refers to multiple nameservers ({nss})."
 msgstr "IP {address} refers to multiple nameservers ({nss})."
 
 #. IPV4_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:144
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:181
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:187
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:273
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:542
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
 #, perl-brace-format
 msgid "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
@@ -606,11 +607,12 @@ msgid "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
 
 #. IPV6_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:148
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:185
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:191
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:277
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:546
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
 #, perl-brace-format
 msgid "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
@@ -638,7 +640,7 @@ msgstr ""
 "query with EDNS (version 0) asking for {dname}."
 
 #. KEY_DETAILS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:505
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:554
 #, perl-brace-format
 msgid ""
 "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
@@ -670,25 +672,25 @@ msgid "Module {module} finished running."
 msgstr "Module {module} finished running."
 
 #. NSEC_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:579
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:628
 #, perl-brace-format
 msgid "NSEC covers {name}."
 msgstr "NSEC covers {name}."
 
 #. NSEC_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:575
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:624
 #, perl-brace-format
 msgid "NSEC does not cover {name}."
 msgstr "NSEC does not cover {name}."
 
 #. NSEC3_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:559
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:608
 #, perl-brace-format
 msgid "NSEC3 record covers {name}."
 msgstr "NSEC3 record covers {name}."
 
 #. NSEC3_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:555
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:604
 #, perl-brace-format
 msgid "NSEC3 record does not cover {name}."
 msgstr "NSEC3 record does not cover {name}."
@@ -761,20 +763,14 @@ msgstr ""
 msgid "Nameserver {ns} has an IP address ({address}) without PTR configured."
 msgstr "Nameserver {ns} has an IP address ({address}) without PTR configured."
 
-#. HAS_NAMESERVERS
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
-#, perl-brace-format
-msgid "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr "Nameserver {ns} listed these servers as glue: {nsnlist}."
-
 #. IS_NOT_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:189
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:195
 #, perl-brace-format
 msgid "Nameserver {ns} response is not authoritative on {proto} port 53."
 msgstr "Nameserver {ns} response is not authoritative on {proto} port 53."
 
 #. NS_RR_IS_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:259
 #, perl-brace-format
 msgid "Nameserver {ns} {address_type} RR point to CNAME."
 msgstr "Nameserver {ns} {address_type} RR point to CNAME."
@@ -821,7 +817,7 @@ msgstr "Nameserver {ns}/{address} did not respond to NS query."
 
 #. NO_RESPONSE
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:167
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:547
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:596
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} did not respond."
 msgstr "Nameserver {ns}/{address} did not respond."
@@ -881,6 +877,12 @@ msgstr "Nameserver {ns}/{address} is a recursor."
 msgid "Nameserver {ns}/{address} is not a recursor."
 msgstr "Nameserver {ns}/{address} is not a recursor."
 
+#. HAS_NAMESERVERS
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} listed these servers as glue: {nsnlist}."
+msgstr "Nameserver {ns}/{address} listed these servers as glue: {nsnlist}."
+
 #. NAMESERVER_NO_TCP_53
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:136
 #, perl-brace-format
@@ -921,7 +923,7 @@ msgstr ""
 "without EDNS."
 
 #. NO_RESPONSE_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:543
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:592
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} responded with no DNSKEY record(s)."
 msgstr "Nameserver {ns}/{address} responded with no DNSKEY record(s)."
@@ -950,22 +952,22 @@ msgid "Nameservers did not respond to A query."
 msgstr "Nameservers did not respond to A query."
 
 #. ADDITIONAL_DNSKEY_SKIPPED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:353
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:398
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr "No DNSKEYs found. Additional tests skipped."
 
 #. NO_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:521
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:570
 msgid "No DNSKEYs were returned."
 msgstr "No DNSKEYs were returned."
 
 #. NO_COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:517
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:566
 msgid "No DS record had a DNSKEY with a matching keytag."
 msgstr "No DS record had a DNSKEY with a matching keytag."
 
 #. DS_MATCH_NOT_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:455
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:496
 msgid "No DS record with a matching DNSKEY record was found."
 msgstr "No DS record with a matching DNSKEY record was found."
 
@@ -991,7 +993,7 @@ msgid "No NS records for tested zone from parent. NS tests aborted."
 msgstr "No NS records for tested zone from parent. NS tests skipped."
 
 #. SOA_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:615
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:664
 msgid "No RRSIG correctly signed the SOA RRset."
 msgstr "No RRSIG correctly signed the SOA RRset."
 
@@ -1017,7 +1019,7 @@ msgid "No nameserver address is in an AS."
 msgstr "No nameserver address is in an AS."
 
 #. NS_RR_NO_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:257
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:263
 msgid "No nameserver point to CNAME alias."
 msgstr "No nameserver points to CNAME alias."
 
@@ -1079,12 +1081,12 @@ msgstr ""
 "{dname}."
 
 #. NSEC_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:583
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:632
 msgid "No signature correctly signed the NSEC RRset."
 msgstr "No signature correctly signed the NSEC RRset."
 
 #. NSEC3_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:563
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:612
 msgid "No signature correctly signed the NSEC3 RRset."
 msgstr "No signature correctly signed the NSEC3 RRset."
 
@@ -1102,7 +1104,7 @@ msgstr ""
 "None of the following nameservers returns an upward referral : {names}."
 
 #. TOTAL_NAME_MISMATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:281
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:287
 msgid "None of the nameservers listed at the parent are listed at the child."
 msgstr "None of the nameservers listed at the parent are listed at the child."
 
@@ -1123,7 +1125,7 @@ msgstr ""
 "with \"{command}\")."
 
 #. NOT_ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:225
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:231
 #, perl-brace-format
 msgid ""
 "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
@@ -1147,13 +1149,13 @@ msgstr ""
 "Parent has extra nameserver IP address(es) not listed at child ({addresses})."
 
 #. EXTRA_NAME_PARENT
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:177
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:183
 #, perl-brace-format
 msgid "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr "Parent has nameserver(s) not listed at the child ({extra})."
 
 #. ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:169
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:175
 #, perl-brace-format
 msgid ""
 "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
@@ -1169,7 +1171,7 @@ msgid "Profile was read from {name}."
 msgstr "Profile was read from {name}."
 
 #. RRSIG_EXPIRATION
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:607
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:656
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
@@ -1177,7 +1179,7 @@ msgstr ""
 "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
 
 #. DURATION_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:471
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:512
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1187,7 +1189,7 @@ msgstr ""
 "{duration} seconds, which is just fine."
 
 #. DURATION_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:465
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:506
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1197,7 +1199,7 @@ msgstr ""
 "{duration} seconds, which is too long."
 
 #. REMAINING_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:595
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:644
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1207,7 +1209,7 @@ msgstr ""
 "validity of {duration} seconds, which is too long."
 
 #. REMAINING_SHORT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:601
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:650
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1217,7 +1219,7 @@ msgstr ""
 "validity of {duration} seconds, which is too short."
 
 #. RRSIG_EXPIRED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:611
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:660
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has already expired "
@@ -1227,7 +1229,7 @@ msgstr ""
 "(expiration is: {expiration})."
 
 #. SOA_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:623
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:672
 #, perl-brace-format
 msgid "RRSIG {signature} correctly signs SOA RRset."
 msgstr "RRSIG {signature} correctly signs SOA RRset."
@@ -1334,13 +1336,13 @@ msgstr "SOA 'mname' nameserver ({mname}) is authoritative for '{zone}' zone."
 
 #. MNAME_NOT_IN_GLUE
 #: ../lib/Zonemaster/Engine/Test/Zone.pm:198
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
-"tested zone ({ns})."
+"tested zone ({nss})."
 msgstr ""
 "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
-"tested zone ({ns})."
+"tested zone ({nss})."
 
 #. MNAME_NO_RESPONSE
 #: ../lib/Zonemaster/Engine/Test/Zone.pm:142
@@ -1512,14 +1514,14 @@ msgid "Saw {count} SOA time parameter set."
 msgstr "Found {count} SOA time parameter set(s)."
 
 #. EXTRA_PROCESSING_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:481
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:522
 #, perl-brace-format
 msgid "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
 msgstr ""
 "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
 
 #. EXTRA_PROCESSING_BROKEN
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:477
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:518
 #, perl-brace-format
 msgid ""
 "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
@@ -1527,7 +1529,7 @@ msgstr ""
 "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
 
 #. DNSKEY_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:415
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:456
 #, perl-brace-format
 msgid ""
 "Signature for DNSKEY with tag {signature} failed to verify with error "
@@ -1542,18 +1544,8 @@ msgstr ""
 msgid "Target ({info}) found to deliver e-mail for the domain name."
 msgstr "Target ({info}) found to deliver e-mail for the domain name."
 
-#. ALGORITHM_DELETE_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:357
-#, perl-brace-format
-msgid ""
-"The DNSKEY with tag {keytag} uses Delete DS algorithm number {algorithm}/"
-"({description})."
-msgstr ""
-"The DNSKEY with tag {keytag} uses Delete DS algorithm number {algorithm}/"
-"({description})."
-
 #. ALGORITHM_NOT_ZONE_SIGN
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:370
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses algorithm number not meant for zone "
@@ -1561,19 +1553,9 @@ msgid ""
 msgstr ""
 "The DNSKEY with tag {keytag} uses algorithm number not meant for zone "
 "signing{algorithm}/({description})."
-
-#. ALGORITHM_INDIRECT_KEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:365
-#, perl-brace-format
-msgid ""
-"The DNSKEY with tag {keytag} uses algorithm number reserved for indirect "
-"keys {algorithm}/({description})."
-msgstr ""
-"The DNSKEY with tag {keytag} uses algorithm number reserved for indirect "
-"keys {algorithm}/({description})."
 
 #. ALGORITHM_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:375
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:416
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
@@ -1582,8 +1564,18 @@ msgstr ""
 "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
 "({description}) [OK]."
 
+#. ALGORITHM_NOT_RECOMMENDED
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:406
+#, fuzzy, perl-brace-format
+msgid ""
+"The DNSKEY with tag {keytag} uses an algorithm number {algorithm}/"
+"({description} which which is not recommended to be used."
+msgstr ""
+"The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
+"({description}) [OK]."
+
 #. ALGORITHM_DEPRECATED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:361
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:402
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
@@ -1593,7 +1585,7 @@ msgstr ""
 "({description})."
 
 #. ALGORITHM_PRIVATE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:379
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:420
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
@@ -1603,7 +1595,7 @@ msgstr ""
 "({description})."
 
 #. ALGORITHM_RESERVED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:383
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:424
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
@@ -1613,7 +1605,7 @@ msgstr ""
 "({description})."
 
 #. ALGORITHM_UNASSIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:387
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:428
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
@@ -1639,12 +1631,12 @@ msgstr ""
 "with an IP address."
 
 #. DNSKEY_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:423
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:464
 msgid "The apex DNSKEY RRset was correcly signed."
 msgstr "The apex DNSKEY RRset was correcly signed."
 
 #. DNSKEY_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:452
 msgid "The apex DNSKEY RRset was not correctly signed."
 msgstr "The apex DNSKEY RRset was not correctly signed."
 
@@ -1696,19 +1688,19 @@ msgid "The module {name} was disabled by the policy."
 msgstr "The module {name} was disabled by the policy."
 
 #. ITERATIONS_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:501
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:550
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is OK."
 msgstr "The number of NSEC3 iterations is {count}, which is OK."
 
 #. MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:509
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:558
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is on the high side."
 msgstr "The number of NSEC3 iterations is {count}, which is on the high side."
 
 #. TOO_MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:631
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:680
 #, perl-brace-format
 msgid ""
 "The number of NSEC3 iterations is {count}, which is too high for key length "
@@ -1718,7 +1710,7 @@ msgstr ""
 "{keylength}."
 
 #. REFERRAL_SIZE_TOO_LARGE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:261
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:267
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is larger than 512 octets (it is "
@@ -1728,7 +1720,7 @@ msgstr ""
 "{size})."
 
 #. REFERRAL_SIZE_OK
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:265
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:271
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is smaller than 513 octets (it "
@@ -1738,33 +1730,33 @@ msgstr ""
 "is {size})."
 
 #. HAS_NSEC
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:493
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:534
 msgid "The zone has NSEC records."
 msgstr "The zone has NSEC records."
 
 #. HAS_NSEC3_OPTOUT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:485
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:526
 msgid "The zone has NSEC3 opt-out records."
 msgstr "The zone has NSEC3 opt-out records."
 
 #. HAS_NSEC3
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:489
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:530
 msgid "The zone has NSEC3 records."
 msgstr "The zone has NSEC3 records."
 
 #. NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:551
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:600
 msgid "The zone is not signed with DNSSEC."
 msgstr "The zone is not signed with DNSSEC."
 
 #. COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:391
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:432
 #, perl-brace-format
 msgid "There are both DS and DNSKEY records with key tags {keytags}."
 msgstr "There are both DS and DNSKEY records with key tags {keytags}."
 
 #. NEITHER_DNSKEY_NOR_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:513
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:562
 msgid "There are neither DS nor DNSKEY records for the zone."
 msgstr "There are neither DS nor DNSKEY records for the zone."
 
@@ -1788,19 +1780,19 @@ msgid ""
 msgstr "Misused '@' character found in SOA RNAME field ({rname})."
 
 #. NSEC_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:591
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:640
 #, perl-brace-format
 msgid "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 msgstr "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 
 #. NSEC3_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:571
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:620
 #, perl-brace-format
 msgid "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
 msgstr "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
 
 #. SOA_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:619
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:668
 #, perl-brace-format
 msgid ""
 "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
@@ -1831,7 +1823,7 @@ msgid "Using version {version} of the Zonemaster engine."
 msgstr "Using version {version} of the Zonemaster engine."
 
 #. INVALID_NAME_RCODE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:497
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:538
 #, perl-brace-format
 msgid ""
 "When asked for the name {name}, which must not exist, the response had RCODE "
@@ -1929,31 +1921,45 @@ msgid "[ASN:RAW] {address};{data}"
 msgstr "[ASN:RAW] {address};{data}"
 
 #. DNSKEY_BUT_NOT_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:407
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:448
 #, perl-brace-format
 msgid "{child} sent a DNSKEY record, but {parent} did not send a DS record."
 msgstr "{child} sent a DNSKEY record, but {parent} did not send a DS record."
 
 #. NO_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:525
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:574
 #, perl-brace-format
 msgid "{from} returned no DS records for {zone}."
 msgstr "{from} returned no DS records for {zone}."
 
 #. DNSKEY_AND_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:403
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:444
 #, perl-brace-format
 msgid "{parent} sent a DS record, and {child} a DNSKEY record."
 msgstr "{parent} sent a DS record, and {child} a DNSKEY record."
 
 #. DS_BUT_NOT_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:427
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:468
 #, perl-brace-format
 msgid "{parent} sent a DS record, but {child} did not send a DNSKEY record."
 msgstr "{parent} sent a DS record, but {child} did not send a DNSKEY record."
 
 #. NO_NSEC3PARAM
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:539
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:588
 #, perl-brace-format
 msgid "{server} returned no NSEC3PARAM records."
 msgstr "{server} returned no NSEC3PARAM records."
+
+#~ msgid ""
+#~ "The DNSKEY with tag {keytag} uses Delete DS algorithm number {algorithm}/"
+#~ "({description})."
+#~ msgstr ""
+#~ "The DNSKEY with tag {keytag} uses Delete DS algorithm number {algorithm}/"
+#~ "({description})."
+
+#~ msgid ""
+#~ "The DNSKEY with tag {keytag} uses algorithm number reserved for indirect "
+#~ "keys {algorithm}/({description})."
+#~ msgstr ""
+#~ "The DNSKEY with tag {keytag} uses algorithm number reserved for indirect "
+#~ "keys {algorithm}/({description})."

--- a/share/fr.po
+++ b/share/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-25 18:32+0200\n"
+"POT-Creation-Date: 2019-10-03 23:11+0200\n"
 "PO-Revision-Date: 2017-12-18\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. SOA_NOT_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:277
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:283
 #, perl-brace-format
 msgid "A SOA query NOERROR response from {ns} was received empty."
 msgstr ""
@@ -21,10 +21,18 @@ msgstr ""
 "\"."
 
 #. DNSKEY_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:419
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:460
 #, perl-brace-format
 msgid "A signature for DNSKEY with tag {signature} was correctly signed."
 msgstr "La signature de la clé avec le tag {signature} est correcte."
+
+#. ONE_SOA_MNAME
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:187
+#, fuzzy, perl-brace-format
+msgid "A single SOA mname value was seen ({mname})"
+msgstr ""
+"Une unique adresse mail a été trouvée dans les enregistrements de type \"SOA"
+"\" de la zone testée ({rname})."
 
 #. ONE_SOA_RNAME
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:191
@@ -122,7 +130,7 @@ msgstr ""
 "de noms."
 
 #. NAMES_MATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:193
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:199
 msgid "All of the nameserver names are listed both at parent and child."
 msgstr ""
 "Tous les serveurs de noms de la zone font partie de la liste des serveurs de "
@@ -135,47 +143,61 @@ msgid "All reverse DNS entry matches name server name."
 msgstr "Tous les enregistrements PTR correspondent aux serveurs de noms."
 
 #. DISTINCT_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:137
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:143
 msgid "All the IP addresses used by the nameservers are unique"
 msgstr ""
 "Toutes les adresses IP utilisées par les serveurs de noms sont uniques."
 
+#. CHILD_DISTINCT_NS_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:127
+#, fuzzy
+msgid "All the IP addresses used by the nameservers in child are unique."
+msgstr ""
+"Toutes les adresses IP utilisées par les serveurs de noms sont uniques."
+
+#. DEL_DISTINCT_NS_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:135
+#, fuzzy
+msgid "All the IP addresses used by the nameservers in parent are unique."
+msgstr ""
+"Toutes les adresses IP utilisées par les serveurs de noms sont uniques."
+
 #. SOA_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:273
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:279
 msgid "All the nameservers have SOA record."
 msgstr ""
 "Tous les serveurs de noms retournent un enregistrement de type \"SOA\"."
 
 #. ARE_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:117
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:123
 #, perl-brace-format
 msgid "All these nameservers are confirmed to be authoritative : {nsset}."
 msgstr ""
 "Ces serveurs de noms ont pu être vérifiés comme faisant autorité : {nsset}."
 
 #. DS_MATCH_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:451
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:492
 msgid "At least one DS record with a matching DNSKEY record was found."
 msgstr ""
 "Au moins un enregistrement de type \"DS\" avec un enregistrement de type "
 "\"DNSKEY\" correspondant a été trouvé."
 
 #. SOA_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:627
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:676
 msgid "At least one RRSIG correctly signs the SOA RRset."
 msgstr ""
 "Au moins une signature (RRSIG) correcte signe correctement l'enregistrement "
 "de type \"SOA\"."
 
 #. NSEC_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:587
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:636
 msgid "At least one signature correctly signed the NSEC RRset."
 msgstr ""
 "Au moins une signature (RRSIG) correcte signe l'ensemble des enregistrements "
 "de type \"NSEC\"."
 
 #. NSEC3_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:567
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:616
 msgid "At least one signature correctly signed the NSEC3 RRset."
 msgstr ""
 "Au moins une signature correcte signe l'ensemble des enregistrements de type "
@@ -209,7 +231,7 @@ msgstr ""
 "'-'."
 
 #. NO_KEYS_OR_NO_SIGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:529
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:578
 #, perl-brace-format
 msgid ""
 "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
@@ -220,7 +242,7 @@ msgstr ""
 "\"RRSIG\"."
 
 #. NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:533
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:582
 #, perl-brace-format
 msgid ""
 "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
@@ -231,11 +253,33 @@ msgstr ""
 "enregistrements de type \"RRSIG\" et {soas} enregistrements de type \"SOA\"."
 
 #. NOT_ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
-#, perl-brace-format
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:227
+#, fuzzy, perl-brace-format
 msgid ""
-"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child does not list enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
+msgstr ""
+"Les serveurs de noms de la zone ne retournent pas assez de serveurs "
+"({count}) faisant autorité ({nss}). La limite inférieure étant fixée à "
+"{minimum}."
+
+#. NOT_ENOUGH_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:203
+#, fuzzy, perl-brace-format
+msgid ""
+"Child does not list enough ({count}) nameservers that resolve to IPv4 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Les serveurs de noms de la zone ne retournent pas assez de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
+
+#. NOT_ENOUGH_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:215
+#, fuzzy, perl-brace-format
+msgid ""
+"Child does not list enough ({count}) nameservers that resolve to IPv6 "
+"addresses ({addrs}). Lower limit set to {minimum}."
 msgstr ""
 "Les serveurs de noms de la zone ne retournent pas assez de serveurs "
 "({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
@@ -252,7 +296,7 @@ msgstr ""
 "zone parente ({addresses})."
 
 #. EXTRA_NAME_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:173
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:179
 #, perl-brace-format
 msgid "Child has nameserver(s) not listed at parent ({extra})."
 msgstr ""
@@ -260,15 +304,53 @@ msgstr ""
 "({extra}) qui ne le sont pas par les serveurs de noms de la zone parente."
 
 #. ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
-#, perl-brace-format
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:171
+#, fuzzy, perl-brace-format
 msgid ""
-"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child lists enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
+msgstr ""
+"Les serveurs de noms de la zone retournent suffisamment de serveurs "
+"({count}) faisant autorité ({nss}). La limite inférieure étant fixée à "
+"{minimum}."
+
+#. ENOUGH_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:147
+#, fuzzy, perl-brace-format
+msgid ""
+"Child lists enough ({count}) nameservers that resolve to IPv4 addresses "
+"({addrs}). Lower limit set to {minimum}."
 msgstr ""
 "Les serveurs de noms de la zone retournent suffisamment de serveurs "
 "({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
 "{minimum}."
+
+#. ENOUGH_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:159
+#, fuzzy, perl-brace-format
+msgid ""
+"Child lists enough ({count}) nameservers that resolve to IPv6 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Les serveurs de noms de la zone retournent suffisamment de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
+
+#. NO_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:235
+#, perl-brace-format
+msgid ""
+"Child lists no nameserver that resolves to an IPv4 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
+
+#. NO_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:247
+#, perl-brace-format
+msgid ""
+"Child lists no nameserver that resolves to an IPv6 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
 
 #. LOOKUP_ERROR
 #: ../lib/Zonemaster/Engine/Translator.pm:49
@@ -280,7 +362,7 @@ msgstr ""
 "le message d'erreur suivant: {message}"
 
 #. DS_DOES_NOT_MATCH_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:439
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:480
 #, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} does not match the "
@@ -291,7 +373,7 @@ msgstr ""
 "ayant le même tag."
 
 #. DS_MATCHES_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:447
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:488
 #, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
@@ -302,7 +384,7 @@ msgstr ""
 "ayant le même tag."
 
 #. DS_DIGTYPE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:435
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:476
 #, fuzzy, perl-brace-format
 msgid "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
 msgstr ""
@@ -310,15 +392,37 @@ msgstr ""
 "de condensat (digest) correct."
 
 #. DS_DIGTYPE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:431
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:472
 #, perl-brace-format
 msgid "DS record with keytag {keytag} uses forbidden digest type {digtype}."
 msgstr ""
 "L'enregistrement de type \"DS\" avec le tag de clé {keytag} utilise un type "
 "de condensat (digest) interdit {digtype}."
 
+#. NOT_ENOUGH_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:209
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation does not list enough ({count}) nameservers that resolve to IPv4 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Les serveurs de noms de la zone ne retournent pas assez de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
+
+#. NOT_ENOUGH_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation does not list enough ({count}) nameservers that resolve to IPv6 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Les serveurs de noms de la zone ne retournent pas assez de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
+
 #. DELEGATION_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:395
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:436
 #, perl-brace-format
 msgid "Delegation from parent to child is not properly signed {reason}."
 msgstr ""
@@ -326,9 +430,47 @@ msgstr ""
 "{reason}."
 
 #. DELEGATION_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:399
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:440
 msgid "Delegation from parent to child is properly signed."
 msgstr "L'enregistrement DS dans la zone parente est correctement signé."
+
+#. ENOUGH_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:153
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation lists enough ({count}) nameservers that resolve to IPv4 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Les serveurs de noms de la zone retournent suffisamment de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
+
+#. ENOUGH_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation lists enough ({count}) nameservers that resolve to IPv6 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Les serveurs de noms de la zone retournent suffisamment de serveurs "
+"({count}) faisant autorité ({ns}). La limite inférieure étant fixée à "
+"{minimum}."
+
+#. NO_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:241
+#, perl-brace-format
+msgid ""
+"Delegation lists no nameserver that resolves to an IPv4 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
+
+#. NO_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
+#, perl-brace-format
+msgid ""
+"Delegation lists no nameserver that resolves to an IPv6 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
 
 #. SOA_SERIAL_VARIATION
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:213
@@ -429,8 +571,16 @@ msgstr ""
 "Les serveurs de noms pour le nom de domaine ne se trouvent pas tous dans le "
 "même AS."
 
+#. NS_ERROR
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:309
+#, fuzzy, perl-brace-format
+msgid "Erroneous response from nameserver {ns}/{address}."
+msgstr ""
+"Le serveur de noms {ns}/{address} n'a pas répondu aux requêtes de type \"NS"
+"\"."
+
 #. DS_RFC4509_NOT_VALID
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:459
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:500
 msgid ""
 "Existing DS with digest type 2, while they do not match DNSKEY records, "
 "prevent use of DS with digest type 1 (RFC4509, section 3)."
@@ -451,7 +601,7 @@ msgid "Followed a fake delegation."
 msgstr "Utilisation d'une configuration DNS alternative (fake delegation)."
 
 #. DS_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:443
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:484
 #, perl-brace-format
 msgid "Found DS records with tags {keytags}."
 msgstr ""
@@ -504,19 +654,34 @@ msgstr ""
 "La liste des adresses IP des serveurs de nom retournée par les serveurs de "
 "noms de la zone parente et par ceux de la zone est identique."
 
+#. CHILD_NS_SAME_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:131
+#, fuzzy, perl-brace-format
+msgid "IP {address} in child refers to multiple nameservers ({nss})."
+msgstr ""
+"L'adresse IP {address} fait référence à plusieurs serveurs de noms ({nss})."
+
+#. DEL_NS_SAME_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:139
+#, fuzzy, perl-brace-format
+msgid "IP {address} in parent refers to multiple nameservers ({nss})."
+msgstr ""
+"L'adresse IP {address} fait référence à plusieurs serveurs de noms ({nss})."
+
 #. SAME_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:269
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:275
 #, perl-brace-format
 msgid "IP {address} refers to multiple nameservers ({nss})."
 msgstr ""
 "L'adresse IP {address} fait référence à plusieurs serveurs de noms ({nss})."
 
 #. IPV4_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:144
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:181
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:187
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:273
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:542
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
 #, perl-brace-format
 msgid "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr ""
@@ -538,11 +703,12 @@ msgstr ""
 "\"{rrtype}\" sur le serveur {ns}/{address}."
 
 #. IPV6_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:148
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:185
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:191
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:277
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:546
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
 #, fuzzy, perl-brace-format
 msgid "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr ""
@@ -574,7 +740,7 @@ msgstr ""
 "EDNS est utilisé (La version EDNS devrait être 0)."
 
 #. KEY_DETAILS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:505
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:554
 #, perl-brace-format
 msgid ""
 "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
@@ -611,25 +777,25 @@ msgid "Module {module} finished running."
 msgstr "Exécution du module {module} terminée."
 
 #. NSEC_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:579
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:628
 #, perl-brace-format
 msgid "NSEC covers {name}."
 msgstr "NSEC couvre le nom {name}."
 
 #. NSEC_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:575
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:624
 #, perl-brace-format
 msgid "NSEC does not cover {name}."
 msgstr "NSEC ne couvre pas le nom {name}."
 
 #. NSEC3_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:559
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:608
 #, perl-brace-format
 msgid "NSEC3 record covers {name}."
 msgstr "NSEC3 couvre le nom {name}."
 
 #. NSEC3_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:555
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:604
 #, perl-brace-format
 msgid "NSEC3 record does not cover {name}."
 msgstr "NSEC3 ne couvre pas le nom {name}."
@@ -708,16 +874,8 @@ msgstr ""
 "Le serveur de noms {ns} a une adresse IP ({address}) sans enregistrement "
 "\"PTR\" correspondant."
 
-#. HAS_NAMESERVERS
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
-#, perl-brace-format
-msgid "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr ""
-"Une requête NS sur le serveur de noms {ns} renvoie la liste de serveurs de "
-"noms suivants: {nsnlist}."
-
 #. IS_NOT_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:189
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:195
 #, perl-brace-format
 msgid "Nameserver {ns} response is not authoritative on {proto} port 53."
 msgstr ""
@@ -725,12 +883,18 @@ msgstr ""
 "autorité."
 
 #. NS_RR_IS_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:259
 #, perl-brace-format
 msgid "Nameserver {ns} {address_type} RR point to CNAME."
 msgstr ""
 "L'enregistrement de type \"{address_type}\" retourné par le serveur de noms "
 "{ns} est un alias (CNAME)."
+
+#. UNSUPPORTED_EDNS_VER
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:333
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} accepts an unsupported EDNS version."
+msgstr "Le serveur de noms {ns}/{address} n'est pas un récurseur."
 
 #. NAMESERVER_HAS_TCP_53
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:128
@@ -773,7 +937,7 @@ msgstr ""
 
 #. NO_RESPONSE
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:167
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:547
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:596
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} did not respond."
 msgstr "Le serveur de noms {ns}/{address} n'a pas répondu."
@@ -820,6 +984,13 @@ msgstr ""
 "Le serveur de noms {ns}/{address} ne répond pas aux requêtes portant sur le "
 "type \"AAAA\"."
 
+#. Z_FLAGS_NOTCLEAR
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:345
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} has one or more unknown EDNS Z flag bits set."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne répond pas à une requête de type \"NS\"."
+
 #. IS_A_RECURSOR
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:281
 #, perl-brace-format
@@ -833,6 +1004,14 @@ msgstr ""
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} is not a recursor."
 msgstr "Le serveur de noms {ns}/{address} n'est pas un récurseur."
+
+#. HAS_NAMESERVERS
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} listed these servers as glue: {nsnlist}."
+msgstr ""
+"Une requête NS sur le serveur de noms {ns}/{address} renvoie la liste de serveurs de "
+"noms suivants: {nsnlist}."
 
 #. NAMESERVER_NO_TCP_53
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:136
@@ -868,6 +1047,30 @@ msgstr ""
 "Le serveur de noms {ns}/{address} répond depuis une autre adresse que celle "
 "à laquelle la requête a été envoyée."
 
+#. MISSING_OPT_IN_TRUNCATED
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:285
+#, fuzzy, perl-brace-format
+msgid ""
+"Nameserver {ns}/{address} replies on an EDNS query with a truncated response "
+"without EDNS."
+msgstr ""
+"Le serveur de noms {ns}/{address} répond depuis une autre adresse que celle "
+"à laquelle la requête a été envoyée."
+
+#. NO_RESPONSE_DNSKEY
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:592
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} responded with no DNSKEY record(s)."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne répond pas à une requête de type \"NS\"."
+
+#. UNKNOWN_OPTION_CODE
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:329
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} responds with an unknown ENDS OPTION-CODE."
+msgstr ""
+"Le serveur de noms {ns}/{address} ne répond pas à une requête de type \"NS\"."
+
 #. HAS_A_RECORDS
 #: ../lib/Zonemaster/Engine/Test/Basic.pm:144
 #, perl-brace-format
@@ -890,26 +1093,26 @@ msgid "Nameservers did not respond to A query."
 msgstr "Aucune réponse des serveurs de noms sur une requête de type \"A\"."
 
 #. ADDITIONAL_DNSKEY_SKIPPED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:353
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:398
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr ""
 "Pas d'enregistrement de type \"DNSKEY\" trouvé. Les tests additionnels sont "
 "abandonnés."
 
 #. NO_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:521
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:570
 msgid "No DNSKEYs were returned."
 msgstr "Aucun enregistrement de type \"DNSKEY\" n'a été retourné."
 
 #. NO_COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:517
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:566
 msgid "No DS record had a DNSKEY with a matching keytag."
 msgstr ""
 "Aucun enregistrement de type \"DS\" n'a d'enregistrement de type \"DNSKEY\" "
 "correspondant (avec le même tag de clé)."
 
 #. DS_MATCH_NOT_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:455
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:496
 msgid "No DS record with a matching DNSKEY record was found."
 msgstr ""
 "Aucun enregistrement de type \"DS\" avec un enregistrement de type \"DNSKEY"
@@ -941,7 +1144,7 @@ msgstr ""
 "testée. Les tests complémentaires sur ces serveurs sont annulés."
 
 #. SOA_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:615
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:664
 msgid "No RRSIG correctly signed the SOA RRset."
 msgstr ""
 "Aucune signature correcte ne signe l'ensemble des enregistrements de type "
@@ -969,7 +1172,7 @@ msgid "No nameserver address is in an AS."
 msgstr "Aucune adresse IP des serveurs de noms ne se trouve dans un AS."
 
 #. NS_RR_NO_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:257
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:263
 msgid "No nameserver point to CNAME alias."
 msgstr "Aucun serveur de noms ne pointe sur un alias (CNAME)."
 
@@ -1020,6 +1223,15 @@ msgstr ""
 msgid "No response from nameserver(s) on SOA queries."
 msgstr "Aucune réponse des serveurs de noms sur une requête de type \"SOA\"."
 
+#. NO_RESPONSE
+#: ../lib/Zonemaster/Engine/Test/Syntax.pm:213
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:301
+#, fuzzy, perl-brace-format
+msgid "No response from {ns}/{address} asking for {dname}."
+msgstr ""
+"Aucune réponse de {ns}/{address} sur le nom de domaine '{dname}' lorsque "
+"EDNS est utilisé."
+
 #. BREAKS_ON_EDNS
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:208
 #, perl-brace-format
@@ -1031,14 +1243,14 @@ msgstr ""
 "EDNS est utilisé."
 
 #. NSEC_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:583
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:632
 msgid "No signature correctly signed the NSEC RRset."
 msgstr ""
 "Aucune signature correcte ne signe l'ensemble des enregistrements de type "
 "\"NSEC\"."
 
 #. NSEC3_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:563
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:612
 msgid "No signature correctly signed the NSEC3 RRset."
 msgstr ""
 "Aucune signature correcte ne signe l'ensemble des enregistrements de type "
@@ -1060,7 +1272,7 @@ msgstr ""
 "sur la racine '.' (upward referral) : {names}."
 
 #. TOTAL_NAME_MISMATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:281
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:287
 msgid "None of the nameservers listed at the parent are listed at the child."
 msgstr ""
 "La liste des serveurs de noms retournée par les serveurs de noms de la zone "
@@ -1085,7 +1297,7 @@ msgstr ""
 "de {maxsize} octets (tester avec la commande \"{command}\")."
 
 #. NOT_ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:225
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:231
 #, perl-brace-format
 msgid ""
 "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
@@ -1113,7 +1325,7 @@ msgstr ""
 "de la zone ({addresses})."
 
 #. EXTRA_NAME_PARENT
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:177
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:183
 #, perl-brace-format
 msgid "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr ""
@@ -1121,7 +1333,7 @@ msgstr ""
 "autorité ({extra}) qui ne le sont pas par les serveurs de noms de la zone."
 
 #. ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:169
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:175
 #, perl-brace-format
 msgid ""
 "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
@@ -1138,7 +1350,7 @@ msgid "Profile was read from {name}."
 msgstr "Le profile a été lu depuis le fichier {name}."
 
 #. RRSIG_EXPIRATION
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:607
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:656
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
@@ -1147,7 +1359,7 @@ msgstr ""
 "enregistrements de type(s) \"{types}\" expire à la date suivante : {date}."
 
 #. DURATION_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:471
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:512
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1158,7 +1370,7 @@ msgstr ""
 "ce qui est raisonnable."
 
 #. DURATION_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:465
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:506
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1169,7 +1381,7 @@ msgstr ""
 "ce qui est trop long."
 
 #. REMAINING_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:595
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:644
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1180,7 +1392,7 @@ msgstr ""
 "{duration} secondes, ce qui est trop long."
 
 #. REMAINING_SHORT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:601
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:650
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1191,7 +1403,7 @@ msgstr ""
 "{duration} secondes, ce qui est trop court."
 
 #. RRSIG_EXPIRED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:611
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:660
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has already expired "
@@ -1202,7 +1414,7 @@ msgstr ""
 "{expiration})."
 
 #. SOA_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:623
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:672
 #, perl-brace-format
 msgid "RRSIG {signature} correctly signs SOA RRset."
 msgstr ""
@@ -1318,13 +1530,13 @@ msgstr ""
 
 #. MNAME_NOT_IN_GLUE
 #: ../lib/Zonemaster/Engine/Test/Zone.pm:198
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
-"tested zone ({ns})."
+"tested zone ({nss})."
 msgstr ""
 "Le serveur maître défini dans le SOA, 'mname' ({mname}), ne fait pas partie "
-"des enregistrements de type \"NS\" listés par la zone parente ({ns})."
+"des enregistrements de type \"NS\" listés par la zone parente ({nss})."
 
 #. MNAME_NO_RESPONSE
 #: ../lib/Zonemaster/Engine/Test/Zone.pm:142
@@ -1488,6 +1700,13 @@ msgstr ""
 "Plusieurs ensembles de serveurs de noms ({count}) ont été trouvés dans les "
 "différents SOA."
 
+#. MULTIPLE_SOA_MNAMES
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:151
+#, fuzzy, perl-brace-format
+msgid "Saw {count} SOA mname."
+msgstr ""
+"Plusieurs adresses mail ({count}) ont été trouvées dans les différents SOA."
+
 #. MULTIPLE_SOA_RNAMES
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:155
 #, perl-brace-format
@@ -1511,7 +1730,7 @@ msgstr ""
 "les différents SOA."
 
 #. EXTRA_PROCESSING_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:481
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:522
 #, perl-brace-format
 msgid "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
 msgstr ""
@@ -1519,7 +1738,7 @@ msgstr ""
 "signatures (RRSIG) {sigs}."
 
 #. EXTRA_PROCESSING_BROKEN
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:477
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:518
 #, perl-brace-format
 msgid ""
 "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
@@ -1528,7 +1747,7 @@ msgstr ""
 "signatures (RRSIG) {sigs}."
 
 #. DNSKEY_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:415
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:456
 #, perl-brace-format
 msgid ""
 "Signature for DNSKEY with tag {signature} failed to verify with error "
@@ -1545,8 +1764,18 @@ msgstr ""
 "Information ({info}) trouvée pour faire parvenir un message à ce nom de "
 "domaine."
 
+#. ALGORITHM_NOT_ZONE_SIGN
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
+#, fuzzy, perl-brace-format
+msgid ""
+"The DNSKEY with tag {keytag} uses algorithm number not meant for zone "
+"signing{algorithm}/({description})."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme privé "
+"{algorithm}/({description})."
+
 #. ALGORITHM_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:375
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:416
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
@@ -1555,8 +1784,18 @@ msgstr ""
 "La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme correct "
 "{algorithm}/({description})."
 
+#. ALGORITHM_NOT_RECOMMENDED
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:406
+#, fuzzy, perl-brace-format
+msgid ""
+"The DNSKEY with tag {keytag} uses an algorithm number {algorithm}/"
+"({description} which which is not recommended to be used."
+msgstr ""
+"La clé (DNSKEY) avec le tag {keytag} utilise un numéro d'algorithme correct "
+"{algorithm}/({description})."
+
 #. ALGORITHM_DEPRECATED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:361
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:402
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
@@ -1566,7 +1805,7 @@ msgstr ""
 "{algorithm}/({description})."
 
 #. ALGORITHM_PRIVATE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:379
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:420
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
@@ -1576,7 +1815,7 @@ msgstr ""
 "{algorithm}/({description})."
 
 #. ALGORITHM_RESERVED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:383
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:424
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
@@ -1586,7 +1825,7 @@ msgstr ""
 "{algorithm}/({description})."
 
 #. ALGORITHM_UNASSIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:387
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:428
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
@@ -1603,13 +1842,21 @@ msgstr ""
 "Le champ RNAME ({rname}) du SOA est conforme aux règles définies dans le "
 "RFC2822."
 
+#. RNAME_MAIL_DOMAIN_INVALID
+#: ../lib/Zonemaster/Engine/Test/Syntax.pm:229
+#, perl-brace-format
+msgid ""
+"The SOA RNAME mail domain ({domain}) cannot be resolved to a mail server "
+"with an IP address."
+msgstr ""
+
 #. DNSKEY_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:423
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:464
 msgid "The apex DNSKEY RRset was correcly signed."
 msgstr "L'ensemble des clés de l'apex (DNSKEY RRset) est signé correctement."
 
 #. DNSKEY_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:452
 msgid "The apex DNSKEY RRset was not correctly signed."
 msgstr ""
 "L'ensemble des clés de l'apex (DNSKEY RRset) n'est pas signé correctement."
@@ -1664,21 +1911,21 @@ msgid "The module {name} was disabled by the policy."
 msgstr "Le module {name} a été désactivé par la politique en cours."
 
 #. ITERATIONS_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:501
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:550
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is OK."
 msgstr ""
 "Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est correct."
 
 #. MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:509
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:558
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is on the high side."
 msgstr ""
 "Le nombre d'itérations pour \"NSEC3\" est de {count}, ce qui est élevé."
 
 #. TOO_MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:631
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:680
 #, perl-brace-format
 msgid ""
 "The number of NSEC3 iterations is {count}, which is too high for key length "
@@ -1688,7 +1935,7 @@ msgstr ""
 "pour une clé de cette taille {keylength}."
 
 #. REFERRAL_SIZE_TOO_LARGE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:261
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:267
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is larger than 512 octets (it is "
@@ -1698,7 +1945,7 @@ msgstr ""
 "est supérieur à 512 octets (elle est de {size})."
 
 #. REFERRAL_SIZE_OK
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:265
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:271
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is smaller than 513 octets (it "
@@ -1708,28 +1955,28 @@ msgstr ""
 "est inférieure à 513 octets (elle est de {size})."
 
 #. HAS_NSEC
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:493
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:534
 msgid "The zone has NSEC records."
 msgstr "La zone a des enregistrements de type \"NSEC\"."
 
 #. HAS_NSEC3_OPTOUT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:485
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:526
 msgid "The zone has NSEC3 opt-out records."
 msgstr ""
 "L'opt-out est mis en oeuvre pour des enregistrements de type \"NSEC3\"."
 
 #. HAS_NSEC3
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:489
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:530
 msgid "The zone has NSEC3 records."
 msgstr "La zone a des enregistrements de type \"NSEC3\"."
 
 #. NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:551
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:600
 msgid "The zone is not signed with DNSSEC."
 msgstr "La zone n'est pas signée avec DNSSEC."
 
 #. COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:391
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:432
 #, perl-brace-format
 msgid "There are both DS and DNSKEY records with key tags {keytags}."
 msgstr ""
@@ -1737,7 +1984,7 @@ msgstr ""
 "tag de clé {keytags}."
 
 #. NEITHER_DNSKEY_NOR_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:513
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:562
 msgid "There are neither DS nor DNSKEY records for the zone."
 msgstr ""
 "Il n'y a pas enregistrements de type \"DS\", ni de type \"DNSKEY\" pour la "
@@ -1766,7 +2013,7 @@ msgstr ""
 "Il ne doit pas y avoir de caractère '@' dans le champ RNAME ({rname}) du SOA."
 
 #. NSEC_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:591
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:640
 #, perl-brace-format
 msgid "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 msgstr ""
@@ -1774,7 +2021,7 @@ msgstr ""
 "enregistrements de type \"NSEC\" avec la signature {sig}."
 
 #. NSEC3_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:571
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:620
 #, perl-brace-format
 msgid "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
 msgstr ""
@@ -1782,7 +2029,7 @@ msgstr ""
 "enregistrements de type \"NSEC3\" avec la RRSIG {sig}."
 
 #. SOA_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:619
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:668
 #, fuzzy, perl-brace-format
 msgid ""
 "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
@@ -1815,7 +2062,7 @@ msgid "Using version {version} of the Zonemaster engine."
 msgstr "Utilisation de la version {version} du moteur Zonemaster."
 
 #. INVALID_NAME_RCODE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:497
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:538
 #, fuzzy, perl-brace-format
 msgid ""
 "When asked for the name {name}, which must not exist, the response had RCODE "
@@ -1916,7 +2163,7 @@ msgid "[ASN:RAW] {address};{data}"
 msgstr "[ASN:RAW] {address};{data}"
 
 #. DNSKEY_BUT_NOT_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:407
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:448
 #, fuzzy, perl-brace-format
 msgid "{child} sent a DNSKEY record, but {parent} did not send a DS record."
 msgstr ""
@@ -1925,7 +2172,7 @@ msgstr ""
 "parente."
 
 #. NO_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:525
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:574
 #, perl-brace-format
 msgid "{from} returned no DS records for {zone}."
 msgstr ""
@@ -1933,7 +2180,7 @@ msgstr ""
 "pour la zone '{zone}'."
 
 #. DNSKEY_AND_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:403
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:444
 #, fuzzy, perl-brace-format
 msgid "{parent} sent a DS record, and {child} a DNSKEY record."
 msgstr ""
@@ -1941,7 +2188,7 @@ msgstr ""
 "noms de la zone, un enregistrement de type \"DNSKEY\"."
 
 #. DS_BUT_NOT_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:427
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:468
 #, fuzzy, perl-brace-format
 msgid "{parent} sent a DS record, but {child} did not send a DNSKEY record."
 msgstr ""
@@ -1949,7 +2196,7 @@ msgstr ""
 "de noms de la zone ne retournent pas d'enregistrement de type \"DNSKEY\"."
 
 #. NO_NSEC3PARAM
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:539
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:588
 #, perl-brace-format
 msgid "{server} returned no NSEC3PARAM records."
 msgstr ""

--- a/share/sv.po
+++ b/share/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-25 18:32+0200\n"
+"POT-Creation-Date: 2019-10-03 23:11+0200\n"
 "PO-Revision-Date: 2017-12-15\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. SOA_NOT_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:277
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:283
 #, perl-brace-format
 msgid "A SOA query NOERROR response from {ns} was received empty."
 msgstr ""
@@ -20,12 +20,18 @@ msgstr ""
 "tomt."
 
 #. DNSKEY_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:419
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:460
 #, perl-brace-format
 msgid "A signature for DNSKEY with tag {signature} was correctly signed."
 msgstr ""
 "Verifiering av en signatur för DNSKEY-posten med 'keytag' {signature} "
 "lyckades."
+
+#. ONE_SOA_MNAME
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:187
+#, fuzzy, perl-brace-format
+msgid "A single SOA mname value was seen ({mname})"
+msgstr "Exakt en 'SOA RNAME' hittades: ({rname})"
 
 #. ONE_SOA_RNAME
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:191
@@ -106,7 +112,7 @@ msgid "All nameservers succeeded to resolve to an IP address."
 msgstr "Alla namnservrar kunde slås upp till minst en IP-adress."
 
 #. NAMES_MATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:193
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:199
 msgid "All of the nameserver names are listed both at parent and child."
 msgstr ""
 "Alla namnservrar (NS-poster) finns både i delegeringen (moderzon) och i "
@@ -118,39 +124,53 @@ msgid "All reverse DNS entry matches name server name."
 msgstr "Varje bakåtuppslagning stämmer med motsvarande namnservernamn."
 
 #. DISTINCT_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:137
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:143
 msgid "All the IP addresses used by the nameservers are unique"
 msgstr ""
 "Varje namnserver har unika IP-adress som inte delas med andra namnservrar."
 
+#. CHILD_DISTINCT_NS_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:127
+#, fuzzy
+msgid "All the IP addresses used by the nameservers in child are unique."
+msgstr ""
+"Varje namnserver har unika IP-adress som inte delas med andra namnservrar."
+
+#. DEL_DISTINCT_NS_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:135
+#, fuzzy
+msgid "All the IP addresses used by the nameservers in parent are unique."
+msgstr ""
+"Varje namnserver har unika IP-adress som inte delas med andra namnservrar."
+
 #. SOA_EXISTS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:273
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:279
 msgid "All the nameservers have SOA record."
 msgstr "Alla namnservrar har en SOA-post."
 
 #. ARE_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:117
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:123
 #, perl-brace-format
 msgid "All these nameservers are confirmed to be authoritative : {nsset}."
 msgstr "Följande namnservrar är auktoritativa : {nsset}."
 
 #. DS_MATCH_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:451
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:492
 msgid "At least one DS record with a matching DNSKEY record was found."
 msgstr "Det finns minst en DS-post med med en matchande DNSKEY-post."
 
 #. SOA_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:627
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:676
 msgid "At least one RRSIG correctly signs the SOA RRset."
 msgstr "Det finns minst en RRSIG-post som korrekt signerar SOA-posten."
 
 #. NSEC_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:587
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:636
 msgid "At least one signature correctly signed the NSEC RRset."
 msgstr "Det finns minst en korrekt signatur (RRSIG) för NSEC-posterna."
 
 #. NSEC3_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:567
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:616
 msgid "At least one signature correctly signed the NSEC3 RRset."
 msgstr "Det finns minst en signatur som korrekt signerar NSEC3-posterna."
 
@@ -182,7 +202,7 @@ msgstr ""
 "bindestreck."
 
 #. NO_KEYS_OR_NO_SIGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:529
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:578
 #, perl-brace-format
 msgid ""
 "Cannot test DNSKEY signatures, because we got {keys} DNSKEY records and "
@@ -192,7 +212,7 @@ msgstr ""
 "{sigs} RRSIG-poster."
 
 #. NO_KEYS_OR_NO_SIGS_OR_NO_SOA
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:533
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:582
 #, perl-brace-format
 msgid ""
 "Cannot test SOA signatures, because we got {keys} DNSKEY records, {sigs} "
@@ -202,11 +222,31 @@ msgstr ""
 "DNSKEY-poster, {sigs} RRSIG-poster och {soas} SOA-poster."
 
 #. NOT_ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:227
 #, fuzzy, perl-brace-format
 msgid ""
-"Child does not list enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child does not list enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
+msgstr ""
+"Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen "
+"({count}). Minsta tillåtna antal är {minimum}."
+
+#. NOT_ENOUGH_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:203
+#, fuzzy, perl-brace-format
+msgid ""
+"Child does not list enough ({count}) nameservers that resolve to IPv4 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen "
+"({count}). Minsta tillåtna antal är {minimum}."
+
+#. NOT_ENOUGH_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:215
+#, fuzzy, perl-brace-format
+msgid ""
+"Child does not list enough ({count}) nameservers that resolve to IPv6 "
+"addresses ({addrs}). Lower limit set to {minimum}."
 msgstr ""
 "Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen "
 "({count}). Minsta tillåtna antal är {minimum}."
@@ -221,7 +261,7 @@ msgstr ""
 "moderzonen ({addresses})."
 
 #. EXTRA_NAME_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:173
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:179
 #, perl-brace-format
 msgid "Child has nameserver(s) not listed at parent ({extra})."
 msgstr ""
@@ -229,14 +269,50 @@ msgstr ""
 "moderzonen ({extra})."
 
 #. ENOUGH_NS_CHILD
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
-#, perl-brace-format
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:171
+#, fuzzy, perl-brace-format
 msgid ""
-"Child lists enough ({count}) nameservers ({ns}). Lower limit set to "
+"Child lists enough ({count}) nameservers ({nss}). Lower limit set to "
 "{minimum}."
+msgstr ""
+"Dotterzonen har tillräckligt många ({count}) namnservrar ({nss}). Minsta "
+"tillåtna antal är {minimum}."
+
+#. ENOUGH_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:147
+#, fuzzy, perl-brace-format
+msgid ""
+"Child lists enough ({count}) nameservers that resolve to IPv4 addresses "
+"({addrs}). Lower limit set to {minimum}."
 msgstr ""
 "Dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta "
 "tillåtna antal är {minimum}."
+
+#. ENOUGH_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:159
+#, fuzzy, perl-brace-format
+msgid ""
+"Child lists enough ({count}) nameservers that resolve to IPv6 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta "
+"tillåtna antal är {minimum}."
+
+#. NO_IPV4_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:235
+#, perl-brace-format
+msgid ""
+"Child lists no nameserver that resolves to an IPv4 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
+
+#. NO_IPV6_NS_CHILD
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:247
+#, perl-brace-format
+msgid ""
+"Child lists no nameserver that resolves to an IPv6 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
 
 #. LOOKUP_ERROR
 #: ../lib/Zonemaster/Engine/Translator.pm:49
@@ -248,7 +324,7 @@ msgstr ""
 "'{message}'"
 
 #. DS_DOES_NOT_MATCH_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:439
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:480
 #, fuzzy, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} does not match the "
@@ -258,7 +334,7 @@ msgstr ""
 "'keytag'."
 
 #. DS_MATCHES_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:447
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:488
 #, fuzzy, perl-brace-format
 msgid ""
 "DS record with keytag {keytag} and digest type {digtype} matches the DNSKEY "
@@ -267,7 +343,7 @@ msgstr ""
 "DS-posten med 'keytag' {keytag} matchar DNSKEY-posten med samma 'keytag'."
 
 #. DS_DIGTYPE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:435
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:476
 #, perl-brace-format
 msgid "DS record with keytag {keytag} uses digest type {digtype}, which is OK."
 msgstr ""
@@ -275,15 +351,35 @@ msgstr ""
 "{digtype}."
 
 #. DS_DIGTYPE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:431
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:472
 #, perl-brace-format
 msgid "DS record with keytag {keytag} uses forbidden digest type {digtype}."
 msgstr ""
 "DS-posten med 'keytag' {keytag} använder den förbjudna digest-typen "
 "{digtype}."
 
+#. NOT_ENOUGH_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:209
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation does not list enough ({count}) nameservers that resolve to IPv4 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen "
+"({count}). Minsta tillåtna antal är {minimum}."
+
+#. NOT_ENOUGH_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:221
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation does not list enough ({count}) nameservers that resolve to IPv6 "
+"addresses ({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Det finns inte tillräckligt många namnservrar (NS-poster) i dotterzonen "
+"({count}). Minsta tillåtna antal är {minimum}."
+
 #. DELEGATION_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:395
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:436
 #, perl-brace-format
 msgid "Delegation from parent to child is not properly signed {reason}."
 msgstr ""
@@ -291,11 +387,47 @@ msgstr ""
 "signerad ({reason})."
 
 #. DELEGATION_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:399
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:440
 msgid "Delegation from parent to child is properly signed."
 msgstr ""
 "Delegeringen från moderzonen till dotterzonens namnservrar är korrekt "
 "signerad."
+
+#. ENOUGH_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:153
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation lists enough ({count}) nameservers that resolve to IPv4 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta "
+"tillåtna antal är {minimum}."
+
+#. ENOUGH_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:165
+#, fuzzy, perl-brace-format
+msgid ""
+"Delegation lists enough ({count}) nameservers that resolve to IPv6 addresses "
+"({addrs}). Lower limit set to {minimum}."
+msgstr ""
+"Dotterzonen har tillräckligt många ({count}) namnservrar ({ns}). Minsta "
+"tillåtna antal är {minimum}."
+
+#. NO_IPV4_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:241
+#, perl-brace-format
+msgid ""
+"Delegation lists no nameserver that resolves to an IPv4 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
+
+#. NO_IPV6_NS_DEL
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
+#, perl-brace-format
+msgid ""
+"Delegation lists no nameserver that resolves to an IPv6 address. If any were "
+"present, the minimum allowed would be {minimum}."
+msgstr ""
 
 #. SOA_SERIAL_VARIATION
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:213
@@ -390,8 +522,14 @@ msgid "Domain's authoritative nameservers do not belong to the same AS."
 msgstr ""
 "IP-adresserna för domänens auktoritativa namnservrar finns i mer än ett AS."
 
+#. NS_ERROR
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:309
+#, fuzzy, perl-brace-format
+msgid "Erroneous response from nameserver {ns}/{address}."
+msgstr "Inget svar från namnservern '{ns}/{address}' på fråga efter NS-post."
+
 #. DS_RFC4509_NOT_VALID
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:459
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:500
 msgid ""
 "Existing DS with digest type 2, while they do not match DNSKEY records, "
 "prevent use of DS with digest type 1 (RFC4509, section 3)."
@@ -412,7 +550,7 @@ msgid "Followed a fake delegation."
 msgstr "Följde en skapad delegering."
 
 #. DS_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:443
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:484
 #, perl-brace-format
 msgid "Found DS records with tags {keytags}."
 msgstr "Det finns DS-poster med keytaggarna {keytags}."
@@ -456,18 +594,31 @@ msgstr ""
 "Glue-poster stämmer överens mellan delegering och auktoritativ data "
 "(dotterzon)."
 
+#. CHILD_NS_SAME_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:131
+#, fuzzy, perl-brace-format
+msgid "IP {address} in child refers to multiple nameservers ({nss})."
+msgstr "IP-adressen {address} referrerar till flera namnservrar ({nss})."
+
+#. DEL_NS_SAME_IP
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:139
+#, fuzzy, perl-brace-format
+msgid "IP {address} in parent refers to multiple nameservers ({nss})."
+msgstr "IP-adressen {address} referrerar till flera namnservrar ({nss})."
+
 #. SAME_IP_ADDRESS
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:269
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:275
 #, perl-brace-format
 msgid "IP {address} refers to multiple nameservers ({nss})."
 msgstr "IP-adressen {address} referrerar till flera namnservrar ({nss})."
 
 #. IPV4_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:144
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:181
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:187
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:273
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:139
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:542
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:176
 #, perl-brace-format
 msgid "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr ""
@@ -486,11 +637,12 @@ msgid "IPv4 is enabled, can send \"{rrtype}\" query to {ns}/{address}."
 msgstr "IPv4 är påslaget. Skickar fråga om '{rrtype}' till {ns}/{address}."
 
 #. IPV6_DISABLED
-#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:148
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:185
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:191
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:277
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:143
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:546
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:184
 #, perl-brace-format
 msgid "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}/{address}."
 msgstr ""
@@ -519,7 +671,7 @@ msgstr ""
 "på förfrågan med EDNS version 0 (fråga efter {dname})."
 
 #. KEY_DETAILS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:505
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:554
 #, perl-brace-format
 msgid ""
 "Key with keytag {keytag} details : Size = {keysize}, Flags ({sep}, "
@@ -552,25 +704,25 @@ msgid "Module {module} finished running."
 msgstr "Modulen '{module}' avslutades."
 
 #. NSEC_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:579
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:628
 #, perl-brace-format
 msgid "NSEC covers {name}."
 msgstr "NSEC täcker '{name}'."
 
 #. NSEC_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:575
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:624
 #, perl-brace-format
 msgid "NSEC does not cover {name}."
 msgstr "NSEC täcker inte '{name}'."
 
 #. NSEC3_COVERS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:559
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:608
 #, perl-brace-format
 msgid "NSEC3 record covers {name}."
 msgstr "Det finns en NSEC3-post som täcker '{name}'."
 
 #. NSEC3_COVERS_NOT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:555
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:604
 #, perl-brace-format
 msgid "NSEC3 record does not cover {name}."
 msgstr "Det finns ingen NSEC3-post som täcker '{name}'."
@@ -644,23 +796,23 @@ msgstr ""
 msgid "Nameserver {ns} has an IP address ({address}) without PTR configured."
 msgstr "Namnservern '{ns}' har en IP-adress ({address}) utan bakåtuppslagning."
 
-#. HAS_NAMESERVERS
-#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
-#, perl-brace-format
-msgid "Nameserver {ns} listed these servers as glue: {nsnlist}."
-msgstr "Namnservern '{ns}' gav dessa servrar som 'glue': {nsnlist}."
-
 #. IS_NOT_AUTHORITATIVE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:189
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:195
 #, perl-brace-format
 msgid "Nameserver {ns} response is not authoritative on {proto} port 53."
 msgstr "Namnservern '{ns}' svarade inte auktoritativt på {proto} port 53."
 
 #. NS_RR_IS_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:253
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:259
 #, fuzzy, perl-brace-format
 msgid "Nameserver {ns} {address_type} RR point to CNAME."
 msgstr "Namnservern '{ns}' har en CNAME-post."
+
+#. UNSUPPORTED_EDNS_VER
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:333
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} accepts an unsupported EDNS version."
+msgstr "Namnservern {ns}/{address} är ingen rekursiv resolver."
 
 #. NAMESERVER_HAS_TCP_53
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:128
@@ -698,7 +850,7 @@ msgstr "Namnservern {ns}/{address} svarade inte på frågan om 'NS'."
 
 #. NO_RESPONSE
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:167
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:547
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:596
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} did not respond."
 msgstr "Inget svar från namnservern '{ns}/{address}'."
@@ -740,6 +892,12 @@ msgstr "Namnservern {ns}/{address} stöder inte EDNS0 (svarar med 'FORMERR')."
 msgid "Nameserver {ns}/{address} dropped AAAA query."
 msgstr "Namnservern {ns}/{address} besvarade inte AAAA-frågan."
 
+#. Z_FLAGS_NOTCLEAR
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:345
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} has one or more unknown EDNS Z flag bits set."
+msgstr "Namnservern {ns}/{address} svarade inte på frågan om 'NS'."
+
 #. IS_A_RECURSOR
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:281
 #, perl-brace-format
@@ -751,6 +909,12 @@ msgstr "Namnservern {ns}/{address} är en rekursiv resolver."
 #, perl-brace-format
 msgid "Nameserver {ns}/{address} is not a recursor."
 msgstr "Namnservern {ns}/{address} är ingen rekursiv resolver."
+
+#. HAS_NAMESERVERS
+#: ../lib/Zonemaster/Engine/Test/Basic.pm:152
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} listed these servers as glue: {nsnlist}."
+msgstr "Namnservern '{ns}/{address}' gav dessa servrar som 'glue': {nsnlist}."
 
 #. NAMESERVER_NO_TCP_53
 #: ../lib/Zonemaster/Engine/Test/Connectivity.pm:136
@@ -782,6 +946,28 @@ msgstr ""
 "Namnservern {ns}/{address} besvarade en SOA-fråga från en annan källadress "
 "({source})."
 
+#. MISSING_OPT_IN_TRUNCATED
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:285
+#, fuzzy, perl-brace-format
+msgid ""
+"Nameserver {ns}/{address} replies on an EDNS query with a truncated response "
+"without EDNS."
+msgstr ""
+"Namnservern {ns}/{address} besvarade en SOA-fråga från en annan källadress "
+"({source})."
+
+#. NO_RESPONSE_DNSKEY
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:592
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} responded with no DNSKEY record(s)."
+msgstr "Namnservern {ns}/{address} svarade inte på frågan om 'NS'."
+
+#. UNKNOWN_OPTION_CODE
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:329
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns}/{address} responds with an unknown ENDS OPTION-CODE."
+msgstr "Namnservern {ns}/{address} svarade inte på frågan om 'NS'."
+
 #. HAS_A_RECORDS
 #: ../lib/Zonemaster/Engine/Test/Basic.pm:144
 #, perl-brace-format
@@ -800,22 +986,22 @@ msgid "Nameservers did not respond to A query."
 msgstr "Namnservern svarade inte på en A-fråga."
 
 #. ADDITIONAL_DNSKEY_SKIPPED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:353
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:398
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr "Inga DNSKEY-poster hittades. Resterande DNSSEC-tester hoppas över."
 
 #. NO_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:521
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:570
 msgid "No DNSKEYs were returned."
 msgstr "Inga DNSKEY-poster returnerades."
 
 #. NO_COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:517
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:566
 msgid "No DS record had a DNSKEY with a matching keytag."
 msgstr "Det finns ingen DS-post som har en DNSKEY-post med matchande keytag."
 
 #. DS_MATCH_NOT_FOUND
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:455
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:496
 msgid "No DS record with a matching DNSKEY record was found."
 msgstr "Det finns ingen DS-post med matchande DNSKEY-post."
 
@@ -842,7 +1028,7 @@ msgstr ""
 "Inga NS-poster för den testade zonen från föräldern. NS-tester hoppas över."
 
 #. SOA_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:615
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:664
 msgid "No RRSIG correctly signed the SOA RRset."
 msgstr "Det finns ingen RRSIG som har korrekt signerat SOA-posten."
 
@@ -868,7 +1054,7 @@ msgid "No nameserver address is in an AS."
 msgstr "Ingen namnserver har någon adress i något AS."
 
 #. NS_RR_NO_CNAME
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:257
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:263
 msgid "No nameserver point to CNAME alias."
 msgstr "Inget namnservernamn har en CNAME-post."
 
@@ -912,6 +1098,14 @@ msgstr "Inget svar från namnservern på PTR-fråga ({reverse})."
 msgid "No response from nameserver(s) on SOA queries."
 msgstr "Inget svar från namnserver på fråga efter SOA-post."
 
+#. NO_RESPONSE
+#: ../lib/Zonemaster/Engine/Test/Syntax.pm:213
+#: ../lib/Zonemaster/Engine/Test/Nameserver.pm:301
+#, fuzzy, perl-brace-format
+msgid "No response from {ns}/{address} asking for {dname}."
+msgstr ""
+"Inget svar från {ns}/{address} på förfrågan med EDNS (fråga efter {dname})."
+
 #. BREAKS_ON_EDNS
 #: ../lib/Zonemaster/Engine/Test/Nameserver.pm:208
 #, perl-brace-format
@@ -922,12 +1116,12 @@ msgstr ""
 "Inget svar från {ns}/{address} på förfrågan med EDNS (fråga efter {dname})."
 
 #. NSEC_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:583
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:632
 msgid "No signature correctly signed the NSEC RRset."
 msgstr "Ingen signatur har korrekt signerat NSEC-posterna."
 
 #. NSEC3_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:563
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:612
 msgid "No signature correctly signed the NSEC3 RRset."
 msgstr "Ingen signatur signerade NSEC3-posterna korrekt."
 
@@ -946,7 +1140,7 @@ msgstr ""
 "Ingen av följande nameserverar skickar hänvisning till moderzonen: {names}."
 
 #. TOTAL_NAME_MISMATCH
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:281
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:287
 msgid "None of the nameservers listed at the parent are listed at the child."
 msgstr ""
 "Ingen av de namnservrar som finns i delegeringen (moderzonen) finns i "
@@ -970,7 +1164,7 @@ msgstr ""
 "{maxsize} byte. Försök med kommandot '{command}'."
 
 #. NOT_ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:225
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:231
 #, fuzzy, perl-brace-format
 msgid ""
 "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set "
@@ -995,7 +1189,7 @@ msgstr ""
 "dotterzonen ({addresses})."
 
 #. EXTRA_NAME_PARENT
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:177
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:183
 #, perl-brace-format
 msgid "Parent has nameserver(s) not listed at the child ({extra})."
 msgstr ""
@@ -1003,7 +1197,7 @@ msgstr ""
 "dotterzonen ({extra})."
 
 #. ENOUGH_NS_DEL
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:169
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:175
 #, perl-brace-format
 msgid ""
 "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to "
@@ -1019,7 +1213,7 @@ msgid "Profile was read from {name}."
 msgstr "Profil lästes från '{name}'."
 
 #. RRSIG_EXPIRATION
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:607
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:656
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} expires at : {date}."
@@ -1027,7 +1221,7 @@ msgstr ""
 "RRSIG med 'keytag' {tag} täckande posttyp(er) {types} löper ut datum {date}."
 
 #. DURATION_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:471
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:512
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1037,7 +1231,7 @@ msgstr ""
 "livslängd på {duration} sekunder (accepterad livslängd)."
 
 #. DURATION_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:465
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:506
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a duration of "
@@ -1047,7 +1241,7 @@ msgstr ""
 "livslängd på {duration} sekunder, vilket är för länge."
 
 #. REMAINING_LONG
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:595
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:644
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1057,7 +1251,7 @@ msgstr ""
 "kvarvarande livslängd på {duration} sekunder, vilket är för länge."
 
 #. REMAINING_SHORT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:601
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:650
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has a remaining "
@@ -1067,7 +1261,7 @@ msgstr ""
 "kvarvarande livslängd på {duration} sekunder, vilket är för kort."
 
 #. RRSIG_EXPIRED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:611
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:660
 #, perl-brace-format
 msgid ""
 "RRSIG with keytag {tag} and covering type(s) {types} has already expired "
@@ -1077,7 +1271,7 @@ msgstr ""
 "löpt ut (utgångstiden är: {expiration})."
 
 #. SOA_SIGNATURE_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:623
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:672
 #, perl-brace-format
 msgid "RRSIG {signature} correctly signs SOA RRset."
 msgstr "RRSIG '{signature}' är en korrekt signatur för SOA-posten."
@@ -1190,9 +1384,9 @@ msgstr "Nameservern i SOA MNAME ({mname}) är auktoritativ för zonen '{zone}'."
 #, fuzzy, perl-brace-format
 msgid ""
 "SOA 'mname' nameserver ({mname}) is not listed in \"parent\" NS records for "
-"tested zone ({ns})."
+"tested zone ({nss})."
 msgstr ""
-"Namnservern i SOA MNAME finns inte i delegeringen från moderzonen ({ns})."
+"Namnservern i SOA MNAME finns inte i delegeringen från moderzonen ({nss})."
 
 #. MNAME_NO_RESPONSE
 #: ../lib/Zonemaster/Engine/Test/Zone.pm:142
@@ -1338,6 +1532,12 @@ msgstr ""
 msgid "Saw {count} NS set."
 msgstr "{count} NS-uppsättningar hittades."
 
+#. MULTIPLE_SOA_MNAMES
+#: ../lib/Zonemaster/Engine/Test/Consistency.pm:151
+#, fuzzy, perl-brace-format
+msgid "Saw {count} SOA mname."
+msgstr "{count} olika 'SOA RNAME' hittades."
+
 #. MULTIPLE_SOA_RNAMES
 #: ../lib/Zonemaster/Engine/Test/Consistency.pm:155
 #, perl-brace-format
@@ -1357,14 +1557,14 @@ msgid "Saw {count} SOA time parameter set."
 msgstr "{count} olika uppsättningar med SOA-tidsparametrar hittades."
 
 #. EXTRA_PROCESSING_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:481
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:522
 #, perl-brace-format
 msgid "Server at {server} sent {keys} DNSKEY records and {sigs} RRSIG records."
 msgstr ""
 "Namnservern '{server}' skickade {keys} DNSKEY-poster och {sigs} RRSIG-poster."
 
 #. EXTRA_PROCESSING_BROKEN
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:477
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:518
 #, perl-brace-format
 msgid ""
 "Server at {server} sent {keys} DNSKEY records, and {sigs} RRSIG records."
@@ -1373,7 +1573,7 @@ msgstr ""
 "poster."
 
 #. DNSKEY_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:415
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:456
 #, perl-brace-format
 msgid ""
 "Signature for DNSKEY with tag {signature} failed to verify with error "
@@ -1388,8 +1588,18 @@ msgstr ""
 msgid "Target ({info}) found to deliver e-mail for the domain name."
 msgstr "Adressen ({info}) är angiven som mål för mail-leverans till domänen."
 
+#. ALGORITHM_NOT_ZONE_SIGN
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
+#, fuzzy, perl-brace-format
+msgid ""
+"The DNSKEY with tag {keytag} uses algorithm number not meant for zone "
+"signing{algorithm}/({description})."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder en algoritm med det privata "
+"algoritmnumret {algorithm}/({description})."
+
 #. ALGORITHM_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:375
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:416
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses algorithm number {algorithm}/"
@@ -1398,8 +1608,18 @@ msgstr ""
 "DNSKEY-posten med 'tag' {keytag} använder det accepterade algoritm numret "
 "{algorithm}/({description})."
 
+#. ALGORITHM_NOT_RECOMMENDED
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:406
+#, fuzzy, perl-brace-format
+msgid ""
+"The DNSKEY with tag {keytag} uses an algorithm number {algorithm}/"
+"({description} which which is not recommended to be used."
+msgstr ""
+"DNSKEY-posten med 'tag' {keytag} använder det accepterade algoritm numret "
+"{algorithm}/({description})."
+
 #. ALGORITHM_DEPRECATED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:361
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:402
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses deprecated algorithm number {algorithm}/"
@@ -1409,7 +1629,7 @@ msgstr ""
 "utfasade algoritmnumret {algorithm}/({description})."
 
 #. ALGORITHM_PRIVATE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:379
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:420
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses private algorithm number {algorithm}/"
@@ -1419,7 +1639,7 @@ msgstr ""
 "algoritmnumret {algorithm}/({description})."
 
 #. ALGORITHM_RESERVED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:383
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:424
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses reserved algorithm number {algorithm}/"
@@ -1429,7 +1649,7 @@ msgstr ""
 "algoritmnumret {algorithm}/({description})."
 
 #. ALGORITHM_UNASSIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:387
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:428
 #, perl-brace-format
 msgid ""
 "The DNSKEY with tag {keytag} uses unassigned algorithm number {algorithm}/"
@@ -1444,13 +1664,21 @@ msgstr ""
 msgid "The SOA RNAME field ({rname}) is compliant with RFC2822."
 msgstr "Adressen i SOA RNAME ({rname}) är giltig enligt RFC822."
 
+#. RNAME_MAIL_DOMAIN_INVALID
+#: ../lib/Zonemaster/Engine/Test/Syntax.pm:229
+#, perl-brace-format
+msgid ""
+"The SOA RNAME mail domain ({domain}) cannot be resolved to a mail server "
+"with an IP address."
+msgstr ""
+
 #. DNSKEY_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:423
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:464
 msgid "The apex DNSKEY RRset was correcly signed."
 msgstr "DNSKEY-posterna i zontoppen var korrekt signerad."
 
 #. DNSKEY_NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:411
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:452
 msgid "The apex DNSKEY RRset was not correctly signed."
 msgstr "DNSKEY-posterna i zontoppen var inte korrekt signerad."
 
@@ -1501,19 +1729,19 @@ msgid "The module {name} was disabled by the policy."
 msgstr "Modulen '{name}' var inaktiverad i policyn."
 
 #. ITERATIONS_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:501
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:550
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is OK."
 msgstr "Antalet NSEC3-iterationer är {count} (accepterad antal)."
 
 #. MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:509
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:558
 #, perl-brace-format
 msgid "The number of NSEC3 iterations is {count}, which is on the high side."
 msgstr "Antalet NSEC3-iterationer är {count}, vilket är högt."
 
 #. TOO_MANY_ITERATIONS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:631
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:680
 #, perl-brace-format
 msgid ""
 "The number of NSEC3 iterations is {count}, which is too high for key length "
@@ -1523,7 +1751,7 @@ msgstr ""
 "{keylength}."
 
 #. REFERRAL_SIZE_TOO_LARGE
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:261
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:267
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is larger than 512 octets (it is "
@@ -1533,7 +1761,7 @@ msgstr ""
 "byte)."
 
 #. REFERRAL_SIZE_OK
-#: ../lib/Zonemaster/Engine/Test/Delegation.pm:265
+#: ../lib/Zonemaster/Engine/Test/Delegation.pm:271
 #, perl-brace-format
 msgid ""
 "The smallest possible legal referral packet is smaller than 513 octets (it "
@@ -1543,33 +1771,33 @@ msgstr ""
 "{size} byte)."
 
 #. HAS_NSEC
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:493
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:534
 msgid "The zone has NSEC records."
 msgstr "Zonen har NSEC-poster."
 
 #. HAS_NSEC3_OPTOUT
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:485
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:526
 msgid "The zone has NSEC3 opt-out records."
 msgstr "Zonen har opt-out-flaggan satt för NSEC3."
 
 #. HAS_NSEC3
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:489
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:530
 msgid "The zone has NSEC3 records."
 msgstr "Zonen har NSEC3-poster."
 
 #. NOT_SIGNED
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:551
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:600
 msgid "The zone is not signed with DNSSEC."
 msgstr "Zonen är inte signerad med DNSSEC."
 
 #. COMMON_KEYTAGS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:391
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:432
 #, perl-brace-format
 msgid "There are both DS and DNSKEY records with key tags {keytags}."
 msgstr "Det finns både DS- and DNSKEY-poster med 'keytag' {keytags}."
 
 #. NEITHER_DNSKEY_NOR_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:513
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:562
 msgid "There are neither DS nor DNSKEY records for the zone."
 msgstr "Zonen har varken DS- eller DNSKEY-poster."
 
@@ -1593,21 +1821,21 @@ msgid ""
 msgstr "Felaktigt använt '@'-tecken i SOA RNAME ({rname})."
 
 #. NSEC_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:591
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:640
 #, perl-brace-format
 msgid "Trying to verify NSEC RRset with RRSIG {sig} gave error '{error}'."
 msgstr ""
 "Försöket att verifiera NSEC-posterna med RRSIG {sig} gav felet '{error}'."
 
 #. NSEC3_SIG_VERIFY_ERROR
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:571
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:620
 #, perl-brace-format
 msgid "Trying to verify NSEC3 RRset with RRSIG {sig} gave error '{error}'."
 msgstr ""
 "Försöket att verifiera NSEC3-posterna med RRSIG {sig} gav felet '{error}'."
 
 #. SOA_SIGNATURE_NOT_OK
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:619
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:668
 #, perl-brace-format
 msgid ""
 "Trying to verify SOA RRset with signature {signature} gave error '{error}'."
@@ -1641,7 +1869,7 @@ msgid "Using version {version} of the Zonemaster engine."
 msgstr "Använder version {version} av Zonemasters testmotor."
 
 #. INVALID_NAME_RCODE
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:497
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:538
 #, perl-brace-format
 msgid ""
 "When asked for the name {name}, which must not exist, the response had RCODE "
@@ -1739,7 +1967,7 @@ msgid "[ASN:RAW] {address};{data}"
 msgstr "[ASN:RAW] {address};{data}"
 
 #. DNSKEY_BUT_NOT_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:407
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:448
 #, perl-brace-format
 msgid "{child} sent a DNSKEY record, but {parent} did not send a DS record."
 msgstr ""
@@ -1747,13 +1975,13 @@ msgstr ""
 "skickade inte någon DS-post."
 
 #. NO_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:525
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:574
 #, perl-brace-format
 msgid "{from} returned no DS records for {zone}."
 msgstr "'{from}' skickade inga DS-poster för '{zone}'."
 
 #. DNSKEY_AND_DS
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:403
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:444
 #, perl-brace-format
 msgid "{parent} sent a DS record, and {child} a DNSKEY record."
 msgstr ""
@@ -1761,7 +1989,7 @@ msgstr ""
 "DNSKEY-post."
 
 #. DS_BUT_NOT_DNSKEY
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:427
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:468
 #, perl-brace-format
 msgid "{parent} sent a DS record, but {child} did not send a DNSKEY record."
 msgstr ""
@@ -1769,7 +1997,7 @@ msgstr ""
 "skickade ingen DNSKEY-post."
 
 #. NO_NSEC3PARAM
-#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:539
+#: ../lib/Zonemaster/Engine/Test/DNSSEC.pm:588
 #, perl-brace-format
 msgid "{server} returned no NSEC3PARAM records."
 msgstr "'{server}' gav inga NSEC3PARAM-poster i svaret."


### PR DESCRIPTION
Very few cases left before this fix. Now {ns} refers only to a name server (without address) and {nss} refers to a list of name servers.

Resolves #102.