### PR TITLE
Add missing dots at the end of several msgid

### DIFF
--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -164,15 +164,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ASN_INFOS_RAW => sub {
         __x    # CONNECTIVITY:ASN_INFOS_RAW
-          '[ASN:RAW] {address};{data}', @_;
+          '[ASN:RAW] {address};{data}.', @_;
     },
     ASN_INFOS_ANNOUNCE_BY => sub {
         __x    # CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
-          '[ASN:ANNOUNCE_BY] {address};{asn}', @_;
+          '[ASN:ANNOUNCE_BY] {address};{asn}.', @_;
     },
     ASN_INFOS_ANNOUNCE_IN => sub {
         __x    # CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
-          '[ASN:ANNOUNCE_IN] {address};{prefix}', @_;
+          '[ASN:ANNOUNCE_IN] {address};{prefix}.', @_;
     },
     TEST_CASE_END => sub {
         __x    # CONNECTIVITY:TEST_CASE_END

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -146,7 +146,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CHILD_ZONE_LAME => sub {
         __x    # CONSISTENCY:CHILD_ZONE_LAME
-          'Lame delegation', @_;
+          'Lame delegation.', @_;
     },
     EXTRA_ADDRESS_CHILD => sub {
         __x    # CONSISTENCY:EXTRA_ADDRESS_CHILD
@@ -159,7 +159,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     IN_BAILIWICK_ADDR_MISMATCH => sub {
         __x    # CONSISTENCY:IN_BAILIWICK_ADDR_MISMATCH
           'In-bailiwick name server listed at parent has a mismatch between glue data at parent '
-          . '({parent_addresses}) and any equivalent address record in child zone ({zone_addresses})',
+          . '({parent_addresses}) and any equivalent address record in child zone ({zone_addresses}).',
           @_;
     },
     IPV4_DISABLED => sub {
@@ -212,11 +212,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ONE_SOA_MNAME => sub {
         __x    # CONSISTENCY:ONE_SOA_MNAME
-          "A single SOA mname value was seen ({mname})", @_;
+          "A single SOA mname value was seen ({mname}).", @_;
     },
     ONE_SOA_RNAME => sub {
         __x    # CONSISTENCY:ONE_SOA_RNAME
-          "A single SOA rname value was found ({rname})", @_;
+          "A single SOA rname value was found ({rname}).", @_;
     },
     ONE_SOA_SERIAL => sub {
         __x    # CONSISTENCY:ONE_SOA_SERIAL
@@ -232,7 +232,7 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # CONSISTENCY:OUT_OF_BAILIWICK_ADDR_MISMATCH
           'Out-of-bailiwick name server listed at parent with glue record has a mismatch between '
           . 'the glue at the parent ({parent_addresses}) and any equivalent address record found '
-          . 'in authoritative zone ({zone_addresses})', @_;
+          . 'in authoritative zone ({zone_addresses}).', @_;
     },
     SOA_RNAME => sub {
         __x    # CONSISTENCY:SOA_RNAME

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -503,7 +503,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ALL_ALGO_SIGNED => sub {
         __x    # DNSSEC:ALL_ALGO_SIGNED
-          'All the tested RRset (SOA/DNSKEY/NS) are signed by each algorithm present in the DNSKEY RRset',
+          'All the tested RRset (SOA/DNSKEY/NS) are signed by each algorithm present in the DNSKEY RRset.',
           @_;
     },
     BROKEN_DNSSEC => sub {
@@ -823,7 +823,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     RRSIG_BROKEN => sub {
         __x    # DNSSEC:RRSIG_BROKEN
           'Nameserver {ns}/{address} responded with an RRSIG which can not be verified with '
-          . 'corresponding DNSKEY (with keytag {keytag})',
+          . 'corresponding DNSKEY (with keytag {keytag}).',
           @_;
     },
     RRSIG_EXPIRED => sub {

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -158,7 +158,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DISTINCT_IP_ADDRESS => sub {
         __x    # DELEGATION:DISTINCT_IP_ADDRESS
-          "All the IP addresses used by the nameservers are unique", @_;
+          "All the IP addresses used by the nameservers are unique.", @_;
     },
     ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_IPV4_NS_CHILD

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -222,7 +222,7 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     AAAA_BAD_RDATA => sub {
         __x    # NAMESERVER:AAAA_BAD_RDATA
-            'Nameserver {ns}/{address} answered AAAA query with an unexpected RDATA length ({length} instead of 16)', @_;
+            'Nameserver {ns}/{address} answered AAAA query with an unexpected RDATA length ({length} instead of 16).', @_;
     },
     AAAA_QUERY_DROPPED => sub {
         __x    # NAMESERVER:AAAA_QUERY_DROPPED


### PR DESCRIPTION
The msgid should be terminated by a dot, and usually it is. This PR fixes some cases where the dot was missing.