### PR TITLE
Reduce duplicate messages about key size

### DIFF
--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -2011,10 +2011,15 @@ sub dnssec14 {
         }
     }
 
+    my %investigated_keys;
     foreach my $key ( @dnskey_rrs ) {
         my $algo = $key->algorithm;  
 
         next if not exists $rsa_key_size_details{$algo};
+
+        # Only test once per keytag, keysize and algorithm
+        my $key_ref = join ':', $key->keytag, $key->keysize, $algo;
+        next if exists $investigated_keys{$key_ref};
 
         my $algo_args = {
             algorithm_number      => $algo,
@@ -2037,6 +2042,8 @@ sub dnssec14 {
         if ( $key->keysize > $rsa_key_size_details{$algo}{max_size} ) {
             push @results, info( DNSKEY_TOO_LARGE_FOR_ALGO => $algo_args );
         }
+
+        $investigated_keys{$key_ref} = 1;
 
     } ## end foreach my $key ( @keys )
 


### PR DESCRIPTION
When the same key from all name servers are tested a lot of duplicate messages are generated.

This fix will reduce the number of duplicate messages, i.e messages having the same keytag, keysize and algorithm.

Normally the same key is propagated to all authoritative name servers so testing each key from each name server will give the same result.

This is a fix for issue #769 