### PR TITLE
- Fixes French translation

### DIFF
--- a/share/fr.po
+++ b/share/fr.po
@@ -709,9 +709,9 @@ msgid ""
 "with keytag {keytag} in zone {zone}."
 msgstr ""
 "Le serveur de noms {ns}/{address} retourne un enregistrement de type \"DS\" "
-"créé à partir d'un algorithme obsolète ({algorithm_number}/"
-"{algorithm_mnemonic}), ce qui est incorrect. Cet enregistrement de type \"DS"
-"\" correspond à la clé (DNSKEY) avec le tag {keytag} dans la zone {zone}."
+"créé à partir de l'algorithme ({algorithm_number}/{algorithm_mnemonic}), "
+"ce qui est correct. Cet enregistrement de type \"DS\" correspond à la clé "
+"(DNSKEY) avec le tag {keytag} dans la zone {zone}."
 
 #. DNSSEC:DS_ALGORITHM_RESERVED
 #, perl-brace-format


### PR DESCRIPTION
Fixes zonemaster/zonemaster-engine#735
French DNSSEC message was wrong (DS_ALGORITHM_OK).