### PR TITLE
Fix issue zonemaster engine dnnsec14 missing messages

### DIFF
--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -1,6 +1,6 @@
 package Zonemaster::Engine::Test::DNSSEC;
 
-use version; our $VERSION = version->declare("v1.1.6");
+use version; our $VERSION = version->declare("v1.1.7");
 
 ###
 ### This test module implements DNSSEC tests.

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -507,6 +507,18 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # DNSSEC:DNSKEY_SIGNED
           "The apex DNSKEY RRset was correcly signed.", @_;
     },
+    DNSKEY_SMALLER_THAN_REC => sub {
+        __x    # DNSSEC:DNSKEY_SMALLER_THAN_REC
+          "DNSKEY with tag {keytag} has a size ({keysize}) smaller than the recommended one ({keysizerec}).", @_;
+    },
+    DNSKEY_TOO_SMALL_FOR_ALGO => sub {
+        __x    # DNSSEC:DNSKEY_TOO_SMALL_FOR_ALGO
+          "DNSKEY with tag {keytag} has a size ({keysize}) smaller than the minimum one ({keysizemin}).", @_;
+    },
+    DNSKEY_TOO_LARGE_FOR_ALGO => sub {
+        __x    # DNSSEC:DNSKEY_TOO_LARGE_FOR_ALGO
+          "DNSKEY with tag {keytag} has a size ({keysize}) larger than the maximum one ({keysizemax}).", @_;
+    },
     DS_ALGORITHM_NOT_DS => sub {
         __x    # DNSSEC:DS_ALGORITHM_NOT_DS
           "{ns}/{address} returned a DS record created by algorithm {algorithm_number} which is not meant for DS. The DS record is for the DNSKEY record with keytag {keytag} in zone {zone}.", @_;

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -1,6 +1,6 @@
 package Zonemaster::Engine::Test::DNSSEC;
 
-use version; our $VERSION = version->declare("v1.1.7");
+use version; our $VERSION = version->declare("v1.1.8");
 
 ###
 ### This test module implements DNSSEC tests.
@@ -509,15 +509,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DNSKEY_SMALLER_THAN_REC => sub {
         __x    # DNSSEC:DNSKEY_SMALLER_THAN_REC
-          "DNSKEY with tag {keytag} has a size ({keysize}) smaller than the recommended one ({keysizerec}).", @_;
+          "DNSKEY with tag {keytag} and using algorithm {algorithm_number} ({algorithm_description}) has a size ({keysize}) smaller than the recommended one ({keysizerec}).", @_;
     },
     DNSKEY_TOO_SMALL_FOR_ALGO => sub {
         __x    # DNSSEC:DNSKEY_TOO_SMALL_FOR_ALGO
-          "DNSKEY with tag {keytag} has a size ({keysize}) smaller than the minimum one ({keysizemin}).", @_;
+          "DNSKEY with tag {keytag} and using algorithm {algorithm_number} ({algorithm_description}) has a size ({keysize}) smaller than the minimum one ({keysizemin}).", @_;
     },
     DNSKEY_TOO_LARGE_FOR_ALGO => sub {
         __x    # DNSSEC:DNSKEY_TOO_LARGE_FOR_ALGO
-          "DNSKEY with tag {keytag} has a size ({keysize}) larger than the maximum one ({keysizemax}).", @_;
+          "DNSKEY with tag {keytag} and using algorithm {algorithm_number} ({algorithm_description}) has a size ({keysize}) larger than the maximum one ({keysizemax}).", @_;
     },
     DS_ALGORITHM_NOT_DS => sub {
         __x    # DNSSEC:DS_ALGORITHM_NOT_DS
@@ -1903,12 +1903,13 @@ sub dnssec14 {
         next if not exists $rsa_key_size_details{$algo};
 
         my $algo_args = {
-            algorithm   => $algo,
-            keytag      => $key->keytag,
-            keysize     => $key->keysize,
-            keysizemin  => $rsa_key_size_details{$algo}{min_size},
-            keysizemax  => $rsa_key_size_details{$algo}{max_size},
-            keysizerec  => $rsa_key_size_details{$algo}{rec_size},
+            algorithm_number      => $algo,
+            algorithm_description => $algo_properties{$algo},
+            keytag                => $key->keytag,
+            keysize               => $key->keysize,
+            keysizemin            => $rsa_key_size_details{$algo}{min_size},
+            keysizemax            => $rsa_key_size_details{$algo}{max_size},
+            keysizerec            => $rsa_key_size_details{$algo}{rec_size},
         };
 
         if ( $key->keysize < $rsa_key_size_details{$algo}{min_size} ) {

--- a/share/en.po
+++ b/share/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-18 18:43+0200\n"
+"POT-Creation-Date: 2019-10-21 16:31+0200\n"
 "PO-Revision-Date: 2019-10-18 14:32+0200\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
@@ -272,6 +272,33 @@ msgid ""
 "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
 msgstr ""
 "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+
+#. DNSSEC:DNSKEY_TOO_LARGE_FOR_ALGO
+#, perl-brace-format
+msgid ""
+"DNSKEY with tag {keytag} has a size ({keysize}) larger than the maximum one "
+"({keysizemax})."
+msgstr ""
+"DNSKEY with tag {keytag} has a size ({keysize}) larger than the maximum one "
+"({keysizemax})."
+
+#. DNSSEC:DNSKEY_TOO_SMALL_FOR_ALGO
+#, perl-brace-format
+msgid ""
+"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the minimum one "
+"({keysizemin})."
+msgstr ""
+"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the minimum one "
+"({keysizemin})."
+
+#. DNSSEC:DNSKEY_SMALLER_THAN_REC
+#, perl-brace-format
+msgid ""
+"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the recommended "
+"one ({keysizerec})."
+msgstr ""
+"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the recommended "
+"one ({keysizerec})."
 
 #. DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
 #, perl-brace-format

--- a/share/en.po
+++ b/share/en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-21 16:31+0200\n"
+"POT-Creation-Date: 2019-10-22 10:30+0200\n"
 "PO-Revision-Date: 2019-10-18 14:32+0200\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
@@ -276,29 +276,35 @@ msgstr ""
 #. DNSSEC:DNSKEY_TOO_LARGE_FOR_ALGO
 #, perl-brace-format
 msgid ""
-"DNSKEY with tag {keytag} has a size ({keysize}) larger than the maximum one "
+"DNSKEY with tag {keytag} and using algorithm {algorithm_number} "
+"({algorithm_description}) has a size ({keysize}) larger than the maximum one "
 "({keysizemax})."
 msgstr ""
-"DNSKEY with tag {keytag} has a size ({keysize}) larger than the maximum one "
+"DNSKEY with tag {keytag} and using algorithm {algorithm_number} "
+"({algorithm_description}) has a size ({keysize}) larger than the maximum one "
 "({keysizemax})."
 
 #. DNSSEC:DNSKEY_TOO_SMALL_FOR_ALGO
 #, perl-brace-format
 msgid ""
-"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the minimum one "
-"({keysizemin})."
+"DNSKEY with tag {keytag} and using algorithm {algorithm_number} "
+"({algorithm_description}) has a size ({keysize}) smaller than the minimum "
+"one ({keysizemin})."
 msgstr ""
-"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the minimum one "
-"({keysizemin})."
+"DNSKEY with tag {keytag} and using algorithm {algorithm_number} "
+"({algorithm_description}) has a size ({keysize}) smaller than the minimum "
+"one ({keysizemin})."
 
 #. DNSSEC:DNSKEY_SMALLER_THAN_REC
 #, perl-brace-format
 msgid ""
-"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the recommended "
-"one ({keysizerec})."
+"DNSKEY with tag {keytag} and using algorithm {algorithm_number} "
+"({algorithm_description}) has a size ({keysize}) smaller than the "
+"recommended one ({keysizerec})."
 msgstr ""
-"DNSKEY with tag {keytag} has a size ({keysize}) smaller than the recommended "
-"one ({keysizerec})."
+"DNSKEY with tag {keytag} and using algorithm {algorithm_number} "
+"({algorithm_description}) has a size ({keysize}) smaller than the "
+"recommended one ({keysizerec})."
 
 #. DNSSEC:DS_DOES_NOT_MATCH_DNSKEY
 #, perl-brace-format


### PR DESCRIPTION
Add the following "human version" for messages in DNSSEC.pm and en.po:
DNSKEY_SMALLER_THAN_REC
DNSKEY_TOO_SMALL_FOR_ALGO
DNSKEY_TOO_LARGE_FOR_ALGO