### PR TITLE
Implement singleton pattern idiomatically

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ requires 'List::MoreUtils'    => 0;
 requires 'Locale::TextDomain' => 1.20;
 requires 'Module::Find'       => 0.10;
 requires 'Moose'              => 2.0401;
+requires 'MooseX::Singleton'  => 0.30;
 requires 'Net::IP'            => 1.26;
 requires 'Readonly'           => 0;
 requires 'Text::CSV'          => 0;

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -51,7 +51,7 @@ This instruction covers the following operating systems:
 5) Install packages from CPAN:
 
    ```sh
-   sudo cpanm Email::Valid Locale::Msgfmt Module::Install Module::Install::XSUtil Test::More
+   sudo cpanm Email::Valid Locale::Msgfmt Module::Install Module::Install::XSUtil MooseX::Singleton Test::More
    ```
 
 6) Install Zonemaster::LDNS and Zonemaster::Engine for *CentOS 7*:
@@ -91,7 +91,7 @@ This instruction covers the following operating systems:
 3) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl libjson-pp-perl liblist-moreutils-perl liblocale-msgfmt-perl libmodule-find-perl libmodule-install-xsutil-perl libmoose-perl libnet-ip-perl libpod-coverage-perl libreadonly-xs-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-pod-perl libtext-csv-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl libjson-pp-perl liblist-moreutils-perl liblocale-msgfmt-perl libmodule-find-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-xs-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-pod-perl libtext-csv-perl libtool m4
    ```
 
 4) Install dependencies from CPAN:
@@ -169,7 +169,7 @@ This instruction covers the following operating systems:
    * On all versions of FreeBSD install:
 
      ```sh
-     pkg install libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Locale-Msgfmt p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP
+     pkg install libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Locale-Msgfmt p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP
      ```
 
    * On FreeBSD 11.x (11.3 or newer) also install OpenSSL 1.1.1 or newer:

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -15,6 +15,7 @@ use POSIX qw[setlocale LC_MESSAGES];
 use Readonly;
 
 use Moose;
+use MooseX::Singleton;
 
 has 'locale'               => ( is => 'rw', isa => 'Str' );
 has 'data'                 => ( is => 'ro', isa => 'HashRef', lazy => 1, builder => '_load_data' );
@@ -172,15 +173,6 @@ sub _build_all_tag_descriptions {
 ### Method modifiers
 ###
 
-around 'new' => sub {
-    my $next = shift;
-    my ( $self, @args ) = @_;
-
-    state $instance = $self->$next( @args );
-
-    return $instance;
-};
-
 around 'locale' => sub {
     my $next = shift;
     my ( $self, @args ) = @_;
@@ -252,7 +244,9 @@ Zonemaster::Engine::Translator - translation support for Zonemaster
 
 =head1 SYNOPSIS
 
-    my $trans = Zonemaster::Engine::Translator->new({ locale => 'sv_SE.UTF-8' });
+    Zonemaster::Engine::Translator->initialize({ locale => 'sv_SE.UTF-8' });
+
+    my $trans = Zonemaster::Engine::Translator->instance;
     say $trans->to_string($entry);
 
 This is a singleton class.
@@ -288,9 +282,6 @@ is returned.
 As a side effect when successfully updating this attribute gettext's textdomain
 is reset.
 
-If no initial value is provided to the constructor, one is determined by calling
-setlocale( LC_MESSAGES, "" ).
-
 =item data
 
 A reference to a hash with translation data. This is unlikely to be useful to
@@ -301,6 +292,38 @@ end-users.
 =head1 METHODS
 
 =over
+
+=item initialize(%args)
+
+Provide initial values for the single instance of this class.
+
+    Zonemaster::Engine::Translator->initialize( locale => 'sv_SE.UTF-8' );
+
+This method must be called at most once and before the first call to instance().
+
+=item instance()
+
+Returns the single instance of this class.
+
+    my $translator = Zonemaster::Engine::Translator->instance;
+
+If initialize() has not been called prior to the first call to instance(), it
+is the same as if initialize() had been called without arguments.
+
+=item new(%args)
+
+Use of this method is deprecated.
+
+See L<MooseX::Singleton->new|MooseX::Singleton/"Singleton->new">.
+
+=over
+
+=item locale
+
+If no initial value is provided to the constructor, one is determined by calling
+setlocale( LC_MESSAGES, "" ).
+
+=back
 
 =item to_string($entry)
 


### PR DESCRIPTION
Apparently Moose doesn't like that you wrap the `new()` constructor unless you're a Moose extension. This is an update implement the singleton pattern using a Moose extension instead of doing it in an ad-hoc manner.

Fixes #766.