### PR TITLE
Updates to translation tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ MYMETA.*
 _build/
 cover_db/
 blib/
+inc/
 .lwpcookies
 .last_cover_stats
 nytprof.out

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Build
 Build.bat
 META.*
 MYMETA.*
+*.mo
 .build/
 _build/
 cover_db/

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,4 +1,5 @@
 \.po$
+^share/[^/]*\.mo$
 \.tar\.gz$
 \bMANIFEST\.SKIP$
 ^\.perlcriticrc$

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -60,7 +60,7 @@ To be written.
 
 Install the following:
 
-C<pkg install gettext git>
+C<apt install gettext git>
 
 =head4 FreeBSD
 

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -48,7 +48,7 @@ Make sure the message tag comments are properly added and up to date.
 
 =head3 Software preparation
 
-For the steps below you need to work on a computer with Git, Perl and Xgettext.
+For the steps below you need to work on a computer with Git, Perl and Gettext.
 Select what OS you want to work on. Other OSs will also work, but you will
 have to find instructions elsewhere.
 
@@ -56,7 +56,7 @@ have to find instructions elsewhere.
 
 Install the following:
 
-C<pkg install git-lite devel/p5-Locale-XGettext devel/p5-Locale-Msgfmt>
+C<pkg install devel/gettext-tools devel/git-lite devel/p5-Locale-Msgfmt>
 
 =head4 CentOS
 
@@ -68,7 +68,7 @@ To be written.
 
 =head4 Debian
 
-To be written
+To be written.
 
 =head3 Background
 

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -56,7 +56,7 @@ have to find instructions elsewhere.
 
 Install the following:
 
-C<pkg install devel/gettext-tools devel/git-lite devel/p5-Locale-Msgfmt>
+C<pkg install devel/gettext-tools devel/git-lite>
 
 =head4 CentOS
 

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -52,21 +52,23 @@ For the steps below you need to work on a computer with Git, Perl and Gettext.
 Select what OS you want to work on. Other OSs will also work, but you will
 have to find instructions elsewhere.
 
+=head4 CentOS
+
+To be written.
+
+=head4 Debian
+
+Install the following:
+
+C<pkg install gettext git>
+
 =head4 FreeBSD
 
 Install the following:
 
 C<pkg install devel/gettext-tools devel/git-lite>
 
-=head4 CentOS
-
-To be written.
-
 =head4 Ubuntu
-
-To be written.
-
-=head4 Debian
 
 To be written.
 

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -56,7 +56,7 @@ have to find instructions elsewhere.
 
 Install the following:
 
-C<pkg install git-lite devel/p5-Locale-XGettext devel/p5-Locale-Msgfmt devel/gmake>
+C<pkg install git-lite devel/p5-Locale-XGettext devel/p5-Locale-Msgfmt>
 
 =head4 CentOS
 
@@ -76,13 +76,11 @@ The first step in updating the translations is to generate a new template file
 (F<Zonemaster-Engine.pot>).
 In practice you rarely need to think about generating it as it is generally
 performed as an implicit intermediate step.
-If you do want to generate it, the command is C<make extract-pot>
-(C<gmake extract-pot> on FreeBSD).
+If you do want to generate it, the command is C<make extract-pot>.
 
 The translated strings are maintained in files named C<{language_code}.po>
 (currently F<en.po>, F<sv.po>, F<da.po> or F<fr.po>).
-Execute C<make update-po> (C<gmake update-po> on FreeBSD) to update these
-files with new message ids from the
+Execute C<make update-po> to update these files with new message ids from the
 source code (C<make extract-pot> will be infoked behind the scenes).
 This should only be necessary to do when a developer has added or changed a test
 module.
@@ -149,7 +147,7 @@ C<git remote add XXXXX git@github.com:XXXXX/zonemaster-engine.git>
 where F<XXXXX> is your Github user name.
 
 =item * Go to the F<share> directory with C<cd share> and execute
-C<make update-po> (C<gmake update-po> on FreeBSD).
+C<make update-po>.
 
 =item * Update the po file the language to be updated. The F<en.po> file should
 not be updated in this way. Instead, create an issue or a pull request
@@ -215,8 +213,8 @@ you can delete the local clone and on your Github fork you can remove the branch
 In order to make a new translation usable, it must be compiled to C<mo> format
 and installed. The first step needs the C<msgfmt> program from the GNU gettext
 package to be installed and available in the shell path. As long as it is, it
-should be enough to go to the F<share> directory and run C<make> (C<gmake> on
-FreeBSD). This is automatically done when following the release instructions.
+should be enough to go to the F<share> directory and run C<make>.
+This is automatically done when following the release instructions.
 
 For the new translation to actually be installed, the C<mo> file must be added
 to the F<MANIFEST> file. At the end of the C<make> run, it should have printed

--- a/share/Makefile
+++ b/share/Makefile
@@ -1,5 +1,6 @@
 .POSIX:
 .SUFFIXES: .po .mo
+.PHONY: all dist touch-po update-po extract-pot
 
 POFILES != echo *.po
 MOFILES := $(POFILES:%.po=%.mo)
@@ -7,9 +8,7 @@ POTFILE = Zonemaster-Engine.pot
 PMFILES != find ../lib -type f -name '*.pm' | sort
 TESTMODULEFILES != find ../lib/Zonemaster/Engine/Test -type f -name '*.pm' | sort
 
-.PHONY: all dist touch-po update-po extract-pot
-
-all: ${MOFILES} modules.txt
+all: $(MOFILES) modules.txt
 	@echo
 	@echo Remember to make sure all of the above names are in the
 	@echo MANIFEST file, or they will not be installed.
@@ -37,4 +36,4 @@ show-fuzzy:
 	@for f in $(POFILES) ; do msgattrib --only-fuzzy $$f ; done
 
 modules.txt: $(TESTMODULEFILES)
-	echo $(TESTMODULEFILES) | xargs basename -s .pm -a | grep -vE '^Basic$$' | sort > modules.txt
+	@echo $(TESTMODULEFILES) | xargs basename -s .pm -a | grep -vE '^Basic$$' | sort > modules.txt

--- a/share/Makefile
+++ b/share/Makefile
@@ -1,10 +1,13 @@
-POFILES = $(wildcard *.po)
-MOFILES := $(POFILES:%.po=locale/%/LC_MESSAGES/Zonemaster-Engine.mo)
-POTFILE = Zonemaster-Engine.pot
-PMFILES = $(shell find ../lib -type f -name '*.pm' | sort)
-TESTMODULEFILES = $(shell find ../lib/Zonemaster/Engine/Test -type f -name '*.pm' | sort)
+.POSIX:
+.SUFFIXES: .po .mo
 
-.PHONY: all touch-po update-po extract-pot
+POFILES != echo *.po
+MOFILES := $(POFILES:%.po=%.mo)
+POTFILE = Zonemaster-Engine.pot
+PMFILES != find ../lib -type f -name '*.pm' | sort
+TESTMODULEFILES != find ../lib/Zonemaster/Engine/Test -type f -name '*.pm' | sort
+
+.PHONY: all dist touch-po update-po extract-pot
 
 all: ${MOFILES} modules.txt
 	@echo
@@ -25,11 +28,10 @@ $(POTFILE): extract-pot
 %.po: $(POTFILE)
 	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
 
-$(MOFILES): locale/%/LC_MESSAGES/Zonemaster-Engine.mo: %.po
-	@mkdir -p locale/$*/LC_MESSAGES
-	@# It must be 'Zonemaster-Engine' because that is defined in "name" in Makefile.PL
-	@perl -e 'use Locale::Msgfmt; msgfmt({in => $$ARGV[0], out => $$ARGV[1]});' $< locale/$*/LC_MESSAGES/Zonemaster-Engine.mo
-	@echo locale/$*/LC_MESSAGES/Zonemaster-Engine.mo
+.po.mo:
+	@perl -e 'use Locale::Msgfmt; msgfmt({in => $$ARGV[0], out => $$ARGV[1]});' $< $@
+	@mkdir -p locale/`basename $@ .mo`/LC_MESSAGES
+	@ln -vf $@ locale/`basename $@ .mo`/LC_MESSAGES/Zonemaster-Engine.mo
 
 show-fuzzy:
 	@for f in $(POFILES) ; do msgattrib --only-fuzzy $$f ; done

--- a/share/Makefile
+++ b/share/Makefile
@@ -28,7 +28,7 @@ $(POTFILE): extract-pot
 	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
 
 .po.mo:
-	@perl -e 'use Locale::Msgfmt; msgfmt({in => $$ARGV[0], out => $$ARGV[1]});' $< $@
+	@msgfmt -o $@ $<
 	@mkdir -p locale/`basename $@ .mo`/LC_MESSAGES
 	@ln -vf $@ locale/`basename $@ .mo`/LC_MESSAGES/Zonemaster-Engine.mo
 


### PR DESCRIPTION
The main improvement here is POSIX compliance of share/Makefile, which means we don't need to use gmake on FreeBSD. Documentation is updated accordingly.

Along with it comes various clean ups related to translation tooling.