### PR TITLE
Updated and expanded Translation document

### DIFF
--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -1,4 +1,4 @@
-=head1 Translation
+=head1 TRANSLATION
 
 =head2 Introduction
 

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -105,7 +105,7 @@ To create a fork of F<Zonemaster-Engine> go to
 L<https://github.com/zonemaster/zonemaster-engine>, make sure you are logged
 in at Github and press the "Fork" button.
 
-Make sure you have your public L<ssh> key uploaded to Github and its
+Make sure you have your public C<ssh> key uploaded to Github and its
 private key available on the computer you are going to work from.
 
 =head3 Steps

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -1,4 +1,6 @@
-=head1 Introduction
+=head1 Translation
+
+=head2 Introduction
 
 The translation system in Zonemaster is a two-step process, where internal
 message tags are first replaced by English strings with argument
@@ -47,6 +49,8 @@ Make sure the message tag comments are properly added and up to date.
 =head3 Software preparation
 
 For the steps below you need to work on a computer with Git, Perl and Xgettext.
+Select what OS you want to work on. Other OSs will also work, but you will
+have to find instructions elsewhere.
 
 =head4 FreeBSD
 
@@ -75,8 +79,8 @@ performed as an implicit intermediate step.
 If you do want to generate it, the command is C<make extract-pot> 
 (C<gmake extract-pot> on FreeBSD).
 
-The translated strings are maintained in files named C<{language_code}.po> (e.g.
-F<en.po>, F<sv.po>, F<da.po> or F<fr.po>).
+The translated strings are maintained in files named C<{language_code}.po>
+(currently F<en.po>, F<sv.po>, F<da.po> or F<fr.po>).
 Execute C<make update-po> (C<gmake update-po> on FreeBSD) to update these 
 files with new message ids from the
 source code (C<make extract-pot> will be infoked behind the scenes).
@@ -93,7 +97,9 @@ C<make update-po MSGMERGE_OPTS=--no-fuzzy-mathing> instead.
 For full integration with Zonemaster translation you need a Github account
 and a fork of F<Zonemaster-Engine>. If you do not have a Github account you
 can easily create one at L<https://github.com/>. If you are not prepared to
-create one, contact the Zonemaster work group for instructions.
+create one, contact the Zonemaster work group for instructions, either by
+creating an issue in L<https://github.com/zonemaster/zonemaster-engine/issues>
+or by sending an email to L<mailto:contact@zonemaster.net>.
 
 To create a fork of F<Zonemaster-Engine> go to 
 L<https://github.com/zonemaster/zonemaster-engine>, make sure you are logged
@@ -124,8 +130,8 @@ where F<XXXXX> is your Github user name.
 C<make update-po> (C<gmake update-po> on FreeBSD).
 
 =item * Update the po file the language to be updated. The F<en.po> file should
-not be updated in this way. Instead, create an issue to have the message
-updated in the Perl module.
+not be updated in this way. Instead, create an issue or a pull request
+to have the message updated in the Perl module.
 
 =item * When doing the update, do not add any changes to the F<msgid>, only update
 F<msgstr>.
@@ -135,14 +141,15 @@ a C<git add xx.po> where F<xx> is the language code of the po file you
 have updated. Make sure you do not "add" any other file that might have been
 changed.
 
-=item * Do a commit C<git commit -m 'Write a description of the change'>.
+=item * Create a commit, C<git commit -m 'Write a description of the change'>.
 
 =item * Now push the branch to your fork at Github. Run 
 C<git push -u XXXXX translation-update> where F<XXXXX> is your 
 Github user name and "translation-update" is name of the branch
 you created above and have been working on.
 
-=item * Go to your fork at Github, L<https://github.com/XXXXX/zonemaster-engine>.
+=item * Go to your fork at Github, https://github.com/XXXXX/zonemaster-engine
+where F<XXXXX> is your Github user name.
 
 =item * Select to create a new F<pull request> where the base directory
 should be F<zonemaster-engine> and the base should be F<develop> (not
@@ -150,15 +157,16 @@ should be F<zonemaster-engine> and the base should be F<develop> (not
 branch as you created above and pushed to your fork.
 
 =item * Inspect what Github says that will change by the pull request. It should
-only be the F<po> file that you have updated and nothing else.
+only be the F<po> file that you have updated and nothing else. If additional
+files are listed, please correct or request for help.
 
 =item * Press "create pull request", write a nice description and press "create"
 again.
 
 =item * If you go back to your own computer and just save the clone as it is, you
-can easily update the pull request if needed. When the pull request has
-been merged by the Zonemaster work group, you can delete the local clone
-and on your Github fork you can remove the branch.
+can easily update the pull request if needed with more changes to the same
+po file. When the pull request has been merged by the Zonemaster work group,
+you can delete the local clone and on your Github fork you can remove the branch.
 
 =back
 

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -1,7 +1,7 @@
-=head1 INTRODUCTION
+=head1 Introduction
 
 The translation system in Zonemaster is a two-step process, where internal
-message tags are first translated to English strings with argument
+message tags are first replaced by English strings with argument
 placeholders, and a second step where GNU gettext is used to translate the
 strings to other languages and fill in the placeholders based on provided data.
 
@@ -9,11 +9,11 @@ All translation files live in the F<share> directory in the
 L<Zonemaster::Engine> source directory and all commands described here are
 executed from that directory.
 
-=head1 FOR DEVELOPERS OF ZONEMASTER TEST MODULES
+=head2 For developers of Zonemaster test modules
 
-Your test code should produce log messages with message tags, as documented
+The test module code should produce log messages with message tags, as documented
 elsewhere. These tags will be used for translation to human language, for
-determining the severity of the even logged and to make the events easily used
+determining the severity of the event logged and to make the events easily used
 by other software.
 
 Each test module must also have a method named C<tag_descriptions()>.
@@ -42,17 +42,43 @@ Every time you add, remove or modify a tag or its message id, re-run
 C<make update-po> as descibed in the next section.
 Make sure the message tag comments are properly added and up to date.
 
-=head1 FOR TRANSLATORS
+=head2 For translators
+
+=head3 Software preparation
+
+For the steps below you need to work on a computer with Git, Perl and Xgettext.
+
+=head4 FreeBSD
+
+Install the following:
+
+C<pkg install git-lite devel/p5-Locale-XGettext devel/p5-Locale-Msgfmt devel/gmake>
+
+=head4 CentOS
+
+To be written.
+
+=head4 Ubuntu
+
+To be written.
+
+=head4 Debian
+
+To be written
+
+=head3 Background
 
 The first step in updating the translations is to generate a new template file
 (F<Zonemaster-Engine.pot>).
 In practice you rarely need to think about generating it as it is generally
 performed as an implicit intermediate step.
-If you do want to generate it, the command is C<make extract-pot>.
+If you do want to generate it, the command is C<make extract-pot> 
+(C<gmake extract-pot> on FreeBSD).
 
 The translated strings are maintained in files named C<{language_code}.po> (e.g.
-F<en.po>, F<sv.po> or F<fr.po>).
-Execute C<make update-po> to update these files with new message ids from the
+F<en.po>, F<sv.po>, F<da.po> or F<fr.po>).
+Execute C<make update-po> (C<gmake update-po> on FreeBSD) to update these 
+files with new message ids from the
 source code (C<make extract-pot> will be infoked behind the scenes).
 This should only be necessary to do when a developer has added or changed a test
 module.
@@ -62,10 +88,87 @@ fuzzy matching of similar strings.
 This is not always desirable and you can disable fuzzy matching by executing
 C<make update-po MSGMERGE_OPTS=--no-fuzzy-mathing> instead.
 
+=head3 Github preparation
+
+For full integration with Zonemaster translation you need a Github account
+and a fork of F<Zonemaster-Engine>. If you do not have a Github account you
+can easily create one at L<https://github.com/>. If you are not prepared to
+create one, contact the Zonemaster work group for instructions.
+
+To create a fork of F<Zonemaster-Engine> go to 
+L<https://github.com/zonemaster/zonemaster-engine>, make sure you are logged
+in at Github and press the "Fork" button.
+
+Make sure you have your public L<ssh> key uploaded to Github and its
+private key available on the computer you are going to work from.
+
+=head3 Steps
+
+For normal translation work, follow the steps below.
+
+=over
+
+=item * Clone the Zonemaster-Engine repository with 
+C<git clone https://github.com/zonemaster/zonemaster-engine.git> 
+and enter the direcory created, C<cd zonemaster-engine>.
+
+=item * Check-out the F<develop> branch and create a new branch to work in,
+C<git checkout origin/develop; git checkout -b translation-update>
+
+=item * Now it is time to add your own fork of F<Zonemaster-Engine> to the 
+created clone. Run 
+C<git remote add XXXXX git@github.com:XXXXX/zonemaster-engine.git> 
+where F<XXXXX> is your Github user name. 
+
+=item * Go to the F<share> directory with C<cd share> and execute 
+C<make update-po> (C<gmake update-po> on FreeBSD).
+
+=item * Update the po file the language to be updated. The F<en.po> file should
+not be updated in this way. Instead, create an issue to have the message
+updated in the Perl module.
+
+=item * When doing the update, do not add any changes to the F<msgid>, only update
+F<msgstr>.
+
+=item * When the update is completed, it is time to commit the changes. First do
+a C<git add xx.po> where F<xx> is the language code of the po file you
+have updated. Make sure you do not "add" any other file that might have been
+changed.
+
+=item * Do a commit C<git commit -m 'Write a description of the change'>.
+
+=item * Now push the branch to your fork at Github. Run 
+C<git push -u XXXXX translation-update> where F<XXXXX> is your 
+Github user name and "translation-update" is name of the branch
+you created above and have been working on.
+
+=item * Go to your fork at Github, L<https://github.com/XXXXX/zonemaster-engine>.
+
+=item * Select to create a new F<pull request> where the base directory
+should be F<zonemaster-engine> and the base should be F<develop> (not
+"master"). The "head" should be your fork and "compare" the same
+branch as you created above and pushed to your fork.
+
+=item * Inspect what Github says that will change by the pull request. It should
+only be the F<po> file that you have updated and nothing else.
+
+=item * Press "create pull request", write a nice description and press "create"
+again.
+
+=item * If you go back to your own computer and just save the clone as it is, you
+can easily update the pull request if needed. When the pull request has
+been merged by the Zonemaster work group, you can delete the local clone
+and on your Github fork you can remove the branch.
+
+=back
+
+=head2 For Zonemaster package maintainers
+
 In order to make a new translation usable, it must be compiled to C<mo> format
 and installed. The first step needs the C<msgfmt> program from the GNU gettext
 package to be installed and available in the shell path. As long as it is, it
-should be enough to go to the F<share> directory and run C<make>.
+should be enough to go to the F<share> directory and run C<make> (C<gmake> on
+FreeBSD). This is automatically done when following the release instructions.
 
 For the new translation to actually be installed, the C<mo> file must be added
 to the F<MANIFEST> file. At the end of the C<make> run, it should have printed
@@ -75,5 +178,3 @@ you just added a new translation, that will be missing, for example).
 
 Once the new translation is compiled and added to F<MANIFEST>, the normal Perl
 C<make install> process will install it.
-
-Don't forget to commit the new C<po> files to git.


### PR DESCRIPTION
The Translation document has three different categories of readers:

* Developers of test modules
* Translators i.e updating po files
* Maintainers of Zonemaster-Engine

I have expanded the instructions to the translators to make it more useful. Maybe the document should be split into three, or at least having a table of contents, which is not possible presently.

The document is a pod document, which is fine for document in code and `man` like pages. For this document I think it would be more fruitful to have it as a markdown document where a table of contents could be added.

I am prepared to convert it if you do not object.