### PR TITLE
Update to make Makefile POSIX compliant.

### DIFF
--- a/share/Makefile
+++ b/share/Makefile
@@ -24,7 +24,7 @@ extract-pot:
 
 $(POTFILE): extract-pot
 
-%.po: $(POTFILE)
+$(POFILES): $(POTFILE)
 	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
 
 .po.mo:


### PR DESCRIPTION
share/Makefile does not work with FreeBSD when a *PO* file is to be updated. This applies to the *develop* branch where GNU Make should not be needed after update by PR #726. Running `make sv.po` or `make update-po` only creates "Zonemaster-Engine.pot" but it does not update the *PO* files. In *master* branch and using `gmake` (FreeBSD GNU Make) it works.

The change in this PR makes it work under FreeBSD with normal `make` and it still works with Linux (tested on Ubuntu 18.04) with GNU Make (which is `make` in Linux).
