### PR TITLE
List IPv6 addresses in IPv6 message

### DIFF
--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -215,7 +215,7 @@ sub delegation01 {
     my @child_ns_ipv4 = uniq map { $_->name->string } grep { $_->address->version == 4 } @child_ns;
     my @child_ns_ipv6 = uniq map { $_->name->string } grep { $_->address->version == 6 } @child_ns;
     my @child_ns_ipv4_addrs = uniq map { $_->address->ip } grep { $_->address->version == 4 } @child_ns;
-    my @child_ns_ipv6_addrs = uniq map { $_->address->short } grep { $_->address->version == 4 } @child_ns;
+    my @child_ns_ipv6_addrs = uniq map { $_->address->short } grep { $_->address->version == 6 } @child_ns;
 
     my $child_ns_ipv4_args = {
         count   => scalar( @child_ns_ipv4 ),

--- a/t/Test-delegation01-A.t
+++ b/t/Test-delegation01-A.t
@@ -28,6 +28,7 @@ my %res = map { $_->tag => $_ } Zonemaster::Engine::Test::Delegation->delegation
 ok( $res{ENOUGH_IPV4_NS_CHILD},      q{should emit ENOUGH_IPV4_NS_CHILD} );
 ok( $res{ENOUGH_IPV4_NS_DEL},        q{should emit ENOUGH_IPV4_NS_DEL} );
 ok( $res{ENOUGH_IPV6_NS_CHILD},      q{should emit ENOUGH_IPV6_NS_CHILD} );
+ok( $res{ENOUGH_IPV6_NS_CHILD} !~ /\d+(\.\d+){3}/, q{should not show IPv4 addresses in IPv6 message} );
 ok( $res{ENOUGH_IPV6_NS_DEL},        q{should emit ENOUGH_IPV6_NS_DEL} );
 ok( $res{ENOUGH_NS_CHILD},           q{should emit ENOUGH_NS_CHILD} );
 ok( $res{ENOUGH_NS_DEL},             q{should emit ENOUGH_NS_DEL} );


### PR DESCRIPTION
Fixes issue mentioned on #523: IPv4 addresses are listed instead of IPv6 addresses in the [NOT_]ENOUGH_IPV6_NS_CHILD messages.