### PR TITLE
Update management of MO file

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -92,6 +92,7 @@ t/profiles/Test-consistency05-only.json
 t/profiles/Test-consistency06-only.json
 t/profiles/Test-consistency-all.json
 t/profiles/Test-delegation-all.json
+t/profiles/Test-disabled.json
 t/profiles/Test-dnssec01-only.json
 t/profiles/Test-dnssec02-only.json
 t/profiles/Test-dnssec03-only.json
@@ -106,6 +107,7 @@ t/profiles/Test-dnssec11-only.json
 t/profiles/Test-dnssec13-only.json
 t/profiles/Test-dnssec14-only.json
 t/profiles/Test-dnssec-all.json
+t/profiles/Test-dnssec-more-all.json
 t/profiles/Test-nameserver01-only.json
 t/profiles/Test-nameserver02-only.json
 t/profiles/Test-nameserver03-only.json

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -5,6 +5,8 @@
 ^\.perltidyrc$
 ^\.travis\.yml$
 ^util/
+^share/Zonemaster-Engine.pot$
+^t/po-files.t$            # PO files are excluded from dist, so we cannot test them
 
 #!start included /usr/share/perl/5.20/ExtUtils/MANIFEST.SKIP
 # Avoid version control files.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,8 +42,8 @@ recommends 'Net::IP::XS'  => 0;
 
 sub MY::postamble {
         return <<'MAKE_FRAG';
-	$(MYEXTLIB): share/Makefile
-	cd share && $(MAKE) all
+pure_all :: share/Makefile
+	cd share && $(MAKE) touch-po all
 MAKE_FRAG
 };
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,7 @@ recommends 'Net::IP::XS'  => 0;
 sub MY::postamble {
         return <<'MAKE_FRAG';
 	$(MYEXTLIB): share/Makefile
-	cd share && $(MAKE) extract-pot touch-po all
+	cd share && $(MAKE) all
 MAKE_FRAG
 };
 

--- a/share/Makefile
+++ b/share/Makefile
@@ -1,10 +1,10 @@
 POFILES = $(wildcard *.po)
-MOFILES := $(POFILES:.po=.mo)
+MOFILES := $(POFILES:%.po=locale/%/LC_MESSAGES/Zonemaster-Engine.mo)
 POTFILE = Zonemaster-Engine.pot
 PMFILES = $(shell find ../lib -type f -name '*.pm' | sort)
 TESTMODULEFILES = $(shell find ../lib/Zonemaster/Engine/Test -type f -name '*.pm' | sort)
 
-.PHONY: all touch-po update-po extract-pot
+.PHONY: all update-po extract-pot
 
 all: ${MOFILES} modules.txt
 	@echo
@@ -14,9 +14,6 @@ all: ${MOFILES} modules.txt
 
 update-po: extract-pot $(POFILES)
 
-touch-po:
-	@touch $(POFILES)
-
 extract-pot:
 	@xgettext --output $(POTFILE) --sort-output --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)
 
@@ -25,7 +22,7 @@ $(POTFILE): extract-pot
 %.po: $(POTFILE)
 	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
 
-%.mo: %.po
+$(MOFILES): locale/%/LC_MESSAGES/Zonemaster-Engine.mo: %.po
 	@mkdir -p locale/$*/LC_MESSAGES
 	@# It must be 'Zonemaster-Engine' because that is defined in "name" in Makefile.PL
 	@perl -e 'use Locale::Msgfmt; msgfmt({in => $$ARGV[0], out => $$ARGV[1]});' $< locale/$*/LC_MESSAGES/Zonemaster-Engine.mo

--- a/share/Makefile
+++ b/share/Makefile
@@ -4,13 +4,16 @@ POTFILE = Zonemaster-Engine.pot
 PMFILES = $(shell find ../lib -type f -name '*.pm' | sort)
 TESTMODULEFILES = $(shell find ../lib/Zonemaster/Engine/Test -type f -name '*.pm' | sort)
 
-.PHONY: all update-po extract-pot
+.PHONY: all touch-po update-po extract-pot
 
 all: ${MOFILES} modules.txt
 	@echo
 	@echo Remember to make sure all of the above names are in the
 	@echo MANIFEST file, or they will not be installed.
 	@echo
+
+touch-po:
+	@touch $(POTFILE) $(POFILES)
 
 update-po: extract-pot $(POFILES)
 
@@ -28,7 +31,7 @@ $(MOFILES): locale/%/LC_MESSAGES/Zonemaster-Engine.mo: %.po
 	@perl -e 'use Locale::Msgfmt; msgfmt({in => $$ARGV[0], out => $$ARGV[1]});' $< locale/$*/LC_MESSAGES/Zonemaster-Engine.mo
 	@echo locale/$*/LC_MESSAGES/Zonemaster-Engine.mo
 
-show-fuzzy: $(POFILES)
+show-fuzzy:
 	@for f in $(POFILES) ; do msgattrib --only-fuzzy $$f ; done
 
 modules.txt: $(TESTMODULEFILES)


### PR DESCRIPTION
Here's an update to how we generate the MO files.

The files:
* The POT file is neither included in the source nor in the dist.
* The PO files are included sources but not in the dist.
* The MO files are included in the dist but not in the source.

The use cases:
 * Installation: Cpanm just wants to install the MO files, and they're included in the dist file.
 * CI: Travis just wants to test the PO files, they're included in the source, and we're already making Travis chdir to the source directory.
 * Release: Make dist is run after make all per our instructions, so make all should generate the MO files from the PO files. It's important that the PO files are not updated before generating the MO files or we'll get fuzzy messages in the MO files.

We depend on gettext to generate the POT file and the MO files, so we depend on gettext when building the dist file but not when installing the dist file. This PR removes the install-time dependency on gettext. This also obsoletes the touch-po make target, so I'm cleaning that up.

There's a unit test that implements a sanity check for the PO files. Since we don't have the PO files available at install-time, this unit test must not be run at install time. This PR makes sure the unit test (i.e. po-files.t) is excluded from the dist file.

Also fixes #660.

**Edit:** Added a list of use cases that this PR needs to consider. The first time around I forgot about Travis.