### PR TITLE
Updated instructions for translators

### DIFF
--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -19,25 +19,25 @@ but you will have to find instructions elsewhere.
 
 * CentOS
 
-To be written.
+  To be written.
 
 * Debian
 
-Install the following:
+  Install the following:
   ```
   apt install gettext git liblocale-po-perl
   ```
 
 * FreeBSD
 
-Install the following:
+  Install the following:
   ```
   pkg install devel/gettext-tools devel/git-lite devel/p5-Locale-PO
   ```
 
 * Ubuntu
 
-Install the following:
+  Install the following:
   ```
   apt install gettext git make liblocale-po-perl
   ```
@@ -102,7 +102,7 @@ handled as a database instead of as a plain file.
 * There is also "[GNOME Translation Editor]", a graphical PO editor 
   available for at least Windows and Linux.
 * There are more tools available, either cloud services or programs
-for download, and they could be found by searching for "po editor".
+  for download, and they could be found by searching for "po editor".
 
 ## Clone preparation
 
@@ -129,7 +129,7 @@ You need a local clone of the repository to work in.
 * Now it is time to connect your own fork of *Zonemaster-Engine*
   at Github to the created clone, unless you have alreday done that,
   in case you can skip the next step.
-  
+
 * You have a user name at Github. Here we use "xxxx" as your user name
   and also the name of the remote in clone on the local machine.
   ```
@@ -257,12 +257,12 @@ be update each time a message is added or changed.
 Above you found the following step that must now be modified, but run the
 steps before this step:
 
-  > * Go to the *share* and update the *PO* file for the language you are going
-  >   to work with. Replace "xx" with the language code in question.
-  > ```
-  > cd share
-  > make xx.po
-  > ```
+> * Go to the *share* and update the *PO* file for the language you are going
+>   to work with. Replace "xx" with the language code in question.
+> ```
+> cd share
+> make xx.po
+> ```
 
 The new language is not there and cannot be updated. Instead you have to
 create the new language file (*PO* file). The easiest way is to make a copy

--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -24,23 +24,23 @@ To be written.
 * Debian
 
 Install the following:
-```
-apt install gettext git liblocale-po-perl
-```
+  ```
+  apt install gettext git liblocale-po-perl
+  ```
 
 * FreeBSD
 
 Install the following:
-```
-pkg install devel/gettext-tools devel/git-lite devel/p5-Locale-PO
-```
+  ```
+  pkg install devel/gettext-tools devel/git-lite devel/p5-Locale-PO
+  ```
 
 * Ubuntu
 
 Install the following:
-```
-apt install gettext git make liblocale-po-perl
-```
+  ```
+  apt install gettext git make liblocale-po-perl
+  ```
 
 ##  Background
 
@@ -67,9 +67,12 @@ from the source code.
 
 By default the updated *PO* file will suggested translations for new message 
 ids based on fuzzy matching of similar strings. This is not always desirable 
-and you can disable fuzzy matching by executing
-`make xx.po MSGMERGE_OPTS=--no-fuzzy-mathing` or
-`make update-po MSGMERGE_OPTS=--no-fuzzy-mathing` instead.
+and you can disable fuzzy matching by executing one of the following
+commands instead:
+  ```
+  make xx.po MSGMERGE_OPTS=--no-fuzzy-mathing
+  make update-po MSGMERGE_OPTS=--no-fuzzy-mathing
+  ```
 
 ## Github preparation
 
@@ -107,21 +110,21 @@ You need a local clone of the repository to work in.
 
 * Clone the Zonemaster-Engine repository, unless you already
   have a clone that you could reuse:
-```
+  ```
   git clone https://github.com/zonemaster/zonemaster-engine.git
-```
+  ```
 
 * Enter the directory of the clone created above or already
   existing clone:
-```
+  ```
   cd zonemaster-engine
-```
+  ```
 
 * If you already have an old clone of Zonemaster-Engine,
   run an update.
-```
+  ```
   git fetch --all
-```
+  ```
 
 * Now it is time to connect your own fork of *Zonemaster-Engine*
   at Github to the created clone, unless you have alreday done that,
@@ -129,10 +132,10 @@ You need a local clone of the repository to work in.
   
 * You have a user name at Github. Here we use "xxxx" as your user name
   and also the name of the remote in clone on the local machine.
-```
+  ```
   git remote add xxxx git@github.com:xxxx/zonemaster-engine.git
   git fetch --all
-```
+  ```
 
 ## Translation steps
 
@@ -143,18 +146,18 @@ welcome comments on these.
   You can call the new branch whatever you want, but here we use
   the name "translation-update". If that name is already taken,
   you have to give it a new name or remove the old branch.
-```
+  ```
   git checkout origin/develop
   git checkout -b translation-update
-```
+  ```
 
 * Go to the *share* directory and run the update command for the *PO* file 
   for the language you are going to work with. Replace "xx" with the 
   language code in question. This should be done every time.
-```
+  ```
   cd share
   make xx.po
-```
+  ```
 
 * The *PO* file is updated with new *msgids*, if any, and now you can start
   working with it.
@@ -185,41 +188,41 @@ welcome comments on these.
 
 * Check that the messages arguments in all *msgstr* strings match up with 
   those in the *msgid* strings.
-```
+  ```
   ../util/check-msg-args xx.po
-```
+  ```
 
 * When the update is completed, it is time to commit the changes. You should
   only commit the "xx.po" file.
-```
+  ```
   git commit -m 'Write a description of the change' xx.po
-```
+  ```
 
 * There could be other files changed or added that should not be included.
   Run the status command to see them.
-```
+  ```
   git status
-```
+  ```
 
 * Other changed files could be reset by a "checkout". This could also
   be done before creating the commit.
-```
+  ```
   git checkout FILENAME
-```
+  ```
 
 * Added files not needed can just be removed. This could also be done
   before the commit.
-```
+  ```
   rm FILE-NAME
-```
+  ```
 
 * Now push the local branch you created to your fork at Github. 
   "translation-update" is name of the branch you created above and 
   have committed the updates to. Use your Github user name instead of
   "xxxx".
-```
+  ```
   git push -u xxxx translation-update
-```
+  ```
 
 * Go to your fork at Github, https://github.com/xxxx/zonemaster-engine
   and use your Github user name instead of "xxxx".
@@ -254,12 +257,12 @@ be update each time a message is added or changed.
 Above you found the following step that must now be modified, but run the
 steps before this step:
 
-> * Go to the *share* and update the *PO* file for the language you are going
->   to work with. Replace "xx" with the language code in question.
-> ```
-> cd share
-> make xx.po
-> ```
+  > * Go to the *share* and update the *PO* file for the language you are going
+  >   to work with. Replace "xx" with the language code in question.
+  > ```
+  > cd share
+  > make xx.po
+  > ```
 
 The new language is not there and cannot be updated. Instead you have to
 create the new language file (*PO* file). The easiest way is to make a copy
@@ -269,25 +272,25 @@ of an existing file.
   a code that is available in the *locale* system. Try the following commands
   to see if it is available. Replace "xx" with that code that you think it
   should be.
-```
+  ```
   locale -a | grep xx      # Works at least in FreeBSD
   grep xx /etc/locale.gen  # Works at least in Ubuntu 18.04
-```
+  ```
 
 * Go to the *share* and update the *PO* file for some language, say Swedish,
   and make a copy of that to the new file name. And then reset the *PO* file
   for Swedish.
-```
+  ```
   cd share
   make sv.po
   cp sv.po xx.po
   git checkout sv.po
-```
+  ```
 
 * You have to "add" the new file to git before you start working on it.
-```
+  ```
   git add xx.po
-```
+  ```
 
 * When you do the update of the new *PO* file you have to replace all *msgstr*
   in Swedish with the translation in the new language, but also update the

--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -3,13 +3,16 @@
 See the general [Translation] document for overall documentation on
 translation.
 
+
 ### Table of contents
 * [Software preparation]
 * [Background]
 * [Github preparation]
 * [Tools]
-* [Steps]
+* [Clone preparation]
+* [Translation steps]
 * [Adding a new language]
+
 
 ## Software preparation
 
@@ -90,6 +93,7 @@ To create a fork of *Zonemaster-Engine*:
 Make sure that your public *ssh* key is uploaded to Github and that its
 private key is available on the computer you are going to work from.
 
+
 ## Tools
 
 The *PO* file can be edited with a plain text editor, but then it is 
@@ -103,6 +107,7 @@ handled as a database instead of as a plain file.
   available for at least Windows and Linux.
 * There are more tools available, either cloud services or programs
   for download, and they could be found by searching for "po editor".
+
 
 ## Clone preparation
 
@@ -136,6 +141,7 @@ You need a local clone of the repository to work in.
   git remote add xxxx git@github.com:xxxx/zonemaster-engine.git
   git fetch --all
   ```
+
 
 ## Translation steps
 
@@ -302,14 +308,15 @@ of an existing file.
 
 [Adding a new language]:             #adding-a-new-language
 [Background]:                        #background
+[Clone preparation]:                 #clone-preparation
 [Emacs PO-mode]:                     https://www.gnu.org/software/gettext/manual/html_node/PO-Mode.html#PO-Mode
 [GNOME Translation Editor]:          https://wiki.gnome.org/Apps/Gtranslator
 [Github preparation]:                #github-preparation
 [Github]:                            https://github.com/
 [Software preparation]:              #software-preparation
-[Steps]:                             #steps
 [Tools]:                             #tools
 [Translation]:                       https://github.com/zonemaster/zonemaster-engine/blob/develop/docs/Translation.pod
+[Translation steps]:                 #translation-steps
 [Zonemaster-Engine repository]:      https://github.com/zonemaster/zonemaster-engine
 [new issue]:                         https://github.com/zonemaster/zonemaster-engine/issues/new
 

--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -257,12 +257,12 @@ be update each time a message is added or changed.
 Above you found the following step that must now be modified, but run the
 steps before this step:
 
-> * Go to the *share* and update the *PO* file for the language you are going
->   to work with. Replace "xx" with the language code in question.
-> ```
-> cd share
-> make xx.po
-> ```
+  > * Go to the *share* and update the *PO* file for the language you are going
+  >   to work with. Replace "xx" with the language code in question.
+  > ```
+  > cd share
+  > make xx.po
+  > ```
 
 The new language is not there and cannot be updated. Instead you have to
 create the new language file (*PO* file). The easiest way is to make a copy

--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -1,0 +1,305 @@
+# Instructions for translators
+
+See the general [Translation] document for overall documentation on
+translation.
+
+### Table of contents
+* [Software preparation]
+* [Background]
+* [Github preparation]
+* [Tools]
+* [Steps]
+* [Adding a new language]
+
+## Software preparation
+
+For the steps below you need to work on a computer with Git, Perl and Gettext.
+Select what OS you want to work on from the list below. Other OSs will also work, 
+but you will have to find instructions elsewhere.
+
+* CentOS
+
+To be written.
+
+* Debian
+
+Install the following:
+```
+apt install gettext git
+```
+
+* FreeBSD
+
+Install the following:
+```
+pkg install devel/gettext-tools devel/git-lite
+```
+
+* Ubuntu
+
+Install the following:
+```
+apt install gettext git make
+```
+
+##  Background
+
+The first step in updating the translations is to generate a new template file
+("Zonemaster-Engine.pot"). In practice you rarely need to think about generating 
+it as it is generally performed as an implicit intermediate step.
+If you do want to generate it, the command is `make extract-pot`.
+
+The translated strings are maintained in files named "<LANG-CODE>.po". 
+Currently there are the following files (and languages):
+* da.po (Danish)
+* fr.po (French)
+* nb.po (Norwegian)
+* sv.po (Swedish)
+
+Execute `make xx.po` to update the *PO* file for language "xx". Choose the
+language code for the language that you want to update. The command will
+update the *PO* file with new message ids (*msgid*) from the source code. 
+This should only be strictly necessary to do when a module has been added, 
+changed or removed, but it it recommended to do this step every time.
+
+Execute `make update-po` to update all the *PO* files with new message ids 
+from the source code.
+
+By default the updated *PO* file will suggested translations for new message 
+ids based on fuzzy matching of similar strings. This is not always desirable 
+and you can disable fuzzy matching by executing
+`make xx.po MSGMERGE_OPTS=--no-fuzzy-mathing` or
+`make update-po MSGMERGE_OPTS=--no-fuzzy-mathing` instead.
+
+## Github preparation
+
+For full integration with Zonemaster translation you need a Github account
+and a fork of *Zonemaster-Engine*. If you do not have a Github account you
+can easily create one at [Github]. If you are not prepared to
+create one, contact the Zonemaster work group for instructions, either by
+creating an [issue][new issue] or by sending an email to 
+"zonemaster@zonemaster.net".
+
+To create a fork of *Zonemaster-Engine*: 
+1. Go to [Zonemaster-Engine repository].
+2. Make sure you are logged in at Github.
+3. Press the "Fork" button.
+
+Make sure that your public *ssh* key is uploaded to Github and that its
+private key is available on the computer you are going to work from.
+
+## Tools
+
+The *PO* file can be edited with a plain text editor, but then it is 
+important to keep the database structur of the file. There are tools that 
+makes editing of the *PO* files easier. When using those, the *PO* file is
+handled as a database instead of as a plain file.
+
+* There is an [add-on to Emacs][emacs PO-mode], which makes updating 
+  and searching in the ".po" file easier and more robust.
+* There is also "[GNOME Translation Editor]", a graphical PO editor 
+  available for at least Windows and Linux.
+* There are more tools available, either cloud services or programs
+for download, and they could be found by searching for "po editor".
+
+## Steps
+
+The steps in this section will work for most translation work. We
+welcome comments on these.
+
+* Clone the Zonemaster-Engine repository and enter the directory
+  created:
+```
+git clone https://github.com/zonemaster/zonemaster-engine.git
+cd zonemaster-engine
+```
+
+* If you already have a clone of Zonemaster-Engine, enter that
+  and run an update.
+```
+cd zonemaster-engine
+git fetch --all
+```
+
+* Check-out the *develop* branch and create a new branch to work in.
+  You can call the new branch whatever you want, but here we use
+  the name "translation-update".
+```
+git checkout origin/develop
+git checkout -b translation-update
+```
+
+* Now it is time to connect your own fork of *Zonemaster-Engine*
+  at Github to the created clone, unless you have alreday done that,
+  in case you can skip the next step.
+  
+* You have a user name at Github. Here we use "xxxx" as the user name 
+  and also the name of the remote in clone om local machine.
+```
+git remote add xxxx git@github.com:xxxx/zonemaster-engine.git
+git fetch --all
+```
+
+* Go to the *share* directory and run the update command for the *PO* file 
+  for the language you are going to work with. Replace "xx" with the 
+  language code in question. This should be done every time.
+```
+cd share
+make xx.po
+```
+
+* The *PO* file is updated with new *msgids*, if any, and now you can start
+  working with it.
+
+* Update the *PO* file with the tool of your choice. See above. You can copy
+  the *PO* file to another computer, edit it there, and then copy it back to
+  your Zonemaster-Engine clone.
+
+* When doing the update, do not change the *msgid*, only the *msgstr*. The 
+  *msgid* cannot be be update in this process. They are the links between
+  the Perl module and the *PO* file.
+
+* If you find a *msgid* that needs an update, create an [issue][new issue] 
+  or a pull request to have the message updated in the Perl module. If you 
+  create an issue, always include module and message tag, e.g. 
+  "BASIC:NO_PARENT". And make a suggestion of the new *msgid*.
+
+* Inspect every *fuzzy entry* (tagged with "fuzzy"). Update *msgstr*
+  if needed and remove the "fuzzy" tag. The "fuzzy" tag must always be removed.
+
+* Search for *untranslated entries* (empty *msgstr*) and add a
+  translation. At the end of the file there could be *obsolete entries*
+  (lines starting with "#~") and those could have matching translations,
+  especially of the *msgid* has been changed.
+
+* Any remaining *obsolete entries* (lines at the end of the file starting 
+  with "#~") could be removed. They have no purpose anymore.
+
+* When the update is completed, it is time to commit the changes. First do
+  a "git add" of the *PO* file you have updated. Make sure not to "add" any 
+  other file that might have been changed.
+```
+git add xx.po
+```
+
+* Verify that only the ".po" file as been added for commit. All other
+files should be ignored.
+```
+git status
+```
+
+* Create a commit
+```
+git commit -m 'Write a description of the change'.
+```
+
+* Other changed files could be reset by a "checkout". This could also
+  be done before creating the commit.
+```
+git checkout FILENAME
+```
+
+* Added files not needed can just be removed. This could also be done
+  before the commit.
+```
+rm FILE-NAME
+```
+
+* Now push the local branch you created to your fork at Github. 
+  "translation-update" is name of the branch you created above and 
+  have committed the updates to. Use your Github user name instead of
+  "xxxx".
+```
+git push -u xxxx translation-update
+```
+
+* Go to your fork at Github, https://github.com/xxxx/zonemaster-engine
+  and use your Github user name instead of "xxxx".
+
+* Select to create a new "pull request" where the base directory
+  should be *zonemaster-engine* and the base should be *develop* (not
+  *master*). The "head" should be your fork and "compare" the same
+  branch as you created above and pushed to your fork, "translation-update".
+
+* Inspect what Github says that will change by the pull request. It should
+  only be the *PO* file that you have updated and nothing else. If additional
+  files are listed, please correct or request for help.
+
+* Press "create pull request", write a nice description and press "create"
+  again.
+
+* If you go back to your own computer and just keep the clone as it is, you
+  can easily update the pull request if needed with more changes to the same
+  *PO* file. When the pull request has been merged by the Zonemaster work group,
+  you can delete the local clone and on your Github fork you can remove the 
+  branch. Or keep them for next time.
+
+
+## Adding a new language
+
+If you want to add a new language, then follow the steps above with some 
+modifications. Before you add a language contact the Zonemaster project
+to discuss timeplan and other aspects of the new language. Every language must
+be update each time a message is added or changed.
+
+Above you found the following step that must now be modified, but run the
+steps before this step:
+
+> * Go to the *share* and update the *PO* file for the language you are going
+>   to work with. Replace "xx" with the language code in question.
+> ```
+> cd share
+> make xx.po
+> ```
+
+The new language is not there and cannot be updated. Instead you have to
+create the new language file (*PO* file). The easiest way is to make a copy
+of an existing file.
+
+* Determine what the language code of the new language should be. I must be
+  a code that is available in the *locale* system. Try the following commands
+  to see if it is available. Replace "xx" with that code that you think it
+  should be.
+```
+locale -a | grep xx      # Works at least in FreeBSD
+grep xx /etc/locale.gen  # Works at least in Ubuntu 18.04
+```
+
+* Go to the *share* and update the *PO* file for some language, say Swedish,
+  and make a copy of that to the new file name. And then reset the *PO* file
+  for Swedish.
+```
+cd share
+make sv.po
+cp sv.po xx.po
+git checkout sv.po
+```
+
+* When you do the update of the new *PO* file you have to replace all *msgstr*
+  in Swedish with the translation in the new language, but also update the
+  "Language" field in the header.
+
+* Now you go back to the steps and continue in the same was with an existing
+  language.
+
+
+[Adding a new language]:             #adding-a-new-language
+[Background]:                        #background
+[Emacs PO-mode]:                     https://www.gnu.org/software/gettext/manual/html_node/PO-Mode.html#PO-Mode
+[GNOME Translation Editor]:          https://wiki.gnome.org/Apps/Gtranslator
+[Github preparation]:                #github-preparation
+[Github]:                            https://github.com/
+[Software preparation]:              #software-preparation
+[Steps]:                             #steps
+[Tools]:                             #tools
+[Translation]:                       https://github.com/zonemaster/zonemaster-engine/blob/develop/docs/Translation.pod
+[Zonemaster-Engine repository]:      https://github.com/zonemaster/zonemaster-engine
+[new issue]:                         https://github.com/zonemaster/zonemaster-engine/issues/new
+
+
+
+
+
+
+
+

--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -76,9 +76,8 @@ and you can disable fuzzy matching by executing
 For full integration with Zonemaster translation you need a Github account
 and a fork of *Zonemaster-Engine*. If you do not have a Github account you
 can easily create one at [Github]. If you are not prepared to
-create one, contact the Zonemaster work group for instructions, either by
-creating an [issue][new issue] or by sending an email to 
-"zonemaster@zonemaster.net".
+create one, contact the Zonemaster work group for instructions by sending
+an email to "zonemaster@zonemaster.net".
 
 To create a fork of *Zonemaster-Engine*: 
 1. Go to [Zonemaster-Engine repository].
@@ -91,7 +90,7 @@ private key is available on the computer you are going to work from.
 ## Tools
 
 The *PO* file can be edited with a plain text editor, but then it is 
-important to keep the database structur of the file. There are tools that 
+important to keep the database structure of the file. There are tools that
 makes editing of the *PO* files easier. When using those, the *PO* file is
 handled as a database instead of as a plain file.
 
@@ -102,50 +101,59 @@ handled as a database instead of as a plain file.
 * There are more tools available, either cloud services or programs
 for download, and they could be found by searching for "po editor".
 
-## Steps
+## Clone preparation
 
-The steps in this section will work for most translation work. We
-welcome comments on these.
+You need a local clone of the repository to work in.
 
-* Clone the Zonemaster-Engine repository and enter the directory
-  created:
+* Clone the Zonemaster-Engine repository, unless you already
+  have a clone that you could reuse:
 ```
-git clone https://github.com/zonemaster/zonemaster-engine.git
-cd zonemaster-engine
+  git clone https://github.com/zonemaster/zonemaster-engine.git
 ```
 
-* If you already have a clone of Zonemaster-Engine, enter that
-  and run an update.
+* Enter the directory of the clone created above or already
+  existing clone:
 ```
-cd zonemaster-engine
-git fetch --all
+  cd zonemaster-engine
 ```
 
-* Check-out the *develop* branch and create a new branch to work in.
-  You can call the new branch whatever you want, but here we use
-  the name "translation-update".
+* If you already have an old clone of Zonemaster-Engine,
+  run an update.
 ```
-git checkout origin/develop
-git checkout -b translation-update
+  git fetch --all
 ```
 
 * Now it is time to connect your own fork of *Zonemaster-Engine*
   at Github to the created clone, unless you have alreday done that,
   in case you can skip the next step.
   
-* You have a user name at Github. Here we use "xxxx" as the user name 
-  and also the name of the remote in clone om local machine.
+* You have a user name at Github. Here we use "xxxx" as your user name
+  and also the name of the remote in clone on the local machine.
 ```
-git remote add xxxx git@github.com:xxxx/zonemaster-engine.git
-git fetch --all
+  git remote add xxxx git@github.com:xxxx/zonemaster-engine.git
+  git fetch --all
+```
+
+## Translation steps
+
+The steps in this section will work for most translation work. We
+welcome comments on these.
+
+* Check-out the *develop* branch and create a new branch to work in.
+  You can call the new branch whatever you want, but here we use
+  the name "translation-update". If that name is already taken,
+  you have to give it a new name or remove the old branch.
+```
+  git checkout origin/develop
+  git checkout -b translation-update
 ```
 
 * Go to the *share* directory and run the update command for the *PO* file 
   for the language you are going to work with. Replace "xx" with the 
   language code in question. This should be done every time.
 ```
-cd share
-make xx.po
+  cd share
+  make xx.po
 ```
 
 * The *PO* file is updated with new *msgids*, if any, and now you can start
@@ -156,8 +164,8 @@ make xx.po
   your Zonemaster-Engine clone.
 
 * When doing the update, do not change the *msgid*, only the *msgstr*. The 
-  *msgid* cannot be be update in this process. They are the links between
-  the Perl module and the *PO* file.
+  *msgid* cannot and must not be be update in this process. They are the
+  links between the Perl module and the *PO* file.
 
 * If you find a *msgid* that needs an update, create an [issue][new issue] 
   or a pull request to have the message updated in the Perl module. If you 
@@ -173,39 +181,36 @@ make xx.po
   especially of the *msgid* has been changed.
 
 * Any remaining *obsolete entries* (lines at the end of the file starting 
-  with "#~") could be removed. They have no purpose anymore.
+  with "#~") could be removed. They serve no purpose anymore.
 
-* Run `../util/check-msg-args xx.po` to make sure the messages arguments in the
-  *msgstr* strings match up with those in the *msgid* strings.
-
-* When the update is completed, it is time to commit the changes. First do
-  a "git add" of the *PO* file you have updated. Make sure not to "add" any 
-  other file that might have been changed.
+* Check that the messages arguments in all *msgstr* strings match up with 
+  those in the *msgid* strings.
 ```
-git add xx.po
+  ../util/check-msg-args xx.po
 ```
 
-* Verify that only the ".po" file as been added for commit. All other
-files should be ignored.
+* When the update is completed, it is time to commit the changes. You should
+  only commit the "xx.po" file.
 ```
-git status
+  git commit -m 'Write a description of the change' xx.po
 ```
 
-* Create a commit
+* There could be other files changed or added that should not be included.
+  Run the status command to see them.
 ```
-git commit -m 'Write a description of the change'.
+  git status
 ```
 
 * Other changed files could be reset by a "checkout". This could also
   be done before creating the commit.
 ```
-git checkout FILENAME
+  git checkout FILENAME
 ```
 
 * Added files not needed can just be removed. This could also be done
   before the commit.
 ```
-rm FILE-NAME
+  rm FILE-NAME
 ```
 
 * Now push the local branch you created to your fork at Github. 
@@ -213,16 +218,17 @@ rm FILE-NAME
   have committed the updates to. Use your Github user name instead of
   "xxxx".
 ```
-git push -u xxxx translation-update
+  git push -u xxxx translation-update
 ```
 
 * Go to your fork at Github, https://github.com/xxxx/zonemaster-engine
   and use your Github user name instead of "xxxx".
 
-* Select to create a new "pull request" where the base directory
-  should be *zonemaster-engine* and the base should be *develop* (not
-  *master*). The "head" should be your fork and "compare" the same
-  branch as you created above and pushed to your fork, "translation-update".
+* Select to create a new "pull request" where the base repository
+  should be *zonemaster/zonemaster-engine* and the base branch should be
+  *develop* (not *master*). The "head" should be your fork and "compare"
+  the same branch as you created above and pushed to your fork,
+  "translation-update".
 
 * Inspect what Github says that will change by the pull request. It should
   only be the *PO* file that you have updated and nothing else. If additional
@@ -264,18 +270,23 @@ of an existing file.
   to see if it is available. Replace "xx" with that code that you think it
   should be.
 ```
-locale -a | grep xx      # Works at least in FreeBSD
-grep xx /etc/locale.gen  # Works at least in Ubuntu 18.04
+  locale -a | grep xx      # Works at least in FreeBSD
+  grep xx /etc/locale.gen  # Works at least in Ubuntu 18.04
 ```
 
 * Go to the *share* and update the *PO* file for some language, say Swedish,
   and make a copy of that to the new file name. And then reset the *PO* file
   for Swedish.
 ```
-cd share
-make sv.po
-cp sv.po xx.po
-git checkout sv.po
+  cd share
+  make sv.po
+  cp sv.po xx.po
+  git checkout sv.po
+```
+
+* You have to "add" the new file to git before you start working on it.
+```
+  git add xx.po
 ```
 
 * When you do the update of the new *PO* file you have to replace all *msgstr*

--- a/docs/Translation.pod
+++ b/docs/Translation.pod
@@ -11,6 +11,11 @@ All translation files live in the F<share> directory in the
 L<Zonemaster::Engine> source directory and all commands described here are
 executed from that directory.
 
+=head2 For translators
+
+Instructions for translators can be found in
+L<https://github.com/zonemaster/zonemaster-engine/blob/develop/docs/Translation-translators.md>
+
 =head2 For developers of Zonemaster test modules
 
 The test module code should produce log messages with message tags, as documented
@@ -43,170 +48,6 @@ message ids and old message strings.
 Every time you add, remove or modify a tag or its message id, re-run
 C<make update-po> as descibed in the next section.
 Make sure the message tag comments are properly added and up to date.
-
-=head2 For translators
-
-=head3 Software preparation
-
-For the steps below you need to work on a computer with Git, Perl and Gettext.
-Select what OS you want to work on. Other OSs will also work, but you will
-have to find instructions elsewhere.
-
-=head4 CentOS
-
-To be written.
-
-=head4 Debian
-
-Install the following:
-
-C<apt install gettext git>
-
-=head4 FreeBSD
-
-Install the following:
-
-C<pkg install devel/gettext-tools devel/git-lite>
-
-=head4 Ubuntu
-
-To be written.
-
-=head3 Background
-
-The first step in updating the translations is to generate a new template file
-(F<Zonemaster-Engine.pot>).
-In practice you rarely need to think about generating it as it is generally
-performed as an implicit intermediate step.
-If you do want to generate it, the command is C<make extract-pot>.
-
-The translated strings are maintained in files named C<{language_code}.po>
-(currently F<sv.po>, F<da.po> or F<fr.po>).
-Execute C<make update-po> to update these files with new message ids from the
-source code (C<make extract-pot> will be infoked behind the scenes).
-This should only be necessary to do when a developer has added or changed a test
-module.
-
-By default C<make update-po> suggests translations for new message ids based on
-fuzzy matching of similar strings.
-This is not always desirable and you can disable fuzzy matching by executing
-C<make update-po MSGMERGE_OPTS=--no-fuzzy-mathing> instead.
-
-=head3 Github preparation
-
-For full integration with Zonemaster translation you need a Github account
-and a fork of F<Zonemaster-Engine>. If you do not have a Github account you
-can easily create one at L<https://github.com/>. If you are not prepared to
-create one, contact the Zonemaster work group for instructions, either by
-creating an issue in L<https://github.com/zonemaster/zonemaster-engine/issues>
-or by sending an email to L<mailto:contact@zonemaster.net>.
-
-To create a fork of F<Zonemaster-Engine> go to
-L<https://github.com/zonemaster/zonemaster-engine>, make sure you are logged
-in at Github and press the "Fork" button.
-
-Make sure you have your public C<ssh> key uploaded to Github and its
-private key available on the computer you are going to work from.
-
-=head3 Tools
-
-The ".po" can be edited with a plain text editor, but then it is important
-to keep the database structur of the file. There are tools that makes
-editing of the ".po" files easier. When using those, the ".po" file is
-handled rather as a database then a plain file.
-
-=over
-
-=item * There is an add-on to Emacs,
-L<https://www.gnu.org/software/gettext/manual/html_node/PO-Mode.html#PO-Mode>,
-which makes updating and searching in the ".po" file easier and more robust.
-
-=item * There is also "GNOME Translation Editor",
-L<https://wiki.gnome.org/Apps/Gtranslator>, a ".po" graphical editor available
-for at least Windows and Linux.
-
-=item * There are more tools available, either cloud services or programs
-for download, and they could be found by searching for "po editor".
-
-=back
-
-=head3 Steps
-
-For normal translation work, follow the steps below.
-
-=over
-
-=item * Clone the Zonemaster-Engine repository with
-C<git clone https://github.com/zonemaster/zonemaster-engine.git>
-and enter the direcory created, C<cd zonemaster-engine>.
-
-=item * Check-out the F<develop> branch and create a new branch to work in,
-C<git checkout origin/develop; git checkout -b translation-update>
-
-=item * Now it is time to add your own fork of F<Zonemaster-Engine> to the
-created clone. Run
-C<git remote add XXXXX git@github.com:XXXXX/zonemaster-engine.git>
-where F<XXXXX> is your Github user name.
-
-=item * Go to the F<share> directory with C<cd share> and execute
-C<make update-po>.
-
-=item * Update the po file the language to be updated.
-
-=item * When doing the update, do not change the F<msgid>, only update
-F<msgstr>. Instead, create an issue or a pull request to have the message
-updated in the Perl module.
-
-=item * Inspect every F<fuzzy entry> (tagged with "fuzzy"). Update F<msgstr>
-if needed and remove the "fuzzy" tag.
-
-=item * Search for F<untranslated entries> (empty F<msgstr>) and add a
-translation. At the end of the file there could be F<obsolete entries>
-(lines starting with "#~") and those could have matching translations.
-
-=item * Any remaining F<obsolete entries> (lines at the end of the file
-starting with "#~") could be removed.
-
-=item * When the update is completed, it is time to commit the changes. First do
-a C<git add xx.po> where F<xx> is the language code of the po file you
-have updated. Make sure not to "add" any other file that might have been
-changed.
-
-=item * Run C<git status> to verify that only the ".po" file as been added for
-commit.
-
-=item * Create a commit, C<git commit -m 'Write a description of the change'>.
-
-=item * Other changed files could be reset by C<git checkout FILE-NAME>.
-
-=item * Added files not needed can just be removed by C<rm FILE-NAME>.
-
-=item * Now push the branch to your fork at Github. Run
-C<git push -u XXXXX translation-update> where F<XXXXX> is your
-Github user name and "translation-update" is name of the branch
-you created above and have been working on.
-
-=item * Go to your fork at Github, https://github.com/XXXXX/zonemaster-engine
-where F<XXXXX> is your Github user name.
-
-=item * Select to create a new F<pull request> where the base directory
-should be F<zonemaster-engine> and the base should be F<develop> (not
-"master"). The "head" should be your fork and "compare" the same
-branch as you created above and pushed to your fork.
-
-=item * Inspect what Github says that will change by the pull request. It should
-only be the F<po> file that you have updated and nothing else. If additional
-files are listed, please correct or request for help.
-
-=item * Press "create pull request", write a nice description and press "create"
-again.
-
-=item * If you go back to your own computer and just save the clone as it is, you
-can easily update the pull request if needed with more changes to the same
-po file. When the pull request has been merged by the Zonemaster work group,
-you can delete the local clone and on your Github fork you can remove the branch.
-
-=back
 
 =head2 For Zonemaster package maintainers
 


### PR DESCRIPTION
This PR does two things:
* Updates the instructions for translators
* Creates a separate document for translators

The POD format is fine for code documents when you want to create "man" pages but for presentation on Github the markdown format is much better. A separate document in markdown has therefore been created for the translators. That was the largest part of the original document.

Updates:
* More details for the steps.
* Norwegian has been added.
* Information on how to create a new language (a new PO file) has been added.

This PR expands the solution added by PR #701, it partly resolves #594, it gives a better resolution to #591 and it resloves #756 

The new "docs/Translation.pod" will link to "docs/Translation-translators.md" in the *develop* branch due to lack of relative links in POD files, which means that the link will not work until this PR has been merged.