### PR TITLE
Make locale not get stuck on FreeBSD 11

### DIFF
--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -228,11 +228,11 @@ Zonemaster::Engine::Translator - translation support for Zonemaster
     my $trans = Zonemaster::Engine::Translator->new({ locale => 'sv_SE.UTF-8' });
     say $trans->to_string($entry);
 
-A side effect of constructing an object of this class is that the program's
-underlying locale for message catalogs (a.k.a. LC_MESSAGES) is updated.
+This is effectively a singleton class.
+More than one instance of this class must not be constructed.
 
-It does not make sense to create more than one object of this class because of
-the globally stateful nature of the locale attribute.
+The instance of this class requires exclusive control over C<$ENV{LC_MESSAGES}>
+and the program's underlying LC_MESSAGES.
 
 =head1 ATTRIBUTES
 
@@ -240,13 +240,17 @@ the globally stateful nature of the locale attribute.
 
 =item locale
 
-The locale that should be used to find translation data. If not
-explicitly provided, defaults to (in order) the contents of the
-environment variable LANG, LC_ALL, LC_MESSAGES or, if none of them are
-set, to C<en_US.UTF-8>.
+The locale used for localized messages.
 
-Updating this attribute also causes an analogous update of the program's
+    say $translator->locale();
+    $translator->locale( 'sv_SE.UTF-8' );
+
+When writing to this attribute, a request is made to update the program's
 underlying LC_MESSAGES.
+
+If no initial value is provided to the constructor, one is determined by calling
+setlocale( LC_MESSAGES, "" ).
+If this call returns C<"C">, the value C<"en_US.UTF-8"> is used instead.
 
 =item data
 

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -9,6 +9,7 @@ use warnings;
 use Zonemaster::Engine;
 
 use Carp;
+use Locale::Messages qw[textdomain];
 use Locale::TextDomain qw[Zonemaster-Engine];
 use POSIX qw[setlocale LC_MESSAGES];
 use Readonly;
@@ -195,6 +196,10 @@ around 'locale' => sub {
     # On some systems gettext takes its locale from %ENV.
     $ENV{LC_MESSAGES} = $new_locale;
 
+    # On some systems gettext refuses to switch over to another locale unless
+    # the textdomain is reset.
+    textdomain( 'Zonemaster-Engine' );
+
     $self->$next( $new_locale );
 
     return $new_locale;
@@ -253,6 +258,7 @@ More than one instance of this class must not be constructed.
 
 The instance of this class requires exclusive control over C<$ENV{LC_MESSAGES}>
 and the program's underlying LC_MESSAGES.
+At times it resets gettext's textdomain.
 On construction it unsets C<$ENV{LC_ALL}> and C<$ENV{LANGUAGE}>, and from then
 on they must remain unset.
 
@@ -275,6 +281,9 @@ When writing to this attribute, a request is made to update the program's
 underlying LC_MESSAGES.
 If this request fails, the attribute value remains unchanged and an empty list
 is returned.
+
+As a side effect when successfully updating this attribute gettext's textdomain
+is reset.
 
 If no initial value is provided to the constructor, one is determined by calling
 setlocale( LC_MESSAGES, "" ).

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -227,11 +227,6 @@ sub _translate_tag {
     my $code = $self->all_tag_descriptions->{$module}{$tag};
 
     if ( $code ) {
-
-        # Partial workaround for FreeBSD 11. It works once, but then translation
-        # gets stuck on that locale.
-        local $ENV{LC_ALL} = $self->{locale};
-
         return $code->( %{$args} );
     }
     else {


### PR DESCRIPTION
This makes Z::E::Translator properly communicate locale to gettext.

Fixes #748 and zonemaster/zonemaster-backend#530.

This PR is best reviewed commit by commit.