### PR TITLE
Remove empty elements from @keys to resolve issue #727

### DIFF
--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -5,7 +5,7 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare( "v1.1.16" );
+use version; our $VERSION = version->declare( "v1.1.17" );
 
 ###
 ### This test module implements DNSSEC tests.
@@ -1880,6 +1880,14 @@ sub dnssec13 {
 
             foreach my $sig ( @sigs ) {
                 my @keys = ($keytags{$sig->keytag});
+                if ( @keys ) {
+                    my @ks;
+                    foreach my $k (@keys) {
+                        push @ks, $k if $k; # Skip any empty elements
+                    }
+                    @keys = @ks;
+                }
+
                 if ( not scalar @keys ) {
                     $all_algo_signed = 0;
                     $ns_args->{keytag} = $sig->keytag;


### PR DESCRIPTION
Resolves issue #727.

`Zonemaster::LDNS::RR::RRSIG::verify()` requires that incoming parameter `$keys` is a reference to a non-empty array of DNSKEYs. Under some circumstances,  `@keys` in Zonemaster::Engine::Test::DNSSEC::dnssec13() is created as an array of an empty key, and is then validated as non-empty and used in a call to `Zonemaster::LDNS::RR::RRSIG::verify()`.

This update removes any empty element from `@keys` after it is created.