### PR TITLE
Remove MODULE_CALL and MODULE_CALL_END messages

### DIFF
--- a/lib/Zonemaster/Engine/Test.pm
+++ b/lib/Zonemaster/Engine/Test.pm
@@ -5,13 +5,12 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare( "v1.1.11" );
+use version; our $VERSION = version->declare( "v1.1.12" );
 
 use Moose;
 
 use Readonly;
 use Module::Find;
-use JSON;
 use Net::IP;
 use List::MoreUtils;
 use Clone;
@@ -47,7 +46,6 @@ sub _log_versions {
     info( DEPENDENCY_VERSION => { name => 'IO::Socket::INET6',     version => $IO::Socket::INET6::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'Moose',                 version => $Moose::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'Module::Find',          version => $Module::Find::VERSION } );
-    info( DEPENDENCY_VERSION => { name => 'JSON',                  version => $JSON::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'File::ShareDir',        version => $File::ShareDir::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'File::Slurp',           version => $File::Slurp::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'Net::IP',               version => $Net::IP::VERSION } );

--- a/lib/Zonemaster/Engine/Test.pm
+++ b/lib/Zonemaster/Engine/Test.pm
@@ -5,7 +5,16 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare( "v1.1.10" );
+use version; our $VERSION = version->declare( "v1.1.11" );
+
+use Moose;
+
+use Readonly;
+use Module::Find;
+use JSON;
+use Net::IP;
+use List::MoreUtils;
+use Clone;
 
 use Zonemaster::LDNS;
 use Zonemaster::Engine;
@@ -164,7 +173,7 @@ sub run_one {
         if ( $module ) {
             my $m = "Zonemaster::Engine::Test::$module";
             if ( $m->metadata->{$test} ) {
-                info( MODULE_CALL => { module => $module, method => $test, version => $m->version } );
+                info( MODULE_VERSION => { module => $m, version => $m->version } );
                 push @res, eval { $m->$test( @arguments ) };
                 if ( $@ ) {
                     my $err = $@;
@@ -175,7 +184,7 @@ sub run_one {
                         push @res, info( MODULE_ERROR => { module => $module, msg => "$err" } );
                     }
                 }
-                info( MODULE_CALL_END => { module => $module, method => $test } );
+                info( MODULE_END => { module => $module } );
                 return @res;
             }
             else {


### PR DESCRIPTION
Fixes zonemaster/zonemaster-engine#732
Remove MODULE_CALL and MODULE_CALL_END messages in Zonemaster::Engine::Test::run_one. Instead use MODULE_VERSION/MODULE_END messages like in Zonemaster::Engine::Test::run_all_for and in Zonemaster::Engine::Test::run_module.
Related to zonemaster/zonemaster-engine#764 PR