### PR TITLE
Validate use of arguments in translated messages

### DIFF
--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -116,7 +116,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NAMESERVERS_IPV4_WITH_MULTIPLE_AS => sub {
         __x    # CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
-          'Authoritative IPv4 nameservers are in more than one AS.', @_;
+          'Authoritative IPv4 nameservers are in more than one AS ({asn}).', @_;
     },
     NAMESERVERS_IPV6_NO_AS => sub {
         __x    # CONNECTIVITY:NAMESERVERS_IPV6_NO_AS

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -865,7 +865,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     UNEXPECTED_RESPONSE_DS => sub {
         __x    # DNSSEC:UNEXPECTED_RESPONSE_DS
-          '{ns}/{address} responded with an unexpected rcode ({rcode}) on a DS query for zone {zone}.', @_;
+          'Nameserver {ns}/{address} responded with an unexpected rcode ({rcode}) on a DS query for zone {zone}.', @_;
     },
 );
 

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -355,7 +355,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     QNAME_CASE_INSENSITIVE => sub {
         __x    # NAMESERVER:QNAME_CASE_INSENSITIVE
-          'Nameserver {ns}/{address} does not preserve original case of queried names.', @_;
+          'Nameserver {ns}/{address} does not preserve original case of the queried name ({dname}).', @_;
     },
     QNAME_CASE_SENSITIVE => sub {
         __x    # NAMESERVER:QNAME_CASE_SENSITIVE

--- a/share/Makefile
+++ b/share/Makefile
@@ -35,5 +35,8 @@ $(POFILES): $(POTFILE)
 show-fuzzy:
 	@for f in $(POFILES) ; do msgattrib --only-fuzzy $$f ; done
 
+check-msg-args:
+	@for f in $(POFILES) ; do ../util/check-msg-args $$f ; done
+
 modules.txt: $(TESTMODULEFILES)
 	@echo $(TESTMODULEFILES) | xargs basename -s .pm -a | grep -vE '^Basic$$' | sort > modules.txt

--- a/share/da.po
+++ b/share/da.po
@@ -1000,15 +1000,6 @@ msgstr ""
 "Antallet af NSEC3-iterationer er {count}, hvilket er for højt for "
 "nøglelængden {keylength}."
 
-#. DNSSEC:UNEXPECTED_RESPONSE_DS
-#, perl-brace-format
-msgid ""
-"Nameserver {ns}/{address} responded with an unexpected rcode ({rcode}) on a "
-"DS query for zone {zone}."
-msgstr ""
-"Nameserver {ns}/{address} answered A query with an unexpected rcode "
-"({rcode})."
-
 #. DELEGATION:ARE_AUTHORITATIVE
 #, perl-brace-format
 msgid "All these nameservers are confirmed to be authoritative : {nsset}."
@@ -1469,10 +1460,11 @@ msgstr "Fejlagtigt svar fra navneserver {ns}/{address}."
 #. NAMESERVER:QNAME_CASE_INSENSITIVE
 #, perl-brace-format
 msgid ""
-"Nameserver {ns}/{address} does not preserve original case of queried names."
+"Nameserver {ns}/{address} does not preserve original case of the queried "
+"name ({dname})."
 msgstr ""
 "Navneserveren {ns}/{address} bevarede ikke versaler og minuskler fra "
-"forespørgslen."
+"forespørgslen ({dname})."
 
 #. NAMESERVER:QNAME_CASE_SENSITIVE
 #, perl-brace-format
@@ -1480,7 +1472,7 @@ msgid ""
 "Nameserver {ns}/{address} preserves original case of queried names ({dname})."
 msgstr ""
 "Navneserveren {ns}/{address} bevarede versaler og minuskler fra "
-"forespørgslen."
+"forespørgslen ({dname})."
 
 #. NAMESERVER:SAME_SOURCE_IP
 msgid "All nameservers reply with same IP used to query them."
@@ -1927,6 +1919,11 @@ msgstr "Modulet {module} afsluttede."
 #. SYSTEM:NO_NETWORK
 msgid "Both IPv4 and IPv6 are disabled."
 msgstr "Både IPv4 og IPv6 er deaktiveret."
+
+#. SYSTEM:POLICY_DISABLED
+#, perl-brace-format
+msgid "The module {name} was disabled by the policy."
+msgstr "Modulet {name} var deaktiveret i politikken."
 
 #. SYSTEM:UNKNOWN_METHOD
 #, perl-brace-format

--- a/share/da.po
+++ b/share/da.po
@@ -189,7 +189,8 @@ msgid "No IPv4 nameserver address is in an AS."
 msgstr "Ingen navneserver har en IPv4-adresse i et AS."
 
 #. CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
-msgid "Authoritative IPv4 nameservers are in more than one AS."
+#, perl-brace-format
+msgid "Authoritative IPv4 nameservers are in more than one AS ({asn})."
 msgstr "Autoritative navneservere (IPv4) er i flere AS'er ({asn})."
 
 #. CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
@@ -1002,8 +1003,8 @@ msgstr ""
 #. DNSSEC:UNEXPECTED_RESPONSE_DS
 #, perl-brace-format
 msgid ""
-"{ns}/{address} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"Nameserver {ns}/{address} responded with an unexpected rcode ({rcode}) on a "
+"DS query for zone {zone}."
 msgstr ""
 "Nameserver {ns}/{address} answered A query with an unexpected rcode "
 "({rcode})."
@@ -1926,11 +1927,6 @@ msgstr "Modulet {module} afsluttede."
 #. SYSTEM:NO_NETWORK
 msgid "Both IPv4 and IPv6 are disabled."
 msgstr "Både IPv4 og IPv6 er deaktiveret."
-
-#. SYSTEM:POLICY_DISABLED
-#, perl-brace-format
-msgid "The module {name} was disabled by the policy."
-msgstr "Modulet {name} var deaktiveret i politikken."
 
 #. SYSTEM:UNKNOWN_METHOD
 #, perl-brace-format

--- a/share/fr.po
+++ b/share/fr.po
@@ -212,10 +212,11 @@ msgid "No IPv4 nameserver address is in an AS."
 msgstr "Aucune adresse IPv4 des serveurs de noms ne se trouve dans un AS."
 
 #. CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
-msgid "Authoritative IPv4 nameservers are in more than one AS."
+#, perl-brace-format
+msgid "Authoritative IPv4 nameservers are in more than one AS ({asn})."
 msgstr ""
 "Les adresses IPv4 des serveurs faisant autorité se trouvent dans plusieurs "
-"AS."
+"AS ({asn})."
 
 #. CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
 msgid "No IPv6 nameserver address is in an AS."
@@ -1136,8 +1137,8 @@ msgstr ""
 #. DNSSEC:UNEXPECTED_RESPONSE_DS
 #, perl-brace-format
 msgid ""
-"{ns}/{address} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"Nameserver {ns}/{address} responded with an unexpected rcode ({rcode}) on a "
+"DS query for zone {zone}."
 msgstr ""
 "Le serveur de noms {ns}/{address} a répondu à une requête de type \"AAAA\" "
 "avec un code retour inattendu ({rcode}) pour la zone '{zone}'."

--- a/share/fr.po
+++ b/share/fr.po
@@ -1365,13 +1365,6 @@ msgstr ""
 "Les serveurs de noms de la zone parente ne retournent pas de serveurs ayant une "
 "adresse IPv6. Si il y en avait, il en faudrait au minimum {minimum}."
 
-#. DELEGATION:NS_IS_CNAME
-#, perl-brace-format
-msgid "Nameserver {ns} RR point to CNAME."
-msgstr ""
-"L'enregistrement de type \"{address_type}\" retourné par le serveur de noms "
-"{ns} est un alias (CNAME)."
-
 #. DELEGATION:NO_NS_CNAME
 msgid "No nameserver points to CNAME alias."
 msgstr "Aucun serveur de noms ne pointe sur un alias (CNAME)."
@@ -1603,13 +1596,6 @@ msgstr ""
 msgid "The following nameservers support EDNS0 : {names}."
 msgstr "Les serveurs de noms suivants supportent EDNS0 : {names}."
 
-#. NAMESERVER:IS_A_RECURSOR
-#, perl-brace-format
-msgid "Nameserver {ns}/{address} is a recursor."
-msgstr ""
-"Le serveur de noms {ns}/{address} retourne le code NXDOMAIN lors d'une "
-"requête de type \"SOA\" sur le nom de domaine '{dname}'. Il est récursif."
-
 #. NAMESERVER:MISSING_OPT_IN_TRUNCATED
 #, perl-brace-format
 msgid ""
@@ -1660,7 +1646,8 @@ msgstr ""
 #. NAMESERVER:QNAME_CASE_INSENSITIVE
 #, perl-brace-format
 msgid ""
-"Nameserver {ns}/{address} does not preserve original case of queried names."
+"Nameserver {ns}/{address} does not preserve original case of the queried "
+"name ({dname})."
 msgstr ""
 "Le serveur de noms {ns}/{address} ne conserve pas la casse des noms requêtés "
 "dans les réponses '{dname}'."

--- a/share/nb.po
+++ b/share/nb.po
@@ -642,7 +642,7 @@ msgid ""
 "record is for the DNSKEY record with keytag {keytag} in zone {zone}."
 msgstr ""
 "Navnetjener {ns}/{address} svarte med en DS-post skapad med algoritme "
-"{algorithm_number} ({algorithm_mnemonic}) som ikke er i bruk. DS-posten "
+"{algorithm_number} som ikke er i bruk. DS-posten "
 "gjelder for DNSKEY-posten med \"key tag\" {keytag} i sonen {zone}."
 
 #. DNSSEC:DS_ALGO_SHA1_DEPRECATED
@@ -1025,7 +1025,7 @@ msgstr "Alle navnetjenere i delegeringen bruker unike IP-addresser."
 msgid "IP {address} in parent refers to multiple nameservers ({nss})."
 msgstr ""
 "IP-adresse {address} brukes til flere navnetjenere (NS-poster) i "
-"delegeringen ({mss})."
+"delegeringen ({nss})."
 
 #. DELEGATION:DISTINCT_IP_ADDRESS
 msgid "All the IP addresses used by the nameservers are unique"
@@ -1161,7 +1161,7 @@ msgid ""
 "{minimum}."
 msgstr ""
 "Det finnes ikke tilstrekkelig med navnetjenere (NS-poster) i dattersonen. "
-"Antall: {count}. Navnetjenere: {ns}. Minste antall er satt til {minimum}."
+"Antall: {count}. Navnetjenere: {nss}. Minste antall er satt til {minimum}."
 
 #. DELEGATION:NOT_ENOUGH_NS_DEL
 #, perl-brace-format
@@ -1473,10 +1473,11 @@ msgstr "Feilaktig svar fra navnetjener {ns}/{address}."
 #. NAMESERVER:QNAME_CASE_INSENSITIVE
 #, perl-brace-format
 msgid ""
-"Nameserver {ns}/{address} does not preserve original case of queried names."
+"Nameserver {ns}/{address} does not preserve original case of the queried "
+"name ({dname})."
 msgstr ""
 "Navnetjener {ns}/{address} bevarer ikke opprinnelige store og små bokstaver "
-"i spørringen."
+"i spørringen ({dname})."
 
 #. NAMESERVER:QNAME_CASE_SENSITIVE
 #, perl-brace-format
@@ -1484,7 +1485,7 @@ msgid ""
 "Nameserver {ns}/{address} preserves original case of queried names ({dname})."
 msgstr ""
 "Navnetjener {ns}/{address} bevarer opprinnelige store og små bokstaver i "
-"spørringen."
+"spørringen ({dname})."
 
 #. NAMESERVER:SAME_SOURCE_IP
 msgid "All nameservers reply with same IP used to query them."
@@ -1664,7 +1665,7 @@ msgstr "Ingen feilanvending av \"@\"-tegnet i SOA/RNAME ({rname})."
 #. SYNTAX:RNAME_RFC822_INVALID
 #, perl-brace-format
 msgid "Illegal character(s) found in SOA RNAME field ({rname})."
-msgstr "Fant tegn i SOA/MNAME-post ({name}) som ikke er tillatt."
+msgstr "Fant tegn i SOA/MNAME-post ({rname}) som ikke er tillatt."
 
 #. SYNTAX:RNAME_RFC822_VALID
 #, perl-brace-format

--- a/share/nb.po
+++ b/share/nb.po
@@ -180,8 +180,9 @@ msgid "No IPv4 nameserver address is in an AS."
 msgstr "Ingen IPv4 navnetjeneradresse befinner seg i et AS."
 
 #. CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
-msgid "Authoritative IPv4 nameservers are in more than one AS."
-msgstr "Autoritative IPv4 navnetjenere befinner seg i fler enn en AS."
+#, perl-brace-format
+msgid "Authoritative IPv4 nameservers are in more than one AS ({asn})."
+msgstr "Autoritative IPv4 navnetjenere befinner seg i fler enn en AS ({asn})."
 
 #. CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
 msgid "No IPv6 nameserver address is in an AS."
@@ -994,8 +995,8 @@ msgstr ""
 #. DNSSEC:UNEXPECTED_RESPONSE_DS
 #, perl-brace-format
 msgid ""
-"{ns}/{address} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"Nameserver {ns}/{address} responded with an unexpected rcode ({rcode}) on a "
+"DS query for zone {zone}."
 msgstr ""
 "Navnetjener {ns}/{address} svarte på en DS-spørring for sonen {zone} med en "
 "uventede svarkoden ({rcode})."

--- a/share/sv.po
+++ b/share/sv.po
@@ -657,9 +657,8 @@ msgid ""
 "record is for the DNSKEY record with keytag {keytag} in zone {zone}."
 msgstr ""
 "Namnserver {ns}/{address} svarade med en DS-post skapad med hash-algoritm "
-"{algorithm_number} ({algorithm_mnemonic}) som inte är satt till någon hash-"
-"algoritm, vilket inte är OK. DS-posten gäller DNSKEY-posten med "
-"'keytag' {keytag} i zonen {zone}."
+"{algorithm_number} som inte är satt till någon hash-algoritm, vilket inte är "
+"OK. DS-posten gäller DNSKEY-posten med 'keytag' {keytag} i zonen {zone}."
 
 #. DNSSEC:DS_ALGO_SHA1_DEPRECATED
 #, perl-brace-format
@@ -1507,7 +1506,8 @@ msgstr "Felaktigt svar från namnserver {ns}/{address}."
 #. NAMESERVER:QNAME_CASE_INSENSITIVE
 #, perl-brace-format
 msgid ""
-"Nameserver {ns}/{address} does not preserve original case of queried names."
+"Nameserver {ns}/{address} does not preserve original case of the queried "
+"name ({dname})."
 msgstr ""
 "Nameserver {ns}/{address} bevarar inte skillnaden mellan versaler och "
 "gemener från frågan ({dname})."
@@ -1516,7 +1516,9 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Nameserver {ns}/{address} preserves original case of queried names ({dname})."
-msgstr "Namnserver {ns}/{address} bevarade versaler och gemener från frågan."
+msgstr ""
+"Namnserver {ns}/{address} bevarade versaler och gemener från frågan "
+"({dname})."
 
 #. NAMESERVER:SAME_SOURCE_IP
 msgid "All nameservers reply with same IP used to query them."
@@ -1685,8 +1687,8 @@ msgid ""
 "The SOA RNAME mail domain ({domain}) cannot be resolved to a mail server "
 "with an IP address."
 msgstr ""
-"Maildomänen från 'SOA RNAME' kan inte slås upp till en mailserver med IP-"
-"adress."
+"Maildomänen från 'SOA RNAME' ({domain}) kan inte slås upp till en mailserver "
+"med IP-adress."
 
 #. SYNTAX:RNAME_MISUSED_AT_SIGN
 #, perl-brace-format
@@ -1810,7 +1812,7 @@ msgid ""
 "SOA 'minimum' value ({minimum}) is between the recommended ones "
 "({lowest_minimum}/{highest_minimum})."
 msgstr ""
-"Värdet för SOA 'minimum' ligger inom det rekommenderade spannet "
+"Värdet för SOA 'minimum' ({minimum}) ligger inom det rekommenderade spannet "
 "({lowest_minimum} - {highest_minimum})."
 
 #. ZONE:MNAME_NOT_AUTHORITATIVE
@@ -1880,7 +1882,8 @@ msgid ""
 "Nameserver {ns}/{address} responds with multiple ({count}) SOA records on "
 "SOA queries."
 msgstr ""
-"Namnserver {ns}/{address} svarade med multipla SOA-poster på SOA-frågor."
+"Namnserver {ns}/{address} svarade med multipla ({count}) SOA-poster på SOA-"
+"frågor."
 
 #. ZONE:NO_SOA_IN_RESPONSE
 #, perl-brace-format
@@ -1906,8 +1909,9 @@ msgid ""
 "SOA 'expire' value ({expire}) is higher than the minimum recommended value "
 "({required_expire}) and not lower than the 'refresh' value ({refresh})."
 msgstr ""
-"Värdet för SOA 'expire' är lika med eller högre än det minsta rekommenderade "
-"värdet ({required_expire}) och inte lägre än värdet på 'refresh' ({refresh})."
+"Värdet för SOA 'expire' ({expire}) är lika med eller högre än det minsta "
+"rekommenderade värdet ({required_expire}) och inte lägre än värdet på "
+"'refresh' ({refresh})."
 
 #. ZONE:WRONG_SOA
 #, perl-brace-format
@@ -1971,6 +1975,11 @@ msgstr "Modulen '{module}' avslutades."
 #. SYSTEM:NO_NETWORK
 msgid "Both IPv4 and IPv6 are disabled."
 msgstr "Både IPv4 och IPv6 är inaktiverade."
+
+#. SYSTEM:POLICY_DISABLED
+#, perl-brace-format
+msgid "The module {name} was disabled by the policy."
+msgstr "Modulen '{name}' var inaktiverad i policyn."
 
 #. SYSTEM:UNKNOWN_METHOD
 #, perl-brace-format

--- a/share/sv.po
+++ b/share/sv.po
@@ -188,10 +188,11 @@ msgid "No IPv4 nameserver address is in an AS."
 msgstr "Ingen namnserver har någon IPv4-adress i något AS."
 
 #. CONNECTIVITY:NAMESERVERS_IPV4_WITH_MULTIPLE_AS
-msgid "Authoritative IPv4 nameservers are in more than one AS."
+#, perl-brace-format
+msgid "Authoritative IPv4 nameservers are in more than one AS ({asn})."
 msgstr ""
 "IPv4-adresserna för de auktoritativa namnservrarna för domännamnet finns i "
-"mer än ett AS."
+"mer än ett AS ({asn})."
 
 #. CONNECTIVITY:NAMESERVERS_IPV6_NO_AS
 msgid "No IPv6 nameserver address is in an AS."
@@ -1019,8 +1020,8 @@ msgstr ""
 #. DNSSEC:UNEXPECTED_RESPONSE_DS
 #, perl-brace-format
 msgid ""
-"{ns}/{address} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"Nameserver {ns}/{address} responded with an unexpected rcode ({rcode}) on a "
+"DS query for zone {zone}."
 msgstr ""
 "Namnserver {ns}/{address} besvarade en DS-fråga för zonen {zone} med den "
 "icke-väntade svarskoden '{rcode}'."
@@ -1702,7 +1703,6 @@ msgstr "Inga felanvända @-tecken hittades i SOA RNAME ({rname})."
 msgid "Illegal character(s) found in SOA RNAME field ({rname})."
 msgstr "Otillåtet tecken finns i SOA RNAME ({rname})."
 
-
 #. SYNTAX:RNAME_RFC822_VALID
 #, perl-brace-format
 msgid "The SOA RNAME field ({rname}) is compliant with RFC2822."
@@ -1971,11 +1971,6 @@ msgstr "Modulen '{module}' avslutades."
 #. SYSTEM:NO_NETWORK
 msgid "Both IPv4 and IPv6 are disabled."
 msgstr "Både IPv4 och IPv6 är inaktiverade."
-
-#. SYSTEM:POLICY_DISABLED
-#, perl-brace-format
-msgid "The module {name} was disabled by the policy."
-msgstr "Modulen '{name}' var inaktiverad i policyn."
 
 #. SYSTEM:UNKNOWN_METHOD
 #, perl-brace-format

--- a/util/check-msg-args
+++ b/util/check-msg-args
@@ -1,0 +1,110 @@
+#!/usr/bin/env perl
+use utf8;
+use strict;
+use warnings;
+use open qw(:std :utf8);
+use feature 'say';
+
+use Locale::PO;
+use Try::Tiny;
+use Getopt::Long qw( GetOptions );
+use Pod::Usage qw( pod2usage );
+
+sub extract_perl_braces {
+    my $string = shift;
+
+    # Strip text before the first and after the last brace
+    $string =~ s/^[^{]*{?|}?[^}]*$//g;
+
+    # Extract the fields
+    my @fields = split /}[^{]*{/, $string;
+
+    return @fields;
+}
+
+sub diff_perl_braces {
+    my $got_string      = shift // die 'undefined value for $got_string';
+    my $expected_string = shift // die 'undefined value for $expected_string';
+
+    my %got_fields      = map { $_ => 1 } extract_perl_braces( $got_string );
+    my %expected_fields = map { $_ => 1 } extract_perl_braces( $expected_string );
+
+    my %missing = %expected_fields;
+    delete @missing{ keys %got_fields };
+
+    my %extra = %got_fields;
+    delete @extra{ keys %expected_fields };
+
+    return [ sort keys %missing ], [ sort keys %extra ];
+}
+
+sub check_perl_braces {
+    my $po = shift;
+    my $filename = shift;
+
+    my $msgid  = $po->dequote( $po->msgid );
+    my $msgstr = $po->dequote( $po->msgstr );
+    my ( $missing, $extra ) = diff_perl_braces( $msgstr, $msgid );
+
+    if ( @{$missing} or @{$extra} ) {
+        say "";
+        say '# ' . $filename . ' line ' . $po->loaded_line_number;
+        print map { "#. $_\n" } split /\n/, $po->automatic // '';
+        say "msgid ",  $po->msgid;
+        say "msgstr ", $po->msgstr;
+        for my $field ( @{$missing} ) {
+            say "  Only in msgid: {$field}";
+        }
+        for my $field ( @{$extra} ) {
+            say "  Only in msgstr: {$field}";
+        }
+    }
+
+    return;
+}
+
+my $opt_help = 0;
+my $opt_man  = 0;
+GetOptions(
+    "help|h" => \$opt_help,
+    "man"    => \$opt_man,
+) or pod2usage( 2 );
+pod2usage( 1 ) if $opt_help;
+pod2usage( -verbose => 2 ) if $opt_man;
+
+for my $filename ( @ARGV ) {
+    my $aref = Locale::PO->load_file_asarray( $filename, 'UTF-8' ) // die "Failed to load PO file '$filename'";
+    for my $po ( @$aref ) {
+        try {
+            if ( $po->has_flag( 'perl-brace-format' ) ) {
+                check_perl_braces( $po, $filename );
+            }
+        }
+        catch {
+            say STDERR "error processing $filename at line " . $po->loaded_line_number . ": " . $_;
+            exit 1;
+        };
+    }
+}
+
+=head1 NAME
+
+    check-msg-args - Verify that PO files have the same args in the msgid and msgstr of their perl-brace-format messages
+
+=head1 SYNOPSIS
+
+    check-msg-args [options] [file ...]
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<--help>
+
+Print a brief help message and exit.
+
+=item B<--man>
+
+Print the manual page and exit.
+
+=back


### PR DESCRIPTION
This adds a util (check-msg-args) that verifies that the args used in the msgstr are the same ones that are used in the msgid for perl-brace-format messages.
The utility is hooked up to the `make check-msg-args` target in `share/Makefile`. ~That target is in turn hooked up in the unit tests.~ This check should not be run as a unit test because it would be impossible to update msgids without also updating the translations for all languages.

In order for the unit test not to immediately fail on these new checks, I had to fix the PO files. In doing so I found a couple of msgids where arguments were available but unused, and one where the word "Nameserver" hadn't been added before {ns}/{address}, so I fixed those as well. In the Danish translation I found a msgstr that didn't correspond to its msgid - instead of trying to fix that I just removed it. In the French translation I found a couple of messages that used arguments that weren't available. In those cases I just removed the arguments hoping that I didn't butcher the grammar or the meaning of the sentences. Please look extra closely at those when reviewing.

The translation documentation should be updated with instructions to use this utility, but I don't want to touch it at the moment because of #772.

~A new test-time dependency is introduced: Locale::PO.~ The translation documentation should be amended with installation of Local::PO, which is a new translation-time dependency. Locale::PO is packaged for all supported platforms except CentOS.

These checks will be very helpful when resolving #60 and #713.