### PR TITLE
Update some message args for consistency

### DIFF
--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -2,14 +2,14 @@
 
 ## Aggregate list
 
-| Argument | Type of value         | Description and formatting                                    |
-|----------|-----------------------|---------------------------------------------------------------|
-| nsname   | Domain name           | The domain name of a name server.                             |
-| nsip     | IP address            | The IP address of a name server.                              |
-| ns       | Domain name and IP address pair | The name and IP address of a name server, separated by "/".|
-| nsnames  | List of domain names  | The names of a list of nameservers, separated by ";".         |
-| nsips    | List of IP addresses  | The addresses of a list of nameservers, separated by ";".     |
-| nss      | List of domain name and IP address pairs | The names and addresses of a list of nameservers, the name and address of a nameserver are separated by "/", nameservers are separated by ";".|
+| Argument    | Type of value        | Description and formatting                                  |
+|-------------|----------------------|-------------------------------------------------------------|
+| nsname      | Domain name          | The domain name of a name server.                           |
+| ns_ip       | IP address           | The IP address of a name server.                            |
+| ns          | Domain name and IP address pair | The name and IP address of a name server, separated by "/". |
+| nsname_list | List of domain names | A list of name servers, as specified by "nsname", separated by ";". |
+| ns_ip_list  | List of IP addresses | A list of name servers, as specified by "nsip", separated by ";". |
+| ns_list     | List of domain name and IP address pairs | A list of name servers, as specified by "ns", separated by ";". |
 || AS number| An Autonomous Space number for an IP address.|
 || Address record type (A or AAAA)| Used to tell the difference between IPv4 and IPv6.|
 || Count of different SOA RNAMEs.| Total number of different SOA RNAME fields seen.|

--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -2,8 +2,14 @@
 
 ## Aggregate list
 
-|Argument name|Type of value | Description |
-|-------------|----------|----------------------------------------------|
+| Argument | Type of value         | Description and formatting                                    |
+|----------|-----------------------|---------------------------------------------------------------|
+| nsname   | Domain name           | The domain name of a name server.                             |
+| nsip     | IP address            | The IP address of a name server.                              |
+| ns       | Domain name and IP address pair | The name and IP address of a name server, separated by "/".|
+| nsnames  | List of domain names  | The names of a list of nameservers, separated by ";".         |
+| nsips    | List of IP addresses  | The addresses of a list of nameservers, separated by ";".     |
+| nss      | List of domain name and IP address pairs | The names and addresses of a list of nameservers, the name and address of a nameserver are separated by "/", nameservers are separated by ";".|
 || AS number| An Autonomous Space number for an IP address.|
 || Address record type (A or AAAA)| Used to tell the difference between IPv4 and IPv6.|
 || Count of different SOA RNAMEs.| Total number of different SOA RNAME fields seen.|
@@ -19,12 +25,12 @@
 || DNSSEC delegation verification failure reason| A somewhat human-readable reason why the delegation step between the tested zone and its parent is not secure.|
 || DS digest type| The digest type used in a DS record.|
 || DS/DNSKEY/RRSIG keytag| A keytag for a DS, DNSKEY or RRSIG record.|
-| dname | Domain name| A domain name.|
-| dlabel | Domain name label| A single label from a domain name.|
-| dlength | Domain name label length| The length of a domain name label.|
+| dname (?) | Domain name| A domain name.|
+| dlabel (?) | Domain name label| A single label from a domain name.|
+| dlength (?) | Domain name label length| The length of a domain name label.|
 || Duration in seconds| An integer number of seconds.|
-| fqdn | FQDN| A fully qualified domain name (with terminating dot).|
-| fqdnlength | FQDN length| The length of an FQDN.|
+| fqdn (?) | FQDN| A fully qualified domain name (with terminating dot).|
+| fqdnlength (?) | FQDN length| The length of an FQDN.|
 || IP address| An IPv4 or IPv6 address.|
 || IP address or nothing| An IPv4 or IPv6 address, or no value.|
 || IP range| An IP range.|
@@ -40,23 +46,18 @@
 || List of SOA RNAMEs| A list of RNAME values from SOA records.|
 || List of SOA serial numbers| A list of serial number values from SOA records.|
 || List of domain names| A list of domain names.|
-|| List of nameserver name/IP pairs.| A list of nameservers, specified as name/address pairs.|
-| nsnlist | List of nameserver names| A list of nameserver names.|
 || NS names from child| A list of nameserver names taken from a zone's child servers.|
 || NS names from parent| A list of nameserver names taken from a zone's parent servers.|
 || NSEC3 iteration count| An iteration count from an NSEC3PARAM record.|
-| nsip | Nameserver IP| The IP address of a name server.|
-| nsname | Nameserver name| The domain name of a name server.|
-| ns | Nameserver name/IP pair| The name and IP address of a name server, separated by a "/" character.|
 || Number of DNSKEY RRs in packet| The number of DNSKEY records found in a packet.|
 || Number of RRSIG RRs in packet| The number of RRSIG records found in a packet.|
 || Number of SOA RRs in packet| The number of SOA records found in a packet.|
 || PTR query name| The domain name generated from an IP address for a reverse name lookup.|
-| pname | Parent zone name| The name of a tested zone's parent zone.|
+| pname (?) | Parent zone name| The name of a tested zone's parent zone.|
 || Protocol (UDP or TCP)| The protocol used for a query.|
-| rcode | RCODE| An RCODE from a DNS packet.|
+| rcode (?) | RCODE| An RCODE from a DNS packet.|
 || RFC reference| A reference to an RFC.|
-| rrtype | RR type| The type of RR the message pertains to.|
+| rrtype (?) | RR type| The type of RR the message pertains to.|
 || RRSIG Expiration date| The time when a signature expires.|
 || RRSIG validation error message| The human-readable reason why the cryptographic validation of a signature failed.|
 || SOA MNAME| The MNAME value from a SOA record.|
@@ -74,7 +75,11 @@
 || Smallest SOA serial number seen| The smallest value seen in a SOA serial field in the tested zone.|
 || TLD| The name of a top-level domain.|
 || `time_t` value when RRSIG validation was attempted| The time when an RRSIG validation was attempted, in Unix `time_t` format.|
-| zname | Zone name| The domain name of the zone being tested.|
+| zname (?) | Zone name| The domain name of the zone being tested.|
+
+Message names maked with a question mark should not be considered stable.
+
+
 ## List by test module
 
 ### Basic

--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -8,7 +8,7 @@
 | ns_ip       | IP address           | The IP address of a name server.                            |
 | ns          | Domain name and IP address pair | The name and IP address of a name server, separated by "/". |
 | nsname_list | List of domain names | A list of name servers, as specified by "nsname", separated by ";". |
-| ns_ip_list  | List of IP addresses | A list of name servers, as specified by "nsip", separated by ";". |
+| ns_ip_list  | List of IP addresses | A list of name servers, as specified by "ns_ip", separated by ";". |
 | ns_list     | List of domain name and IP address pairs | A list of name servers, as specified by "ns", separated by ";". |
 || AS number| An Autonomous Space number for an IP address.|
 || Address record type (A or AAAA)| Used to tell the difference between IPv4 and IPv6.|

--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -77,15 +77,15 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     NAMESERVER_IP_WITHOUT_REVERSE => sub {
         __x    # ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
-          'Nameserver {nsname} has an IP address ({nsip}) without PTR configured.', @_;
+          'Nameserver {nsname} has an IP address ({ns_ip}) without PTR configured.', @_;
     },
     NAMESERVER_IP_PTR_MISMATCH => sub {
         __x    # ADDRESS:NAMESERVER_IP_PTR_MISMATCH
-          'Nameserver {nsname} has an IP address ({nsip}) with mismatched PTR result ({names}).', @_;
+          'Nameserver {nsname} has an IP address ({ns_ip}) with mismatched PTR result ({names}).', @_;
     },
     NAMESERVER_IP_PRIVATE_NETWORK => sub {
         __x    # ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
-          'Nameserver {nsname} has an IP address ({nsip}) '
+          'Nameserver {nsname} has an IP address ({ns_ip}) '
           . 'with prefix {prefix} referenced in {reference} as a \'{name}\'.',
           @_;
     },
@@ -161,7 +161,7 @@ sub address01 {
               info(
                 NAMESERVER_IP_PRIVATE_NETWORK => {
                     nsname    => $local_ns->name->string,
-                    nsip      => $local_ns->address->short,
+                    ns_ip     => $local_ns->address->short,
                     prefix    => ${$ip_details_ref}{ip}->print,
                     name      => ${$ip_details_ref}{name},
                     reference => ${$ip_details_ref}{reference},
@@ -212,7 +212,7 @@ sub address02 {
                   info(
                     NAMESERVER_IP_WITHOUT_REVERSE => {
                         nsname => $local_ns->name->string,
-                        nsip   => $local_ns->address->short,
+                        ns_ip  => $local_ns->address->short,
                     }
                   );
             }
@@ -269,7 +269,7 @@ sub address03 {
                       info(
                         NAMESERVER_IP_PTR_MISMATCH => {
                             nsname => $local_ns->name->string,
-                            nsip   => $local_ns->address->short,
+                            ns_ip  => $local_ns->address->short,
                             names  => join( q{/}, map { $_->ptrdname } @ptr ),
                         }
                       );
@@ -280,7 +280,7 @@ sub address03 {
                   info(
                     NAMESERVER_IP_WITHOUT_REVERSE => {
                         nsname => $local_ns->name->string,
-                        nsip   => $local_ns->address->short,
+                        ns_ip  => $local_ns->address->short,
                     }
                   );
             }

--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -77,15 +77,15 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     NAMESERVER_IP_WITHOUT_REVERSE => sub {
         __x    # ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
-          'Nameserver {ns} has an IP address ({address}) without PTR configured.', @_;
+          'Nameserver {nsname} has an IP address ({nsip}) without PTR configured.', @_;
     },
     NAMESERVER_IP_PTR_MISMATCH => sub {
         __x    # ADDRESS:NAMESERVER_IP_PTR_MISMATCH
-          'Nameserver {ns} has an IP address ({address}) with mismatched PTR result ({names}).', @_;
+          'Nameserver {nsname} has an IP address ({nsip}) with mismatched PTR result ({names}).', @_;
     },
     NAMESERVER_IP_PRIVATE_NETWORK => sub {
         __x    # ADDRESS:NAMESERVER_IP_PRIVATE_NETWORK
-          'Nameserver {ns} has an IP address ({address}) '
+          'Nameserver {nsname} has an IP address ({nsip}) '
           . 'with prefix {prefix} referenced in {reference} as a \'{name}\'.',
           @_;
     },
@@ -160,8 +160,8 @@ sub address01 {
             push @results,
               info(
                 NAMESERVER_IP_PRIVATE_NETWORK => {
-                    ns        => $local_ns->name->string,
-                    address   => $local_ns->address->short,
+                    nsname    => $local_ns->name->string,
+                    nsip      => $local_ns->address->short,
                     prefix    => ${$ip_details_ref}{ip}->print,
                     name      => ${$ip_details_ref}{name},
                     reference => ${$ip_details_ref}{reference},
@@ -211,8 +211,8 @@ sub address02 {
                 push @results,
                   info(
                     NAMESERVER_IP_WITHOUT_REVERSE => {
-                        ns      => $local_ns->name->string,
-                        address => $local_ns->address->short,
+                        nsname => $local_ns->name->string,
+                        nsip   => $local_ns->address->short,
                     }
                   );
             }
@@ -268,9 +268,9 @@ sub address03 {
                     push @results,
                       info(
                         NAMESERVER_IP_PTR_MISMATCH => {
-                            ns      => $local_ns->name->string,
-                            address => $local_ns->address->short,
-                            names   => join( q{/}, map { $_->ptrdname } @ptr ),
+                            nsname => $local_ns->name->string,
+                            nsip   => $local_ns->address->short,
+                            names  => join( q{/}, map { $_->ptrdname } @ptr ),
                         }
                       );
                 }
@@ -279,8 +279,8 @@ sub address03 {
                 push @results,
                   info(
                     NAMESERVER_IP_WITHOUT_REVERSE => {
-                        ns      => $local_ns->name->string,
-                        address => $local_ns->address->short,
+                        nsname => $local_ns->name->string,
+                        nsip   => $local_ns->address->short,
                     }
                   );
             }

--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -150,15 +150,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     HAS_A_RECORDS => sub {
         __x    # BASIC:HAS_A_RECORDS
-          "Nameserver {ns}/{address} returned \"A\" record(s) for {dname}.", @_;
+          "Nameserver {ns} returned \"A\" record(s) for {dname}.", @_;
     },
     NO_A_RECORDS => sub {
         __x    # BASIC:NO_A_RECORDS
-          "Nameserver {ns}/{address} did not return \"A\" record(s) for {dname}.", @_;
+          "Nameserver {ns} did not return \"A\" record(s) for {dname}.", @_;
     },
     HAS_NAMESERVERS => sub {
         __x    # BASIC:HAS_NAMESERVERS
-          'Nameserver {ns}/{address} listed these servers as glue: {nsnlist}.', @_;
+          'Nameserver {ns} listed these servers as glue: {nsnlist}.', @_;
     },
     NO_GLUE_PREVENTS_NAMESERVER_TESTS => sub {
         __x    # BASIC:NO_GLUE_PREVENTS_NAMESERVER_TESTS
@@ -166,11 +166,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NS_FAILED => sub {
         __x    # BASIC:NS_FAILED
-          'Nameserver {ns}/{address} did not return NS records. RCODE was {rcode}.', @_;
+          'Nameserver {ns} did not return NS records. RCODE was {rcode}.', @_;
     },
     NS_NO_RESPONSE => sub {
         __x    # BASIC:NS_NO_RESPONSE
-          'Nameserver {ns}/{address} did not respond to NS query.', @_;
+          'Nameserver {ns} did not respond to NS query.', @_;
     },
     A_QUERY_NO_RESPONSES => sub {
         __x    # BASIC:A_QUERY_NO_RESPONSES
@@ -182,19 +182,19 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     IPV4_DISABLED => sub {
         __x    # BASIC:IPV4_DISABLED
-          'IPv4 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV4_ENABLED => sub {
         __x    # BASIC:IPV4_ENABLED
-          'IPv4 is enabled, can send "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is enabled, can send "{rrtype}" query to {ns}.', @_;
     },
     IPV6_DISABLED => sub {
         __x    # BASIC:IPV6_DISABLED
-          'IPv6 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV6_ENABLED => sub {
         __x    # BASIC:IPV6_ENABLED
-          'IPv6 is enabled, can send "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is enabled, can send "{rrtype}" query to {ns}.', @_;
     },
     TEST_CASE_END => sub {
         __x    # BASIC:TEST_CASE_END
@@ -305,9 +305,8 @@ sub basic02 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -316,9 +315,8 @@ sub basic02 {
             push @results,
               info(
                 IPV4_ENABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
         }
@@ -327,9 +325,8 @@ sub basic02 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -338,9 +335,8 @@ sub basic02 {
             push @results,
               info(
                 IPV6_ENABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
         }
@@ -354,8 +350,7 @@ sub basic02 {
                     HAS_NAMESERVERS => {
                         nsnlist =>
                           join( q{,}, sort map { $_->nsdname } $p->get_records_for_name( $query_type, $zone->name ) ),
-                        ns      => $ns->name->string,
-                        address => $ns->address->short,
+                        ns => $ns->string,
                     }
                   );
             }
@@ -363,21 +358,14 @@ sub basic02 {
                 push @results,
                   info(
                     NS_FAILED => {
-                        ns      => $ns->name->string,
-                        address => $ns->address->short,
-                        rcode   => $p->rcode,
+                        ns    => $ns->string,
+                        rcode => $p->rcode,
                     }
                   );
             }
         } ## end if ( $p )
         else {
-            push @results,
-              info(
-                NS_NO_RESPONSE => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                }
-              );
+            push @results, info( NS_NO_RESPONSE => { ns => $ns->string } );
         }
     } ## end foreach my $ns ( @{ Zonemaster::Engine::TestMethods...})
 
@@ -396,9 +384,8 @@ sub basic03 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -407,9 +394,8 @@ sub basic03 {
             push @results,
               info(
                 IPV4_ENABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
         }
@@ -418,9 +404,8 @@ sub basic03 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -429,9 +414,8 @@ sub basic03 {
             push @results,
               info(
                 IPV6_ENABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $ns->string,
+                    rrtype => $query_type,
                 }
               );
         }
@@ -443,9 +427,8 @@ sub basic03 {
             push @results,
               info(
                 HAS_A_RECORDS => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    dname   => $name,
+                    ns    => $ns->string,
+                    dname => $name,
                 }
               );
         }
@@ -453,9 +436,8 @@ sub basic03 {
             push @results,
               info(
                 NO_A_RECORDS => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    dname   => $name,
+                    ns    => $ns->string,
+                    dname => $name,
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -164,15 +164,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ASN_INFOS_RAW => sub {
         __x    # CONNECTIVITY:ASN_INFOS_RAW
-          '[ASN:RAW] {nsip};{data}.', @_;
+          '[ASN:RAW] {ns_ip};{data}.', @_;
     },
     ASN_INFOS_ANNOUNCE_BY => sub {
         __x    # CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
-          '[ASN:ANNOUNCE_BY] {nsip};{asn}.', @_;
+          '[ASN:ANNOUNCE_BY] {ns_ip};{asn}.', @_;
     },
     ASN_INFOS_ANNOUNCE_IN => sub {
         __x    # CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
-          '[ASN:ANNOUNCE_IN] {nsip};{prefix}.', @_;
+          '[ASN:ANNOUNCE_IN] {ns_ip};{prefix}.', @_;
     },
     TEST_CASE_END => sub {
         __x    # CONNECTIVITY:TEST_CASE_END
@@ -320,8 +320,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_RAW => {
-                    nsip => $v4ip->short,
-                    data => $raw,
+                    ns_ip => $v4ip->short,
+                    data  => $raw,
                 }
               );
         }
@@ -329,8 +329,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_BY => {
-                    nsip => $v4ip->short,
-                    asn  => join( q{,}, @{$asnref} ),
+                    ns_ip => $v4ip->short,
+                    asn   => join( q{,}, @{$asnref} ),
                 }
               );
             push @v4asns, @{$asnref};
@@ -339,7 +339,7 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_IN => {
-                    nsip   => $v4ip->short,
+                    ns_ip  => $v4ip->short,
                     prefix => sprintf "%s/%d",
                     $prefix->ip, $prefix->prefixlen,
                 }
@@ -352,8 +352,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_RAW => {
-                    nsip => $v6ip->short,
-                    data => $raw,
+                    ns_ip => $v6ip->short,
+                    data  => $raw,
                 }
               );
         }
@@ -361,8 +361,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_BY => {
-                    nsip => $v6ip->short,
-                    asn  => join( q{,}, @{$asnref} ),
+                    ns_ip => $v6ip->short,
+                    asn   => join( q{,}, @{$asnref} ),
                 }
               );
             push @v6asns, @{$asnref};
@@ -371,7 +371,7 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_IN => {
-                    nsip   => $v6ip->short,
+                    ns_ip  => $v6ip->short,
                     prefix => sprintf "%s/%d",
                     $prefix->short, $prefix->prefixlen,
                 }

--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -132,27 +132,27 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NAMESERVER_HAS_TCP_53 => sub {
         __x    # CONNECTIVITY:NAMESERVER_HAS_TCP_53
-          'Nameserver {ns}/{address} accessible over TCP on port 53.', @_;
+          'Nameserver {ns} accessible over TCP on port 53.', @_;
     },
     NAMESERVER_HAS_UDP_53 => sub {
         __x    # CONNECTIVITY:NAMESERVER_HAS_UDP_53
-          'Nameserver {ns}/{address} accessible over UDP on port 53.', @_;
+          'Nameserver {ns} accessible over UDP on port 53.', @_;
     },
     NAMESERVER_NO_TCP_53 => sub {
         __x    # CONNECTIVITY:NAMESERVER_NO_TCP_53
-          'Nameserver {ns}/{address} not accessible over TCP on port 53.', @_;
+          'Nameserver {ns} not accessible over TCP on port 53.', @_;
     },
     NAMESERVER_NO_UDP_53 => sub {
         __x    # CONNECTIVITY:NAMESERVER_NO_UDP_53
-          'Nameserver {ns}/{address} not accessible over UDP on port 53.', @_;
+          'Nameserver {ns} not accessible over UDP on port 53.', @_;
     },
     IPV4_DISABLED => sub {
         __x    # CONNECTIVITY:IPV4_DISABLED
-          'IPv4 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV6_DISABLED => sub {
         __x    # CONNECTIVITY:IPV6_DISABLED
-          'IPv6 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV4_ASN => sub {
         __x    # CONNECTIVITY:IPV4_ASN
@@ -164,15 +164,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ASN_INFOS_RAW => sub {
         __x    # CONNECTIVITY:ASN_INFOS_RAW
-          '[ASN:RAW] {address};{data}.', @_;
+          '[ASN:RAW] {nsip};{data}.', @_;
     },
     ASN_INFOS_ANNOUNCE_BY => sub {
         __x    # CONNECTIVITY:ASN_INFOS_ANNOUNCE_BY
-          '[ASN:ANNOUNCE_BY] {address};{asn}.', @_;
+          '[ASN:ANNOUNCE_BY] {nsip};{asn}.', @_;
     },
     ASN_INFOS_ANNOUNCE_IN => sub {
         __x    # CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
-          '[ASN:ANNOUNCE_IN] {address};{prefix}.', @_;
+          '[ASN:ANNOUNCE_IN] {nsip};{prefix}.', @_;
     },
     TEST_CASE_END => sub {
         __x    # CONNECTIVITY:TEST_CASE_END
@@ -211,9 +211,8 @@ sub connectivity01 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -223,9 +222,8 @@ sub connectivity01 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -236,22 +234,10 @@ sub connectivity01 {
         my $p = $local_ns->query( $zone->name, $query_type, { usevc => 0 } );
 
         if ( $p ) {
-            push @results,
-              info(
-                NAMESERVER_HAS_UDP_53 => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NAMESERVER_HAS_UDP_53 => { ns => $local_ns->string } );
         }
         else {
-            push @results,
-              info(
-                NAMESERVER_NO_UDP_53 => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NAMESERVER_NO_UDP_53 => { ns => $local_ns->string } );
         }
 
         $ips{ $local_ns->address->short }++;
@@ -275,9 +261,8 @@ sub connectivity02 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -287,9 +272,8 @@ sub connectivity02 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -300,22 +284,10 @@ sub connectivity02 {
         my $p = $local_ns->query( $zone->name, $query_type, { usevc => 1 } );
 
         if ( $p ) {
-            push @results,
-              info(
-                NAMESERVER_HAS_TCP_53 => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NAMESERVER_HAS_TCP_53 => { ns => $local_ns->string } );
         }
         else {
-            push @results,
-              info(
-                NAMESERVER_NO_TCP_53 => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NAMESERVER_NO_TCP_53 => { ns => $local_ns->string } );
         }
 
         $ips{ $local_ns->address->short }++;
@@ -348,8 +320,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_RAW => {
-                    address => $v4ip->short,
-                    data    => $raw,
+                    nsip => $v4ip->short,
+                    data => $raw,
                 }
               );
         }
@@ -357,8 +329,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_BY => {
-                    address => $v4ip->short,
-                    asn     => join( q{,}, @{$asnref} ),
+                    nsip => $v4ip->short,
+                    asn  => join( q{,}, @{$asnref} ),
                 }
               );
             push @v4asns, @{$asnref};
@@ -367,8 +339,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_IN => {
-                    address => $v4ip->short,
-                    prefix  => sprintf "%s/%d",
+                    nsip   => $v4ip->short,
+                    prefix => sprintf "%s/%d",
                     $prefix->ip, $prefix->prefixlen,
                 }
               );
@@ -380,8 +352,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_RAW => {
-                    address => $v6ip->short,
-                    data    => $raw,
+                    nsip => $v6ip->short,
+                    data => $raw,
                 }
               );
         }
@@ -389,8 +361,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_BY => {
-                    address => $v6ip->short,
-                    asn     => join( q{,}, @{$asnref} ),
+                    nsip => $v6ip->short,
+                    asn  => join( q{,}, @{$asnref} ),
                 }
               );
             push @v6asns, @{$asnref};
@@ -399,8 +371,8 @@ sub connectivity03 {
             push @results,
               info(
                 ASN_INFOS_ANNOUNCE_IN => {
-                    address => $v6ip->short,
-                    prefix  => sprintf "%s/%d",
+                    nsip   => $v6ip->short,
+                    prefix => sprintf "%s/%d",
                     $prefix->short, $prefix->prefixlen,
                 }
               );

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -142,7 +142,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CHILD_NS_FAILED => sub {
         __x    # CONSISTENCY:CHILD_NS_FAILED
-          'Unexpected or erroneous reply from {ns}/{address}.', @_;
+          'Unexpected or erroneous reply from {ns}.', @_;
     },
     CHILD_ZONE_LAME => sub {
         __x    # CONSISTENCY:CHILD_ZONE_LAME
@@ -164,11 +164,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     IPV4_DISABLED => sub {
         __x    # CONSISTENCY:IPV4_DISABLED
-          'IPv4 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV6_DISABLED => sub {
         __x    # CONSISTENCY:IPV6_DISABLED
-          'IPv6 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     MULTIPLE_NS_SET => sub {
         __x    # CONSISTENCY:MULTIPLE_NS_SET
@@ -192,15 +192,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE => sub {
         __x    # CONSISTENCY:NO_RESPONSE
-          'Nameserver {ns}/{address} did not respond.', @_;
+          'Nameserver {ns} did not respond.', @_;
     },
     NO_RESPONSE_NS_QUERY => sub {
         __x    # CONSISTENCY:NO_RESPONSE_NS_QUERY
-          'No response from nameserver {ns}/{address} on NS queries.', @_;
+          'No response from nameserver {ns} on NS queries.', @_;
     },
     NO_RESPONSE_SOA_QUERY => sub {
         __x    # CONSISTENCY:NO_RESPONSE_SOA_QUERY
-          'No response from nameserver {ns}/{address} on SOA queries.', @_;
+          'No response from nameserver {ns} on SOA queries.', @_;
     },
     NS_SET => sub {
         __x    # CONSISTENCY:NS_SET
@@ -295,9 +295,8 @@ sub consistency01 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -307,9 +306,8 @@ sub consistency01 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -318,26 +316,14 @@ sub consistency01 {
         my $p = $local_ns->query( $zone->name, $query_type );
 
         if ( not $p ) {
-            push @results,
-              info(
-                NO_RESPONSE => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE => { ns => $local_ns->string } );
             next;
         }
 
         my ( $soa ) = $p->get_records_for_name( $query_type, $zone->name );
 
         if ( not $soa ) {
-            push @results,
-              info(
-                NO_RESPONSE_SOA_QUERY => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE_SOA_QUERY => { ns => $local_ns->string } );
             next;
         }
         else {
@@ -405,9 +391,8 @@ sub consistency02 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -417,9 +402,8 @@ sub consistency02 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -428,26 +412,14 @@ sub consistency02 {
         my $p = $local_ns->query( $zone->name, $query_type );
 
         if ( not $p ) {
-            push @results,
-              info(
-                NO_RESPONSE => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE => { ns => $local_ns->string } );
             next;
         }
 
         my ( $soa ) = $p->get_records_for_name( $query_type, $zone->name );
 
         if ( not $soa ) {
-            push @results,
-              info(
-                NO_RESPONSE_SOA_QUERY => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE_SOA_QUERY => { ns => $local_ns->string } );
             next;
         }
         else {
@@ -502,9 +474,8 @@ sub consistency03 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -514,9 +485,8 @@ sub consistency03 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -525,26 +495,14 @@ sub consistency03 {
         my $p = $local_ns->query( $zone->name, $query_type );
 
         if ( not $p ) {
-            push @results,
-              info(
-                NO_RESPONSE => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE => { ns => $local_ns->string } );
             next;
         }
 
         my ( $soa ) = $p->get_records_for_name( $query_type, $zone->name );
 
         if ( not $soa ) {
-            push @results,
-              info(
-                NO_RESPONSE_SOA_QUERY => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE_SOA_QUERY => { ns => $local_ns->string } );
             next;
         }
         else {
@@ -610,9 +568,8 @@ sub consistency04 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -622,9 +579,8 @@ sub consistency04 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -633,26 +589,14 @@ sub consistency04 {
         my $p = $local_ns->query( $zone->name, $query_type );
 
         if ( not $p ) {
-            push @results,
-              info(
-                NO_RESPONSE => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE => { ns => $local_ns->string } );
             next;
         }
 
         my ( @ns ) = sort map { lc( $_->nsdname ) } $p->get_records_for_name( $query_type, $zone->name );
 
         if ( not scalar( @ns ) ) {
-            push @results,
-              info(
-                NO_RESPONSE_NS_QUERY => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE_NS_QUERY => { ns => $local_ns->string } );
             next;
         }
         else {
@@ -694,12 +638,7 @@ sub _get_addr_rrs {
     my ( $class, $ns, $name, $qtype ) = @_;
     my $p = $ns->query( $name, $qtype, { recurse => 0 } );
     if ( !$p ) {
-        return info(
-            NO_RESPONSE => {
-                ns      => $ns->name->string,
-                address => $ns->address->short,
-            }
-        );
+        return info( NO_RESPONSE => { ns => $ns->string } );
     }
     elsif ($p->is_redirect) {
         my $p = Zonemaster::Engine->recurse( $name, $qtype, q{IN} );
@@ -713,12 +652,7 @@ sub _get_addr_rrs {
         return ( undef, $p->get_records_for_name( $qtype, $name, 'answer' ) );
     }
     elsif (not ($p->aa and $p->rcode eq 'NXDOMAIN')) {
-        return info(
-            CHILD_NS_FAILED => {
-                ns      => $ns->name->string,
-                address => $ns->address->short,
-            }
-        );
+        return info( CHILD_NS_FAILED => { ns => $ns->string } );
     }
     return ( undef );
 }
@@ -883,9 +817,8 @@ sub consistency06 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -895,9 +828,8 @@ sub consistency06 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -906,26 +838,14 @@ sub consistency06 {
         my $p = $local_ns->query( $zone->name, $query_type );
 
         if ( not $p ) {
-            push @results,
-              info(
-                NO_RESPONSE => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE => { ns => $local_ns->string } );
             next;
         }
 
         my ( $soa ) = $p->get_records_for_name( $query_type, $zone->name );
 
         if ( not $soa ) {
-            push @results,
-              info(
-                NO_RESPONSE_SOA_QUERY => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE_SOA_QUERY => { ns => $local_ns->string } );
             next;
         }
         else {

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -497,7 +497,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ALGO_NOT_SIGNED_RRSET => sub {
         __x    # DNSSEC:ALGO_NOT_SIGNED_RRSET
-          'Nameserver {ns}/{address} responded with no RRSIG for RRset {rrtype} created by the '
+          'Nameserver {ns} responded with no RRSIG for RRset {rrtype} created by the '
           . 'algorithm {algorithm}.',
           @_;
     },
@@ -514,13 +514,13 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     BROKEN_DS => sub {
         __x    # DNSSEC:BROKEN_DS
-          'DNSKEY record with tag {keytag} returned by nameserver {ns}/{address} does not match '
+          'DNSKEY record with tag {keytag} returned by nameserver {ns} does not match '
           . 'the algorithm and hash values in a DS record with same tag in parent zone.',
           @_;
     },
     BROKEN_RRSIG => sub {
         __x    # DNSSEC:BROKEN_RRSIG
-          'The RRSIG of the DNSKEY RRset created by tag {keytag} returned by nameserver {ns}/{address} '
+          'The RRSIG of the DNSKEY RRset created by tag {keytag} returned by nameserver {ns} '
           . 'failed to be verified with error \'{error}\' (a DS record with same tag is present in the '
           . 'parent zone).',
           @_;
@@ -543,13 +543,13 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DNSKEY_KSK_NOT_SEP => sub {
         __x    # DNSSEC:DNSKEY_KSK_NOT_SEP
-          'Flags field of DNSKEY record with tag {keytag} returned by nameserver {ns}/{address} '
+          'Flags field of DNSKEY record with tag {keytag} returned by nameserver {ns} '
           . 'has not SEP bit set although DS with same tag is present in parent.',
           @_;
     },
     DNSKEY_NOT_ZONE_SIGN => sub {
         __x    # DNSSEC:DNSKEY_NOT_ZONE_SIGN
-          'Flags field of DNSKEY record with tag {keytag} returned by nameserver {ns}/{address} '
+          'Flags field of DNSKEY record with tag {keytag} returned by nameserver {ns} '
           . 'has not ZONE bit set although DS with same tag is present in parent.',
           @_;
     },
@@ -589,41 +589,41 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DS_ALGORITHM_NOT_DS => sub {
         __x    # DNSSEC:DS_ALGORITHM_NOT_DS
-          '{ns}/{address} returned a DS record created by algorithm {algorithm_number} '
+          '{ns} returned a DS record created by algorithm {algorithm_number} '
           . '({algorithm_mnemonic}) which is not meant for DS. The DS record is for the DNSKEY '
           . 'record with keytag {keytag} in zone {zone}.',
           @_;
     },
     DS_ALGORITHM_DEPRECATED => sub {
         __x    # DNSSEC:DS_ALGORITHM_DEPRECATED
-          '{ns}/{address} returned a DS record created by algorithm {algorithm_number} '
+          '{ns} returned a DS record created by algorithm {algorithm_number} '
           . '({algorithm_mnemonic}), which is deprecated. The DS record is for the DNSKEY '
           . 'record with keytag {keytag} in zone {zone}.',
           @_;
     },
     DS_ALGORITHM_MISSING => sub {
         __x    # DNSSEC:DS_ALGORITHM_MISSING
-          '{ns}/{address} returned no DS record created by algorithm {algorithm_number} '
+          '{ns} returned no DS record created by algorithm {algorithm_number} '
           . '({algorithm_mnemonic}) for zone {zone}, which is required.',
           @_;
     },
     DS_ALGORITHM_OK => sub {
         __x    # DNSSEC:DS_ALGORITHM_OK
-          '{ns}/{address} returned a DS record created by algorithm {algorithm_number} '
+          '{ns} returned a DS record created by algorithm {algorithm_number} '
           . '({algorithm_mnemonic}), which is OK. The DS record is for the DNSKEY record with '
           . 'keytag {keytag} in zone {zone}.',
           @_;
     },
     DS_ALGORITHM_RESERVED => sub {
         __x    # DNSSEC:DS_ALGORITHM_RESERVED
-          '{ns}/{address} returned a DS record created by with an algorithm not assigned (algorithm number '
+          '{ns} returned a DS record created by with an algorithm not assigned (algorithm number '
           . '{algorithm_number}), which is not OK. The DS record is for the DNSKEY record with keytag {keytag} '
           . 'in zone {zone}.',
           @_;
     },
     DS_ALGO_SHA1_DEPRECATED => sub {
         __x    # DNSSEC:DS_ALGO_SHA1_DEPRECATED
-          'Nameserver {ns}/{address} returned a DS record created by algorithm {algorithm_number} '
+          'Nameserver {ns} returned a DS record created by algorithm {algorithm_number} '
           . '({algorithm_mnemonic}) which is deprecated, while it is still widely used. The DS record is '
           . 'for the DNSKEY record with keytag {keytag} in zone {zone}.',
           @_;
@@ -682,11 +682,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     IPV4_DISABLED => sub {
         __x    # DNSSEC:IPV4_DISABLED
-          'IPv4 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV6_DISABLED => sub {
         __x    # DNSSEC:IPV6_DISABLED
-          'IPv6 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     ITERATIONS_OK => sub {
         __x    # DNSSEC:ITERATIONS_OK
@@ -706,7 +706,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MIXED_NSEC_NSEC3 => sub {
         __x    # DNSSEC:MIXED_NSEC_NSEC3
-          'Nameserver {ns}/{address} for zone {zone} responds with both NSEC and NSEC3 '
+          'Nameserver {ns} for zone {zone} responds with both NSEC and NSEC3 '
           . 'records when only one record type is expected.',
           @_;
     },
@@ -731,13 +731,13 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_MATCHING_DNSKEY => sub {
         __x    # DNSSEC:NO_MATCHING_DNSKEY
-          'Nameserver {ns}/{address} returned no DNSKEY record matching the DS record with tag {keytag} '
+          'Nameserver {ns} returned no DNSKEY record matching the DS record with tag {keytag} '
           . 'found in the parent zone.',
           @_;
     },
     NO_MATCHING_RRSIG => sub {
         __x    # DNSSEC:NO_MATCHING_RRSIG
-          'Nameserver {ns}/{address} returned no signature on the DNSKEY RRset that corresponds to the '
+          'Nameserver {ns} returned no signature on the DNSKEY RRset that corresponds to the '
           . 'DNSKEY with tag {keytag} even though there is a DS record in the parent zone for that '
           . 'DNSKEY record.',
           @_;
@@ -748,29 +748,29 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_NSEC_NSEC3 => sub {
         __x    # DNSSEC:NO_NSEC_NSEC3
-          'Nameserver {ns}/{address} for zone {zone} responds with neither NSEC nor NSEC3 record when '
+          'Nameserver {ns} for zone {zone} responds with neither NSEC nor NSEC3 record when '
           . 'when such records are expected.',
           @_;
     },
     NO_RESPONSE_DNSKEY => sub {
         __x    # DNSSEC:NO_RESPONSE_DNSKEY
-          'Nameserver {ns}/{address} responded with no DNSKEY record(s).', @_;
+          'Nameserver {ns} responded with no DNSKEY record(s).', @_;
     },
     NO_RESPONSE_DS => sub {
         __x    # DNSSEC:NO_RESPONSE_DS
-          '{ns}/{address} returned no DS records for {zone}.', @_;
+          '{ns} returned no DS records for {zone}.', @_;
     },
     NO_RESPONSE_RRSET => sub {
         __x    # DNSSEC:NO_RESPONSE_RRSET
-          'Nameserver {ns}/{address} responded with no {rrtype} record(s).', @_;
+          'Nameserver {ns} responded with no {rrtype} record(s).', @_;
     },
     NO_RESPONSE => sub {
         __x    # DNSSEC:NO_RESPONSE
-          'Nameserver {ns}/{address} did not respond.', @_;
+          'Nameserver {ns} did not respond.', @_;
     },
     NO_RRSIG_DNSKEY => sub {
         __x    # DNSSEC:NO_RRSIG_DNSKEY
-          'Nameserver {ns}/{address} responded with no RRSIG record(s) covering the DNSKEY RRset.', @_;
+          'Nameserver {ns} responded with no RRSIG record(s) covering the DNSKEY RRset.', @_;
     },
     NOT_SIGNED => sub {
         __x    # DNSSEC:NOT_SIGNED
@@ -818,11 +818,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     RRSET_NOT_SIGNED => sub {
         __x    # DNSSEC:RRSET_NOT_SIGNED
-          'Nameserver {ns}/{address} responded with no RRSIG for {rrtype} RRset.', @_;
+          'Nameserver {ns} responded with no RRSIG for {rrtype} RRset.', @_;
     },
     RRSIG_BROKEN => sub {
         __x    # DNSSEC:RRSIG_BROKEN
-          'Nameserver {ns}/{address} responded with an RRSIG which can not be verified with '
+          'Nameserver {ns} responded with an RRSIG which can not be verified with '
           . 'corresponding DNSKEY (with keytag {keytag}).',
           @_;
     },
@@ -834,7 +834,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     RRSIG_NOT_MATCH_DNSKEY => sub {
         __x    # DNSSEC:RRSIG_NOT_MATCH_DNSKEY
-          'Nameserver {ns}/{address} responded with an RRSIG with unknown keytag {keytag}.', @_;
+          'Nameserver {ns} responded with an RRSIG with unknown keytag {keytag}.', @_;
     },
     SOA_NOT_SIGNED => sub {
         __x    # DNSSEC:SOA_NOT_SIGNED
@@ -854,7 +854,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     TEST_ABORTED => sub {
         __x    # DNSSEC:TEST_ABORTED
-          'Nameserver {ns}/{address} for zone {zone} responds with RCODE "NOERROR" on a query that '
+          'Nameserver {ns} for zone {zone} responds with RCODE "NOERROR" on a query that '
           . 'is expected to give response with RCODE "NXDOMAIN". Test for NSEC and NSEC3 is aborted '
           . 'for this nameserver.',
           @_;
@@ -873,7 +873,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     UNEXPECTED_RESPONSE_DS => sub {
         __x    # DNSSEC:UNEXPECTED_RESPONSE_DS
-          'Nameserver {ns}/{address} responded with an unexpected rcode ({rcode}) on a DS query for zone {zone}.', @_;
+          'Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query for zone {zone}.', @_;
     },
 );
 
@@ -896,10 +896,9 @@ sub dnssec01 {
     if ( my $parent = $zone->parent ) {
         foreach my $ns ( @{ $parent->ns } ) {
             my $ns_args = {
-                ns      => $ns->name->string,
-                address => $ns->address->short,
-                zone    => q{} . $zone->name,
-                rrtype  => q{DS},
+                ns     => $ns->string,
+                zone   => q{} . $zone->name,
+                rrtype => q{DS},
             };
 
             if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
@@ -969,10 +968,9 @@ sub dnssec02 {
     if ( my $parent = $zone->parent ) {
         foreach my $ns ( @{ $parent->ns } ) {
             my $ns_args = {
-                ns      => $ns->name->string,
-                address => $ns->address->short,
-                zone    => q{} . $zone->name,
-                rrtype  => q{DS},
+                ns     => $ns->string,
+                zone   => q{} . $zone->name,
+                rrtype => q{DS},
             };
 
             if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
@@ -987,7 +985,7 @@ sub dnssec02 {
 
             my $ds_p = $ns->query( $zone->name, q{DS}, { usevc => 0, dnssec => 1 } );
             if ( not $ds_p ) {
-                push @results, info( NO_RESPONSE => $ns_args );
+                push @results, info( NO_RESPONSE => { ns => $ns->string } );
                 next;
             }
             elsif ($ds_p->rcode ne q{NOERROR} ) {
@@ -1012,10 +1010,9 @@ sub dnssec02 {
             for my $nss_key ( sort keys %nss ) {
                 my $ns = $nss{$nss_key};
                 my $ns_args = {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    zone    => q{} . $zone->name,
-                    rrtype  => q{DNSKEY},
+                    ns     => $ns->string,
+                    zone   => q{} . $zone->name,
+                    rrtype => q{DNSKEY},
                 };
 
                 if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
@@ -1030,12 +1027,12 @@ sub dnssec02 {
 
                 my $dnskey_p = $ns->query( $zone->name, q{DNSKEY}, { dnssec => 1, usevc => 0 } );
                 if ( not $dnskey_p ) {
-                    push @results, info( NO_RESPONSE => $ns_args );
+                    push @results, info( NO_RESPONSE => { ns => $ns->string } );
                     next;
                 }
                 my @keys = $dnskey_p->get_records( q{DNSKEY}, q{answer} );
                 if ( not @keys ) {
-                    push @results, info( NO_RESPONSE_DNSKEY => $ns_args );
+                    push @results, info( NO_RESPONSE_DNSKEY => { ns => $ns->string } );
                     next;
                 }
                 else {
@@ -1044,7 +1041,7 @@ sub dnssec02 {
 
                 my @key_sigs = $dnskey_p->get_records( q{RRSIG}, q{answer} );
                 if ( not scalar @key_sigs ) {
-                    push @results, info( NO_RRSIG_DNSKEY => $ns_args );
+                    push @results, info( NO_RRSIG_DNSKEY => { ns => $ns->string } );
                 }
                 else {
                     DS_LOOP: {
@@ -1054,8 +1051,7 @@ sub dnssec02 {
                                 push @results,
                                   info(
                                     NO_MATCHING_DNSKEY => {
-                                        ns      => $ns->name->string,
-                                        address => $ns->address->short,
+                                        ns      => $ns->string,
                                         keytag  => $ds->keytag,
                                     }
                                   );
@@ -1065,9 +1061,8 @@ sub dnssec02 {
                                     push @results,
                                       info(
                                         BROKEN_DS => {
-                                            ns      => $ns->name->string,
-                                            address => $ns->address->short,
-                                            keytag  => $ds->keytag,
+                                            ns     => $ns->string,
+                                            keytag => $ds->keytag,
                                         }
                                       );
                                 }
@@ -1075,9 +1070,8 @@ sub dnssec02 {
                                     push @results,
                                       info(
                                         DNSKEY_NOT_ZONE_SIGN => {
-                                            ns      => $ns->name->string,
-                                            address => $ns->address->short,
-                                            keytag  => $ds->keytag,
+                                            ns     => $ns->string,
+                                            keytag => $ds->keytag,
                                         }
                                       );
                                     next DS_LOOP;
@@ -1086,9 +1080,8 @@ sub dnssec02 {
                                     push @results,
                                       info(
                                         DNSKEY_KSK_NOT_SEP => {
-                                            ns      => $ns->name->string,
-                                            address => $ns->address->short,
-                                            keytag  => $ds->keytag,
+                                            ns     => $ns->string,
+                                            keytag => $ds->keytag,
                                         }
                                       );
                                 }
@@ -1098,8 +1091,7 @@ sub dnssec02 {
                                 push @results,
                                   info(
                                     NO_MATCHING_RRSIG => {
-                                        ns      => $ns->name->string,
-                                        address => $ns->address->short,
+                                        ns      => $ns->string,
                                         keytag  => $ds->keytag,
                                     }
                                   );
@@ -1111,8 +1103,7 @@ sub dnssec02 {
                                     push @results,
                                       info(
                                         BROKEN_RRSIG => {
-                                            ns      => $ns->name->string,
-                                            address => $ns->address->short,
+                                            ns      => $ns->string,
                                             keytag  => $ds->keytag,
                                             error   => $msg,
                                         }
@@ -1312,18 +1303,13 @@ sub dnssec05 {
 
     for my $key ( sort keys %nss ) {
         my $ns = $nss{$key};
-        my $ns_args = {
-            ns      => $ns->name->string,
-            address => $ns->address->short,
-        };
 
         if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => q{DNSKEY},
+                    ns     => $ns->string,
+                    rrtype => q{DNSKEY},
                 }
               );
             next;
@@ -1333,8 +1319,7 @@ sub dnssec05 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
+                    ns     => $ns->string,
                     rrtype => q{DNSKEY},
                 }
               );
@@ -1343,13 +1328,13 @@ sub dnssec05 {
 
         my $dnskey_p = $ns->query( $zone->name, 'DNSKEY', { dnssec => 1 } );
         if ( not $dnskey_p ) {
-            push @results, info( NO_RESPONSE => $ns_args );
+            push @results, info( NO_RESPONSE => { ns => $ns->string } );
             next;
         }
 
         my @keys = $dnskey_p->get_records( 'DNSKEY', 'answer' );
         if ( not @keys ) {
-            push @results, info( NO_RESPONSE_DNSKEY => $ns_args );
+            push @results, info( NO_RESPONSE_DNSKEY => { ns => $ns->string } );
             next;
         }
 
@@ -1646,46 +1631,66 @@ sub dnssec10 {
 
     for my $nss_key ( sort keys %nss ) {
         my $ns = $nss{$nss_key};
-        my $ns_args = {
-            ns      => $ns->name->string,
-            address => $ns->address->short,
-        };
 
         if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
-            $ns_args->{rrtype} = q{A};
-            push @results, info( IPV6_DISABLED => $ns_args );
+            push @results,
+              info(
+                IPV6_DISABLED => {
+                    ns     => $ns->string,
+                    rrtype => q{A},
+                }
+              );
             next;
         }
 
         if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == $IP_VERSION_4 ) {
-            $ns_args->{rrtype} = q{A};
-            push @results, info( IPV4_DISABLED => $ns_args );
+            push @results,
+              info(
+                IPV4_DISABLED => {
+                    ns     => $ns->string,
+                    rrtype => q{A},
+                }
+              );
             next;
         }
 
         my $a_p = $ns->query( $non_existent_domain_name , q{A}, { usevc => 0, dnssec => 1 } );
         if ( not $a_p ) {
-            push @results, info( NO_RESPONSE => $ns_args );
+            push @results, info( NO_RESPONSE => { ns => $ns->string } );
         }
         elsif ($a_p->rcode eq q{NOERROR} ) {
-            $ns_args->{zone} = $zone->name->string;
-            push @results, info( TEST_ABORTED => $ns_args );
+            push @results,
+              info(
+                TEST_ABORTED => {
+                    ns   => $ns->string,
+                    zone => $zone->name->string,
+                }
+              );
         }
         elsif ($a_p->rcode ne q{NXDOMAIN} ) {
-            $ns_args->{rcode} = $a_p->rcode;
-            push @results, info( INVALID_RCODE => $ns_args );
+            my $args = {
+                ns    => $ns->string,
+                rcode => $a_p->rcode,
+            };
+            push @results, info( INVALID_RCODE => $args );
         }
         else {
             my @nsec  = $a_p->get_records( q{NSEC}, q{authority} );
             my @nsec3 = $a_p->get_records( q{NSEC3}, q{authority} );
             if ( scalar @nsec and scalar @nsec3 ) {
-                $ns_args->{zone} = $zone->name->string;
-                push @results, info( MIXED_NSEC_NSEC3 => $ns_args );
+                my $args = {
+                    ns => $ns->string,
+                    zone => $zone->name->string,
+                };
+                push @results, info( MIXED_NSEC_NSEC3 => $args );
             }
             elsif ( not scalar @nsec and not scalar @nsec3 ) {
-                $ns_args->{zone} = $zone->name->string;
+                my $args = {
+                    ns => $ns->string,
+                    zone => $zone->name->string,
+                };
+                push @results, info( NO_NSEC_NSEC3 => $args );
                 $no_dnssec_zone{$ns->address->short}++;
-                push @results, info( NO_NSEC_NSEC3 => $ns_args );
             }
             elsif ( scalar @nsec and not scalar @nsec3 ) {
                 $nsec_zone{$ns->address->short}++;
@@ -1897,17 +1902,12 @@ sub dnssec13 {
 
     for my $nss_key ( sort keys %nss ) {
         my $ns = $nss{$nss_key};
-        my $ns_args = {
-            ns      => $ns->name->string,
-            address => $ns->address->short,
-        };
 
         if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
+                    ns     => $ns->string,
                     rrtype => q{DNSKEY},
                 }
               );
@@ -1918,8 +1918,7 @@ sub dnssec13 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
+                    ns     => $ns->string,
                     rrtype => q{DNSKEY},
                 }
               );
@@ -1930,13 +1929,16 @@ sub dnssec13 {
         my @algorithms;
         foreach my $query_type ( qw{DNSKEY SOA NS} ) {
 
-            $ns_args->{rrtype} = $query_type;
             my $p = $ns->query( $zone->name, $query_type, { dnssec => 1, usevc => 0 } );
             if ( not $p ) {
-                push @results, info( NO_RESPONSE => $ns_args );
+                push @results, info( NO_RESPONSE => { ns => $ns->string } );
                 next;
             }
 
+            my $ns_args = {
+                ns     => $ns->string,
+                rrtype => $query_type,
+            };
             my @rrs = $p->get_records( $query_type, q{answer} );
             if ( not scalar @rrs ) {
                 $all_algo_signed = 0;
@@ -2010,17 +2012,12 @@ sub dnssec14 {
 
     for my $nss_key ( sort keys %nss ) {
         my $ns = $nss{$nss_key};
-        my $ns_args = {
-            ns      => $ns->name->string,
-            address => $ns->address->short,
-        };
 
         if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
+                    ns     => $ns->string,
                     rrtype => q{DNSKEY},
                 }
               );
@@ -2031,8 +2028,7 @@ sub dnssec14 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
+                    ns     => $ns->string,
                     rrtype => q{DNSKEY},
                 }
               );
@@ -2041,13 +2037,13 @@ sub dnssec14 {
 
         my $dnskey_p = $ns->query( $zone->name, 'DNSKEY', { dnssec => 1, usevc => 0 } );
         if ( not $dnskey_p ) {
-            push @results, info( NO_RESPONSE => $ns_args );
+            push @results, info( NO_RESPONSE => { ns => $ns->string } );
             next;
         }
 
         my @keys = $dnskey_p->get_records( 'DNSKEY', 'answer' );
         if ( not @keys ) {
-            push @results, info( NO_RESPONSE_DNSKEY => $ns_args );
+            push @results, info( NO_RESPONSE_DNSKEY => { ns => $ns->string } );
             next;
         } else {
             push @dnskey_rrs, @keys;

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -1051,8 +1051,8 @@ sub dnssec02 {
                                 push @results,
                                   info(
                                     NO_MATCHING_DNSKEY => {
-                                        ns      => $ns->string,
-                                        keytag  => $ds->keytag,
+                                        ns     => $ns->string,
+                                        keytag => $ds->keytag,
                                     }
                                   );
                             }
@@ -1091,8 +1091,8 @@ sub dnssec02 {
                                 push @results,
                                   info(
                                     NO_MATCHING_RRSIG => {
-                                        ns      => $ns->string,
-                                        keytag  => $ds->keytag,
+                                        ns     => $ns->string,
+                                        keytag => $ds->keytag,
                                     }
                                   );
                             }
@@ -1103,9 +1103,9 @@ sub dnssec02 {
                                     push @results,
                                       info(
                                         BROKEN_RRSIG => {
-                                            ns      => $ns->string,
-                                            keytag  => $ds->keytag,
-                                            error   => $msg,
+                                            ns     => $ns->string,
+                                            keytag => $ds->keytag,
+                                            error  => $msg,
                                         }
                                       );
                                 }
@@ -1679,14 +1679,14 @@ sub dnssec10 {
             my @nsec3 = $a_p->get_records( q{NSEC3}, q{authority} );
             if ( scalar @nsec and scalar @nsec3 ) {
                 my $args = {
-                    ns => $ns->string,
+                    ns   => $ns->string,
                     zone => $zone->name->string,
                 };
                 push @results, info( MIXED_NSEC_NSEC3 => $args );
             }
             elsif ( not scalar @nsec and not scalar @nsec3 ) {
                 my $args = {
-                    ns => $ns->string,
+                    ns   => $ns->string,
                     zone => $zone->name->string,
                 };
                 push @results, info( NO_NSEC_NSEC3 => $args );

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -146,7 +146,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CHILD_NS_SAME_IP => sub {
         __x    # DELEGATION:CHILD_NS_SAME_IP
-          "IP {nsip} in child refers to multiple nameservers ({nsnames}).", @_;
+          "IP {ns_ip} in child refers to multiple nameservers ({nsname_list}).", @_;
     },
     DEL_DISTINCT_NS_IP => sub {
         __x    # DELEGATION:DEL_DISTINCT_NS_IP
@@ -154,7 +154,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DEL_NS_SAME_IP => sub {
         __x    # DELEGATION:DEL_NS_SAME_IP
-          "IP {nsip} in parent refers to multiple nameservers ({nsnames}).", @_;
+          "IP {ns_ip} in parent refers to multiple nameservers ({nsname_list}).", @_;
     },
     DISTINCT_IP_ADDRESS => sub {
         __x    # DELEGATION:DISTINCT_IP_ADDRESS
@@ -162,31 +162,31 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_IPV4_NS_CHILD
-          "Child lists enough ({count}) nameservers ({nsnames}) "
+          "Child lists enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV4_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_IPV4_NS_DEL
-          "Delegation lists enough ({count}) nameservers ({nsnames}) "
+          "Delegation lists enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV6_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_IPV6_NS_CHILD
-          "Child lists enough ({count}) nameservers ({nsnames}) "
+          "Child lists enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV6_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_IPV6_NS_DEL
-          "Delegation lists enough ({count}) nameservers ({nsnames}) "
+          "Delegation lists enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_NS_CHILD
-          "Child lists enough ({count}) nameservers ({nsnames}). Lower limit set to {minimum}.", @_;
+          "Child lists enough ({count}) nameservers ({nsname_list}). Lower limit set to {minimum}.", @_;
     },
     ENOUGH_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_NS_DEL
@@ -222,31 +222,31 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NOT_ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV4_NS_CHILD
-          "Child does not list enough ({count}) nameservers ({nsnames}) "
+          "Child does not list enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV4_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV4_NS_DEL
-          "Delegation does not list enough ({count}) nameservers ({nsnames}) "
+          "Delegation does not list enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV6_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV6_NS_CHILD
-          "Child does not list enough ({count}) nameservers ({nsnames}) "
+          "Child does not list enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV6_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV6_NS_DEL
-          "Delegation does not list enough ({count}) nameservers ({nsnames}) "
+          "Delegation does not list enough ({count}) nameservers ({nsname_list}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_NS_CHILD
-          "Child does not list enough ({count}) nameservers ({nsnames}). Lower limit set to {minimum}.", @_;
+          "Child does not list enough ({count}) nameservers ({nsname_list}). Lower limit set to {minimum}.", @_;
     },
     NOT_ENOUGH_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_NS_DEL
@@ -294,7 +294,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     SAME_IP_ADDRESS => sub {
         __x    # DELEGATION:SAME_IP_ADDRESS
-          "IP {nsip} refers to multiple nameservers ({nsnames}).", @_;
+          "IP {ns_ip} refers to multiple nameservers ({nsname_list}).", @_;
     },
     SOA_EXISTS => sub {
         __x    # DELEGATION:SOA_EXISTS
@@ -359,9 +359,9 @@ sub delegation01 {
     # Determine child NS names
     my @child_nsnames = map { $_->string } @{ Zonemaster::Engine::TestMethods->method3( $zone ) };
     my $child_nsnames_args = {
-        count   => scalar( @child_nsnames ),
-        minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nsnames => join( q{;}, sort @child_nsnames ),
+        count       => scalar( @child_nsnames ),
+        minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
+        nsname_list => join( q{;}, sort @child_nsnames ),
     };
 
     # Check child NS names
@@ -383,13 +383,13 @@ sub delegation01 {
     my $child_ns_ipv4_args = {
         count   => scalar( @child_ns_ipv4 ),
         minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nss     => join( q{;}, sort @child_ns_ipv4 ),
+        ns_list => join( q{;}, sort @child_ns_ipv4 ),
         addrs   => join( q{;}, sort @child_ns_ipv4_addrs ),
     };
     my $child_ns_ipv6_args = {
         count   => scalar( @child_ns_ipv6 ),
         minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nss     => join( q{;}, sort @child_ns_ipv6 ),
+        ns_list => join( q{;}, sort @child_ns_ipv6 ),
         addrs   => join( q{;}, sort @child_ns_ipv6_addrs ),
     };
 
@@ -421,16 +421,16 @@ sub delegation01 {
     my @del_ns_ipv6_addrs = uniq map { $_->address->short } grep { $_->address->version == 6 } @del_ns;
 
     my $del_ns_ipv4_args = {
-        count   => scalar( @del_ns_ipv4 ),
-        minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nsnames => join( q{;}, sort @del_ns_ipv4 ),
-        addrs   => join( q{;}, sort @del_ns_ipv4_addrs ),
+        count       => scalar( @del_ns_ipv4 ),
+        minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
+        nsname_list => join( q{;}, sort @del_ns_ipv4 ),
+        addrs       => join( q{;}, sort @del_ns_ipv4_addrs ),
     };
     my $del_ns_ipv6_args = {
-        count   => scalar( @del_ns_ipv6 ),
-        minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nsnames => join( q{;}, sort @del_ns_ipv6 ),
-        addrs   => join( q{;}, sort @del_ns_ipv6_addrs ),
+        count       => scalar( @del_ns_ipv6 ),
+        minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
+        nsname_list => join( q{;}, sort @del_ns_ipv6 ),
+        addrs       => join( q{;}, sort @del_ns_ipv6_addrs ),
     };
 
     if ( scalar( @del_ns_ipv4 ) >= $MINIMUM_NUMBER_OF_NAMESERVERS ) {
@@ -457,10 +457,10 @@ sub delegation01 {
 } ## end sub delegation01
 
 sub _find_dup_ns {
-    my %args = @_;
+    my %args          = @_;
     my $duplicate_tag = $args{duplicate_tag};
-    my $distinct_tag = $args{distinct_tag};
-    my @nss = @{ $args{nss} };
+    my $distinct_tag  = $args{distinct_tag};
+    my @nss           = @{ $args{ns_list} };
 
     my %nsnames_and_ip;
     my %ips;
@@ -480,8 +480,8 @@ sub _find_dup_ns {
             push @results,
               info(
                 $duplicate_tag => {
-                    nsnames => join( q{;}, @{ $ips{$local_ip} } ),
-                    nsip    => $local_ip,
+                    nsname_list => join( q{;}, @{ $ips{$local_ip} } ),
+                    ns_ip       => $local_ip,
                 }
               );
         }
@@ -505,21 +505,21 @@ sub delegation02 {
       _find_dup_ns(
         duplicate_tag => 'DEL_NS_SAME_IP',
         distinct_tag  => 'DEL_DISTINCT_NS_IP',
-        nss           => [@nss_del],
+        ns_list       => [@nss_del],
       );
 
     push @results,
       _find_dup_ns(
         duplicate_tag => 'CHILD_NS_SAME_IP',
         distinct_tag  => 'CHILD_DISTINCT_NS_IP',
-        nss           => [@nss_child],
+        ns_list       => [@nss_child],
       );
 
     push @results,
       _find_dup_ns(
         duplicate_tag => 'SAME_IP_ADDRESS',
         distinct_tag  => 'DISTINCT_IP_ADDRESS',
-        nss           => [ @nss_del, @nss_child ],
+        ns_list       => [ @nss_del, @nss_child ],
       );
 
     return ( @results, info( TEST_CASE_END => { testcase => (split /::/, (caller(0))[3])[-1] } ) );
@@ -592,8 +592,8 @@ sub delegation04 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->string,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -603,8 +603,8 @@ sub delegation04 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->string,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -734,8 +734,8 @@ sub delegation06 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->string,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -146,7 +146,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CHILD_NS_SAME_IP => sub {
         __x    # DELEGATION:CHILD_NS_SAME_IP
-          "IP {address} in child refers to multiple nameservers ({nss}).", @_;
+          "IP {nsip} in child refers to multiple nameservers ({nsnames}).", @_;
     },
     DEL_DISTINCT_NS_IP => sub {
         __x    # DELEGATION:DEL_DISTINCT_NS_IP
@@ -154,7 +154,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DEL_NS_SAME_IP => sub {
         __x    # DELEGATION:DEL_NS_SAME_IP
-          "IP {address} in parent refers to multiple nameservers ({nss}).", @_;
+          "IP {nsip} in parent refers to multiple nameservers ({nsnames}).", @_;
     },
     DISTINCT_IP_ADDRESS => sub {
         __x    # DELEGATION:DISTINCT_IP_ADDRESS
@@ -162,31 +162,31 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_IPV4_NS_CHILD
-          "Child lists enough ({count}) nameservers ({nss}) "
+          "Child lists enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV4_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_IPV4_NS_DEL
-          "Delegation lists enough ({count}) nameservers ({nss}) "
+          "Delegation lists enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV6_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_IPV6_NS_CHILD
-          "Child lists enough ({count}) nameservers ({nss}) "
+          "Child lists enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV6_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_IPV6_NS_DEL
-          "Delegation lists enough ({count}) nameservers ({nss}) "
+          "Delegation lists enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_NS_CHILD
-          "Child lists enough ({count}) nameservers ({nss}). Lower limit set to {minimum}.", @_;
+          "Child lists enough ({count}) nameservers ({nsnames}). Lower limit set to {minimum}.", @_;
     },
     ENOUGH_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_NS_DEL
@@ -202,11 +202,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     IPV4_DISABLED => sub {
         __x    # DELEGATION:IPV4_DISABLED
-          'IPv4 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV6_DISABLED => sub {
         __x    # DELEGATION:IPV6_DISABLED
-          'IPv6 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IS_NOT_AUTHORITATIVE => sub {
         __x    # DELEGATION:IS_NOT_AUTHORITATIVE
@@ -218,35 +218,35 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE => sub {
         __x    # DELEGATION:NO_RESPONSE
-          "Nameserver {ns}/{address} did not respond.", @_;
+          "Nameserver {ns} did not respond.", @_;
     },
     NOT_ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV4_NS_CHILD
-          "Child does not list enough ({count}) nameservers ({nss}) "
+          "Child does not list enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV4_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV4_NS_DEL
-          "Delegation does not list enough ({count}) nameservers ({nss}) "
+          "Delegation does not list enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV6_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV6_NS_CHILD
-          "Child does not list enough ({count}) nameservers ({nss}) "
+          "Child does not list enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV6_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV6_NS_DEL
-          "Delegation does not list enough ({count}) nameservers ({nss}) "
+          "Delegation does not list enough ({count}) nameservers ({nsnames}) "
           . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_NS_CHILD
-          "Child does not list enough ({count}) nameservers ({nss}). Lower limit set to {minimum}.", @_;
+          "Child does not list enough ({count}) nameservers ({nsnames}). Lower limit set to {minimum}.", @_;
     },
     NOT_ENOUGH_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_NS_DEL
@@ -278,7 +278,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NS_IS_CNAME => sub {
         __x    # DELEGATION:NS_IS_CNAME
-          "Nameserver {ns} RR point to CNAME.", @_;
+          "Nameserver {nsname} RR point to CNAME.", @_;
     },
     NO_NS_CNAME => sub {
         __x    # DELEGATION:NO_NS_CNAME
@@ -294,7 +294,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     SAME_IP_ADDRESS => sub {
         __x    # DELEGATION:SAME_IP_ADDRESS
-          "IP {address} refers to multiple nameservers ({nss}).", @_;
+          "IP {nsip} refers to multiple nameservers ({nsnames}).", @_;
     },
     SOA_EXISTS => sub {
         __x    # DELEGATION:SOA_EXISTS
@@ -318,7 +318,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     UNEXPECTED_RCODE => sub {
         __x    # DELEGATION:UNEXPECTED_RCODE
-          'Nameserver {ns}/{address} answered query with an unexpected rcode ({rcode}).', @_;
+          'Nameserver {ns} answered query with an unexpected rcode ({rcode}).', @_;
     },
 
 );
@@ -361,7 +361,7 @@ sub delegation01 {
     my $child_nsnames_args = {
         count   => scalar( @child_nsnames ),
         minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nss     => join( q{;}, sort @child_nsnames ),
+        nsnames => join( q{;}, sort @child_nsnames ),
     };
 
     # Check child NS names
@@ -423,13 +423,13 @@ sub delegation01 {
     my $del_ns_ipv4_args = {
         count   => scalar( @del_ns_ipv4 ),
         minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nss     => join( q{;}, sort @del_ns_ipv4 ),
+        nsnames => join( q{;}, sort @del_ns_ipv4 ),
         addrs   => join( q{;}, sort @del_ns_ipv4_addrs ),
     };
     my $del_ns_ipv6_args = {
         count   => scalar( @del_ns_ipv6 ),
         minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        nss     => join( q{;}, sort @del_ns_ipv6 ),
+        nsnames => join( q{;}, sort @del_ns_ipv6 ),
         addrs   => join( q{;}, sort @del_ns_ipv6_addrs ),
     };
 
@@ -480,8 +480,8 @@ sub _find_dup_ns {
             push @results,
               info(
                 $duplicate_tag => {
-                    nss     => join( q{;}, @{ $ips{$local_ip} } ),
-                    address => $local_ip,
+                    nsnames => join( q{;}, @{ $ips{$local_ip} } ),
+                    nsip    => $local_ip,
                 }
               );
         }
@@ -592,8 +592,7 @@ sub delegation04 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
+                    ns      => $local_ns->string,
                     rrtype  => $query_type,
                 }
               );
@@ -604,8 +603,7 @@ sub delegation04 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
+                    ns      => $local_ns->string,
                     rrtype  => $query_type,
                 }
               );
@@ -621,7 +619,7 @@ sub delegation04 {
                     push @results,
                       info(
                         IS_NOT_AUTHORITATIVE => {
-                            ns    => $local_ns->name->string,
+                            ns    => $local_ns->string,
                             proto => $usevc ? q{TCP} : q{UDP},
                         }
                       );
@@ -671,9 +669,8 @@ sub delegation05 {
             for my $key ( sort keys %nss ) {
                 my $ns = $nss{$key};
                 my $ns_args = {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => q{A},
+                    ns     => $ns->string,
+                    rrtype => q{A},
                 };
 
                 if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
@@ -697,13 +694,13 @@ sub delegation05 {
                     next;
                 }
                 elsif ( scalar $p->get_records( q{CNAME}, q{answer} ) > 0 ) {
-                    push @results, info( NS_IS_CNAME => { ns => $local_nsname } );
+                    push @results, info( NS_IS_CNAME => { nsname => $local_nsname } );
                     next;
                 }
                 elsif ($p->is_redirect) {
                     my $p = $ns->query( $local_nsname, q{A}, { recurse => 1 } );
                     if ( defined $p and scalar $p->get_records( q{CNAME}, q{answer} ) > 0 ) {
-                        push @results, info( NS_IS_CNAME => { ns => $local_nsname } );
+                        push @results, info( NS_IS_CNAME => { nsname => $local_nsname } );
                     }
                 }
             }
@@ -711,7 +708,7 @@ sub delegation05 {
         else {
             my $p = Zonemaster::Engine::Recursor->recurse( $local_nsname, q{A} );
             if ( defined $p and scalar $p->get_records( q{CNAME}, q{answer} ) > 0 ) {
-                push @results, info( NS_IS_CNAME => { ns => $local_nsname } );
+                push @results, info( NS_IS_CNAME => { nsname => $local_nsname } );
             }
         }
     }
@@ -737,8 +734,7 @@ sub delegation06 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
+                    ns      => $local_ns->string,
                     rrtype  => $query_type,
                 }
               );
@@ -749,9 +745,8 @@ sub delegation06 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                    rrtype  => $query_type,
+                    ns     => $local_ns->string,
+                    rrtype => $query_type,
                 }
               );
             next;
@@ -762,12 +757,7 @@ sub delegation06 {
         my $p = $local_ns->query( $zone->name, $query_type );
         if ( $p and $p->rcode eq q{NOERROR} ) {
             if ( not $p->get_records( $query_type, q{answer} ) ) {
-                push @results,
-                  info(
-                    SOA_NOT_EXISTS => {
-                        ns => $local_ns->name->string,
-                    }
-                  );
+                push @results, info( SOA_NOT_EXISTS => { nsname => $local_ns->string } );
             }
         }
 

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -222,15 +222,15 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     AAAA_BAD_RDATA => sub {
         __x    # NAMESERVER:AAAA_BAD_RDATA
-            'Nameserver {ns}/{address} answered AAAA query with an unexpected RDATA length ({length} instead of 16).', @_;
+            'Nameserver {ns} answered AAAA query with an unexpected RDATA length ({length} instead of 16).', @_;
     },
     AAAA_QUERY_DROPPED => sub {
         __x    # NAMESERVER:AAAA_QUERY_DROPPED
-          'Nameserver {ns}/{address} dropped AAAA query.', @_;
+          'Nameserver {ns} dropped AAAA query.', @_;
     },
     AAAA_UNEXPECTED_RCODE => sub {
         __x    # NAMESERVER:AAAA_UNEXPECTED_RCODE
-          'Nameserver {ns}/{address} answered AAAA query with an unexpected rcode ({rcode}).', @_;
+          'Nameserver {ns} answered AAAA query with an unexpected rcode ({rcode}).', @_;
     },
     AAAA_WELL_PROCESSED => sub {
         __x    # NAMESERVER:AAAA_WELL_PROCESSED
@@ -238,19 +238,19 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     A_UNEXPECTED_RCODE => sub {
         __x    # NAMESERVER:A_UNEXPECTED_RCODE
-          'Nameserver {ns}/{address} answered A query with an unexpected rcode ({rcode}).', @_;
+          'Nameserver {ns} answered A query with an unexpected rcode ({rcode}).', @_;
     },
     AXFR_AVAILABLE => sub {
         __x    # NAMESERVER:AXFR_AVAILABLE
-          'Nameserver {ns}/{address} allow zone transfer using AXFR.', @_;
+          'Nameserver {ns} allow zone transfer using AXFR.', @_;
     },
     AXFR_FAILURE => sub {
         __x    # NAMESERVER:AXFR_FAILURE
-          'AXFR not available on nameserver {ns}/{address}.', @_;
+          'AXFR not available on nameserver {ns}.', @_;
     },
     BREAKS_ON_EDNS => sub {
         __x    # NAMESERVER:BREAKS_ON_EDNS
-          'No response from {ns}/{address} when EDNS is used in query asking for {dname}.', @_;
+          'No response from {ns} when EDNS is used in query asking for {dname}.', @_;
     },
     CAN_BE_RESOLVED => sub {
         __x    # NAMESERVER:CAN_BE_RESOLVED
@@ -271,41 +271,41 @@ Readonly my %TAG_DESCRIPTIONS => (
     CASE_QUERY_DIFFERENT_ANSWER => sub {
         __x    # NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
           'When asked for {type} records on "{query1}" and "{query2}", '
-          . 'nameserver {ns}/{address} returns different answers.',
+          . 'nameserver {ns} returns different answers.',
           @_;
     },
     CASE_QUERY_DIFFERENT_RC => sub {
         __x    # NAMESERVER:CASE_QUERY_DIFFERENT_RC
           'When asked for {type} records on "{query1}" and "{query2}", '
-          . 'nameserver {ns}/{address} returns different RCODE ("{rcode1}" vs "{rcode2}").',
+          . 'nameserver {ns} returns different RCODE ("{rcode1}" vs "{rcode2}").',
           @_;
     },
     CASE_QUERY_NO_ANSWER => sub {
         __x    # NAMESERVER:CASE_QUERY_NO_ANSWER
-          'When asked for {type} records on "{query}", nameserver {ns}/{address} returns nothing.', @_;
+          'When asked for {type} records on "{query}", nameserver {ns} returns nothing.', @_;
     },
     CASE_QUERY_SAME_ANSWER => sub {
         __x    # NAMESERVER:CASE_QUERY_SAME_ANSWER
-          'When asked for {type} records on "{query1}" and "{query2}", nameserver {ns}/{address} returns same answers.',
+          'When asked for {type} records on "{query1}" and "{query2}", nameserver {ns} returns same answers.',
           @_;
     },
     CASE_QUERY_SAME_RC => sub {
         __x    # NAMESERVER:CASE_QUERY_SAME_RC
           'When asked for {type} records on "{query1}" and "{query2}", '
-          . 'nameserver {ns}/{address} returns same RCODE "{rcode}".',
+          . 'nameserver {ns} returns same RCODE "{rcode}".',
           @_;
     },
     DIFFERENT_SOURCE_IP => sub {
         __x    # NAMESERVER:DIFFERENT_SOURCE_IP
-          'Nameserver {ns}/{address} replies on a SOA query with a different source address ({source}).', @_;
+          'Nameserver {ns} replies on a SOA query with a different source address ({source}).', @_;
     },
     EDNS_RESPONSE_WITHOUT_EDNS => sub {
         __x    # NAMESERVER:EDNS_RESPONSE_WITHOUT_EDNS
-          'Response without EDNS from {ns}/{address} on query with EDNS0 asking for {dname}.', @_;
+          'Response without EDNS from {ns} on query with EDNS0 asking for {dname}.', @_;
     },
     EDNS_VERSION_ERROR => sub {
         __x    # NAMESERVER:EDNS_VERSION_ERROR
-          'Incorrect version of EDNS (expected 0) in response from {ns}/{address} '
+          'Incorrect version of EDNS (expected 0) in response from {ns} '
           . 'on query with EDNS (version 0) asking for {dname}.',
           @_;
     },
@@ -315,27 +315,27 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     IPV4_DISABLED => sub {
         __x    # NAMESERVER:IPV4_DISABLED
-          'IPv4 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV6_DISABLED => sub {
         __x    # NAMESERVER:IPV6_DISABLED
-          'IPv6 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IS_A_RECURSOR => sub {
         __x    # NAMESERVER:IS_A_RECURSOR
-          'Nameserver {ns}/{address} is a recursor.', @_;
+          'Nameserver {ns} is a recursor.', @_;
     },
     MISSING_OPT_IN_TRUNCATED => sub {
         __x    # NAMESERVER:MISSING_OPT_IN_TRUNCATED
-          'Nameserver {ns}/{address} replies on an EDNS query with a truncated response without EDNS.', @_;
+          'Nameserver {ns} replies on an EDNS query with a truncated response without EDNS.', @_;
     },
     NO_EDNS_SUPPORT => sub {
         __x    # NAMESERVER:NO_EDNS_SUPPORT
-          'Nameserver {ns}/{address} does not support EDNS0 (replies with FORMERR).', @_;
+          'Nameserver {ns} does not support EDNS0 (replies with FORMERR).', @_;
     },
     NO_RECURSOR => sub {
         __x    # NAMESERVER:NO_RECURSOR
-          'Nameserver {ns}/{address} is not a recursor.', @_;
+          'Nameserver {ns} is not a recursor.', @_;
     },
     NO_RESOLUTION => sub {
         __x    # NAMESERVER:NO_RESOLUTION
@@ -343,7 +343,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE => sub {
         __x    # NAMESERVER:NO_RESPONSE
-          'No response from {ns}/{address} asking for {dname}.', @_;
+          'No response from {ns} asking for {dname}.', @_;
     },
     NO_UPWARD_REFERRAL => sub {
         __x    # NAMESERVER:NO_UPWARD_REFERRAL
@@ -351,15 +351,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NS_ERROR => sub {
         __x    # NAMESERVER:NS_ERROR
-          'Erroneous response from nameserver {ns}/{address}.', @_;
+          'Erroneous response from nameserver {ns}.', @_;
     },
     QNAME_CASE_INSENSITIVE => sub {
         __x    # NAMESERVER:QNAME_CASE_INSENSITIVE
-          'Nameserver {ns}/{address} does not preserve original case of the queried name ({dname}).', @_;
+          'Nameserver {ns} does not preserve original case of the queried name ({dname}).', @_;
     },
     QNAME_CASE_SENSITIVE => sub {
         __x    # NAMESERVER:QNAME_CASE_SENSITIVE
-          "Nameserver {ns}/{address} preserves original case of queried names ({dname}).", @_;
+          "Nameserver {ns} preserves original case of queried names ({dname}).", @_;
     },
     SAME_SOURCE_IP => sub {
         __x    # NAMESERVER:SAME_SOURCE_IP
@@ -375,15 +375,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     UNKNOWN_OPTION_CODE => sub {
         __x    # NAMESERVER:UNKNOWN_OPTION_CODE
-          'Nameserver {ns}/{address} responds with an unknown ENDS OPTION-CODE.', @_;
+          'Nameserver {ns} responds with an unknown ENDS OPTION-CODE.', @_;
     },
     UNSUPPORTED_EDNS_VER => sub {
         __x    # NAMESERVER:UNSUPPORTED_EDNS_VER
-          'Nameserver {ns}/{address} accepts an unsupported EDNS version.', @_;
+          'Nameserver {ns} accepts an unsupported EDNS version.', @_;
     },
     UPWARD_REFERRAL => sub {
         __x    # NAMESERVER:UPWARD_REFERRAL
-          'Nameserver {ns}/{address} returns an upward referral.', @_;
+          'Nameserver {ns} returns an upward referral.', @_;
     },
     UPWARD_REFERRAL_IRRELEVANT => sub {
         __x    # NAMESERVER:UPWARD_REFERRAL_IRRELEVANT
@@ -391,7 +391,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     Z_FLAGS_NOTCLEAR => sub {
         __x    # NAMESERVER:Z_FLAGS_NOTCLEAR
-          'Nameserver {ns}/{address} has one or more unknown EDNS Z flag bits set.', @_;
+          'Nameserver {ns} has one or more unknown EDNS Z flag bits set.', @_;
     },
 );
 
@@ -423,10 +423,6 @@ sub nameserver01 {
     }
 
     for my $ns ( @nss ) {
-        my %ns_args = (
-            ns      => $ns->name->string,
-            address => $ns->address->short,
-        );
 
         my $response_count = 0;
         my $nxdomain_count = 0;
@@ -438,7 +434,7 @@ sub nameserver01 {
             if ( !$p ) {
                 my %name_args = (
                     dname => $nonexistent_name,
-                    %ns_args,
+                    ns    => $ns->string,
                 );
                 push @results, info( NO_RESPONSE => \%name_args );
                 $is_no_recursor = 0;
@@ -457,12 +453,12 @@ sub nameserver01 {
         } ## end for my $nonexistent_name...
 
         if ( $has_seen_ra || ( $response_count > 0 && $nxdomain_count == $response_count ) ) {
-            push @results, info( IS_A_RECURSOR => \%ns_args );
+            push @results, info( IS_A_RECURSOR => { ns => $ns->string } );
             $is_no_recursor = 0;
         }
 
         if ( $is_no_recursor ) {
-            push @results, info( NO_RECURSOR => \%ns_args );
+            push @results, info( NO_RECURSOR => { ns => $ns->string } );
         }
     } ## end for my $ns ( @nss )
 
@@ -486,13 +482,7 @@ sub nameserver02 {
         my $p = $local_ns->query( $zone->name, q{SOA}, { edns_size => 512 } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->has_edns) {
-                push @results,
-                  info(
-                    NO_EDNS_SUPPORT => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                    }
-                  );
+                push @results, info( NO_EDNS_SUPPORT => { ns => $local_ns->string } );
             }
             elsif ( $p->rcode eq q{NOERROR} and not $p->edns_rcode and $p->get_records( q{SOA}, q{answer} ) and $p->edns_version == 0 ) {
                 $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short }++;
@@ -502,9 +492,8 @@ sub nameserver02 {
                 push @results,
                   info(
                     EDNS_RESPONSE_WITHOUT_EDNS => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        dname   => $zone->name,
+                        ns    => $local_ns->string,
+                        dname => $zone->name,
                     }
                   );
             }
@@ -512,20 +501,13 @@ sub nameserver02 {
                 push @results,
                   info(
                     EDNS_VERSION_ERROR => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        dname   => $zone->name,
+                        ns    => $local_ns->string,
+                        dname => $zone->name,
                     }
                   );
             }
             else {
-                push @results,
-                  info(
-                    NS_ERROR => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                    }
-                  );
+                push @results, info( NS_ERROR => { ns => $local_ns->string } );
             }
         }
         else {
@@ -534,9 +516,8 @@ sub nameserver02 {
                 push @results,
                   info(
                     BREAKS_ON_EDNS => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        dname   => $zone->name,
+                        ns    => $local_ns->string,
+                        dname => $zone->name,
                     }
                   );
             }
@@ -544,9 +525,8 @@ sub nameserver02 {
                 push @results,
                   info(
                     NO_RESPONSE => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        dname   => $zone->name,
+                        ns    => $local_ns->string,
+                        dname => $zone->name,
                     }
                   );
             }
@@ -587,23 +567,11 @@ sub nameserver03 {
             $local_ns->axfr( $zone->name, sub { ( $first_rr ) = @_; return 0; } );
             1;
         } or do {
-            push @results,
-              info(
-                AXFR_FAILURE => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( AXFR_FAILURE => { ns => $local_ns->string } );
         };
 
         if ( $first_rr and $first_rr->type eq q{SOA} ) {
-            push @results,
-              info(
-                AXFR_AVAILABLE => {
-                    ns      => $local_ns->name->string,
-                    address => $local_ns->address->short,
-                }
-              );
+            push @results, info( AXFR_AVAILABLE => { ns => $local_ns->string } );
         }
 
         $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short }++;
@@ -633,9 +601,8 @@ sub nameserver04 {
                 push @results,
                   info(
                     DIFFERENT_SOURCE_IP => {
-                        ns      => $local_ns->name->string,
-                        address => $local_ns->address->short,
-                        source  => $p->answerfrom,
+                        ns     => $local_ns->string,
+                        source => $p->answerfrom,
                     }
                   );
             }
@@ -670,9 +637,8 @@ sub nameserver05 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => q{A},
+                    ns     => $ns->string,
+                    rrtype => q{A},
                 }
               );
             next;
@@ -682,9 +648,8 @@ sub nameserver05 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => q{A},
+                    ns     => $ns->string,
+                    rrtype => q{A},
                 }
               );
             next;
@@ -698,9 +663,8 @@ sub nameserver05 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns      => $ns->name,
-                    address => $ns->address->short,
-                    dname   => $zone->name,
+                    ns    => $ns->string,
+                    dname => $zone->name,
                 }
               );
         }
@@ -708,9 +672,8 @@ sub nameserver05 {
             push @results,
               info(
                 A_UNEXPECTED_RCODE => {
-                    ns      => $ns->name,
-                    address => $ns->address->short,
-                    rcode   => $p->rcode,
+                    ns    => $ns->string,
+                    rcode => $p->rcode,
                 }
               );
         }
@@ -719,21 +682,15 @@ sub nameserver05 {
 
             if ( not $p ) {
                 push @results,
-                  info(
-                    AAAA_QUERY_DROPPED => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                info( AAAA_QUERY_DROPPED => { ns => $ns->string } );
                 $aaaa_issue++;
             }
             elsif ( $p->rcode ne q{NOERROR} ) {
                 push @results,
                   info(
                     AAAA_UNEXPECTED_RCODE => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                        rcode   => $p->rcode,
+                        ns    => $ns->string,
+                        rcode => $p->rcode,
                     }
                   );
                 $aaaa_issue++;
@@ -744,9 +701,8 @@ sub nameserver05 {
                         push @results,
                           info(
                             AAAA_BAD_RDATA => {
-                                ns      => $ns->name,
-                                address => $ns->address->short,
-                                length  => length($rr->rdf(0)),
+                                ns     => $ns->string,
+                                length => length($rr->rdf(0)),
                             }
                           );
                         $aaaa_issue++;
@@ -832,13 +788,7 @@ sub nameserver07 {
                 my @ns = $p->get_records( q{NS}, q{authority} );
 
                 if ( @ns ) {
-                    push @results,
-                      info(
-                        UPWARD_REFERRAL => {
-                            ns      => $local_ns->name->string,
-                            address => $local_ns->address->short,
-                        }
-                      );
+                    push @results, info( UPWARD_REFERRAL => { ns => $local_ns->string } );
                 }
             }
             $nsnames{ $local_ns->name }++;
@@ -889,9 +839,8 @@ sub nameserver08 {
                 push @results,
                   info(
                     QNAME_CASE_SENSITIVE => {
-                        ns      => $local_ns->name->string,
-                        address => $local_ns->address->short,
-                        dname   => $randomized_uc_name,
+                        ns    => $local_ns->string,
+                        dname => $randomized_uc_name,
                     }
                   );
             }
@@ -899,9 +848,8 @@ sub nameserver08 {
                 push @results,
                   info(
                     QNAME_CASE_INSENSITIVE => {
-                        ns      => $local_ns->name->string,
-                        address => $local_ns->address->short,
-                        dname   => $randomized_uc_name,
+                        ns    => $local_ns->string,
+                        dname => $randomized_uc_name,
                     }
                   );
             }
@@ -962,11 +910,10 @@ sub nameserver09 {
                 push @results,
                   info(
                     CASE_QUERY_SAME_ANSWER => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        type    => $record_type,
-                        query1  => $randomized_uc_name1,
-                        query2  => $randomized_uc_name2,
+                        ns     => $local_ns->string,
+                        type   => $record_type,
+                        query1 => $randomized_uc_name1,
+                        query2 => $randomized_uc_name2,
                     }
                   );
             }
@@ -975,11 +922,10 @@ sub nameserver09 {
                 push @results,
                   info(
                     CASE_QUERY_DIFFERENT_ANSWER => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        type    => $record_type,
-                        query1  => $randomized_uc_name1,
-                        query2  => $randomized_uc_name2,
+                        ns     => $local_ns->string,
+                        type   => $record_type,
+                        query1 => $randomized_uc_name1,
+                        query2 => $randomized_uc_name2,
                     }
                   );
             }
@@ -991,12 +937,11 @@ sub nameserver09 {
                 push @results,
                   info(
                     CASE_QUERY_SAME_RC => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        type    => $record_type,
-                        query1  => $randomized_uc_name1,
-                        query2  => $randomized_uc_name2,
-                        rcode   => $p1->rcode,
+                        ns     => $local_ns->string,
+                        type   => $record_type,
+                        query1 => $randomized_uc_name1,
+                        query2 => $randomized_uc_name2,
+                        rcode  => $p1->rcode,
                     }
                   );
             }
@@ -1005,13 +950,12 @@ sub nameserver09 {
                 push @results,
                   info(
                     CASE_QUERY_DIFFERENT_RC => {
-                        ns      => $local_ns->name,
-                        address => $local_ns->address->short,
-                        type    => $record_type,
-                        query1  => $randomized_uc_name1,
-                        query2  => $randomized_uc_name2,
-                        rcode1  => $p1->rcode,
-                        rcode2  => $p2->rcode,
+                        ns     => $local_ns->string,
+                        type   => $record_type,
+                        query1 => $randomized_uc_name1,
+                        query2 => $randomized_uc_name2,
+                        rcode1 => $p1->rcode,
+                        rcode2 => $p2->rcode,
                     }
                   );
             }
@@ -1022,10 +966,9 @@ sub nameserver09 {
             push @results,
               info(
                 CASE_QUERY_NO_ANSWER => {
-                    ns      => $local_ns->name,
-                    address => $local_ns->address->short,
-                    type    => $record_type,
-                    query   => $p1 ? $randomized_uc_name1 : $randomized_uc_name2,
+                    ns    => $local_ns->string,
+                    type  => $record_type,
+                    query => $p1 ? $randomized_uc_name1 : $randomized_uc_name2,
                 }
               );
         }
@@ -1078,43 +1021,24 @@ sub nameserver10 {
         my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { version => 1 } } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->edns_rcode ) {
-                push @results,
-                  info(
-                    NO_EDNS_SUPPORT => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NO_EDNS_SUPPORT => { ns => $ns->string } );
             }
             elsif ( $p->rcode eq q{NOERROR} and not $p->edns_rcode ) {
-                push @results,
-                  info(
-                    UNSUPPORTED_EDNS_VER => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( UNSUPPORTED_EDNS_VER => { ns => $ns->string } );
             }
             elsif ( ($p->rcode eq q{NOERROR} and $p->edns_rcode == 1) and $p->edns_version == 0 and not scalar $p->answer) {
                 next;
             }
             else {
-                push @results,
-                  info(
-                    NS_ERROR => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NS_ERROR => { ns => $ns->string } );
             }
         }
         else {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns      => $ns->name,
-                    address => $ns->address->short,
-                    dname   => $zone->name,
+                    ns    => $ns->string,
+                    dname => $zone->name,
                 }
               );
         }
@@ -1153,43 +1077,24 @@ sub nameserver11 {
         my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { data => $rdata } } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->edns_rcode ) {
-                push @results,
-                  info(
-                    NO_EDNS_SUPPORT => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NO_EDNS_SUPPORT => { ns => $ns->string } );
             }
             elsif ( defined $p->edns_data ) {
-                push @results,
-                  info(
-                    UNKNOWN_OPTION_CODE => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( UNKNOWN_OPTION_CODE => { ns => $ns->string } );
             }
             elsif ( $p->rcode eq q{NOERROR} and not $p->edns_rcode and $p->edns_version == 0 and not defined $p->edns_data and $p->get_records( q{SOA}, q{answer} ) ) {
                 next;
             }
             else {
-                push @results,
-                  info(
-                    NS_ERROR => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NS_ERROR => { ns => $ns->string, } );
             }
         }
         else {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns      => $ns->name,
-                    address => $ns->address->short,
-                    dname   => $zone->name,
+                    ns    => $ns->string,
+                    dname => $zone->name,
                 }
               );
         }
@@ -1222,43 +1127,24 @@ sub nameserver12 {
         my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { z => 3 } } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->edns_rcode ) {
-                push @results,
-                  info(
-                    NO_EDNS_SUPPORT => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NO_EDNS_SUPPORT => { ns => $ns->string } );
             }
             elsif ( $p->edns_z ) {
-                push @results,
-                  info(
-                    Z_FLAGS_NOTCLEAR => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( Z_FLAGS_NOTCLEAR => { ns => $ns->string } );
             }
             elsif ( $p->rcode eq q{NOERROR} and not $p->edns_rcode and $p->edns_version == 0 and $p->edns_z == 0 and $p->get_records( q{SOA}, q{answer} ) ) {
                 next;
             }
             else {
-                push @results,
-                  info(
-                    NS_ERROR => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NS_ERROR => { ns => $ns->string } );
             }
         }
         else {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns      => $ns->name,
-                    address => $ns->address->short,
-                    dname   => $zone->name,
+                    ns    => $ns->string,
+                    dname => $zone->name,
                 }
               );
         }
@@ -1290,43 +1176,24 @@ sub nameserver13 {
         my $p = $ns->query( $zone->name, q{SOA}, { usevc => 0, fallback => 0, edns_details => { do => 1, udp_size => 512  } } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->edns_rcode ) {
-                push @results,
-                  info(
-                    NO_EDNS_SUPPORT => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NO_EDNS_SUPPORT => { ns => $ns->string, } );
             }
             elsif ( $p->tc and not $p->has_edns ) {
-                push @results,
-                  info(
-                    MISSING_OPT_IN_TRUNCATED => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( MISSING_OPT_IN_TRUNCATED => { ns => $ns->string } );
             }
             elsif ( $p->rcode eq q{NOERROR} and not $p->edns_rcode and $p->edns_version == 0 ) {
                 next;
             }
             else {
-                push @results,
-                  info(
-                    NS_ERROR => {
-                        ns      => $ns->name,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NS_ERROR => { ns => $ns->string } );
             }
         }
         else {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns      => $ns->name,
-                    address => $ns->address->short,
-                    dname   => $zone->name,
+                    ns    => $ns->string,
+                    dname => $zone->name,
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -702,7 +702,7 @@ sub nameserver05 {
                           info(
                             AAAA_BAD_RDATA => {
                                 ns     => $ns->string,
-                                length => length($rr->rdf(0)),
+                                length => length( $rr->rdf( 0 ) ),
                             }
                           );
                         $aaaa_issue++;

--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -469,8 +469,8 @@ sub syntax06 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->string,
-                    rrtype  => q{SOA},
+                    ns     => $ns->string,
+                    rrtype => q{SOA},
                 }
               );
             next;

--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -160,11 +160,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     IPV4_DISABLED => sub {
         __x    # SYNTAX:IPV4_DISABLED
-          'IPv4 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     IPV6_DISABLED => sub {
         __x    # SYNTAX:IPV6_DISABLED
-          'IPv6 is disabled, not sending "{rrtype}" query to {ns}/{address}.', @_;
+          'IPv6 is disabled, not sending "{rrtype}" query to {ns}.', @_;
     },
     MNAME_DISCOURAGED_DOUBLE_DASH => sub {
         __x    # SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
@@ -236,7 +236,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE => sub {
         __x    # SYNTAX:NO_RESPONSE
-          'No response from {ns}/{address} asking for {dname}.', @_;
+          'No response from {ns} asking for {dname}.', @_;
     },
     NO_RESPONSE_MX_QUERY => sub {
         __x    # SYNTAX:NO_RESPONSE_MX_QUERY
@@ -457,9 +457,8 @@ sub syntax06 {
             push @results,
               info(
                 IPV6_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    rrtype  => q{SOA},
+                    ns     => $ns->string,
+                    rrtype => q{SOA},
                 }
               );
             next;
@@ -470,8 +469,7 @@ sub syntax06 {
             push @results,
               info(
                 IPV4_DISABLED => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
+                    ns      => $ns->string,
                     rrtype  => q{SOA},
                 }
               );
@@ -484,9 +482,8 @@ sub syntax06 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                    dname   => $zone->name,
+                    ns    => $ns->string,
+                    dname => $zone->name,
                 }
               );
             next;

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -228,7 +228,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MNAME_NOT_IN_GLUE => sub {
         __x    # ZONE:MNAME_NOT_IN_GLUE
-          'SOA \'mname\' nameserver ({mname}) is not listed in "parent" NS records for tested zone ({nss}).', @_;
+          'SOA \'mname\' nameserver ({mname}) is not listed in "parent" NS records for tested zone ({ns_list}).', @_;
     },
     REFRESH_LOWER_THAN_RETRY => sub {
         __x    # ZONE:REFRESH_LOWER_THAN_RETRY
@@ -347,8 +347,8 @@ sub zone01 {
                 push @results,
                   info(
                     MNAME_NOT_IN_GLUE => {
-                        mname => $soa_mname,
-                        nss   => join( q{;}, @{ Zonemaster::Engine::TestMethods->method2( $zone ) } ),
+                        mname   => $soa_mname,
+                        ns_list => join( q{;}, @{ Zonemaster::Engine::TestMethods->method2( $zone ) } ),
                     }
                   );
             }

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -172,7 +172,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MNAME_NO_RESPONSE => sub {
         __x    # ZONE:MNAME_NO_RESPONSE
-          'SOA \'mname\' nameserver {ns}/{address} does not respond.', @_;
+          'SOA \'mname\' nameserver {ns} does not respond.', @_;
     },
     MNAME_IS_CNAME => sub {
         __x    # ZONE:MNAME_IS_CNAME
@@ -216,7 +216,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MNAME_NOT_AUTHORITATIVE => sub {
         __x    # ZONE:MNAME_NOT_AUTHORITATIVE
-          'SOA \'mname\' nameserver {ns}/{address} is not authoritative for \'{zone}\' zone.', @_;
+          'SOA \'mname\' nameserver {ns} is not authoritative for \'{zone}\' zone.', @_;
     },
     MNAME_RECORD_DOES_NOT_EXIST => sub {
         __x    # ZONE:MNAME_RECORD_DOES_NOT_EXIST
@@ -252,11 +252,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MULTIPLE_SOA => sub {
         __x    # ZONE:MULTIPLE_SOA
-          'Nameserver {ns}/{address} responds with multiple ({count}) SOA records on SOA queries.', @_;
+          'Nameserver {ns} responds with multiple ({count}) SOA records on SOA queries.', @_;
     },
     NO_RESPONSE => sub {
         __x    # ZONE:NO_RESPONSE
-          'Nameserver {ns}/{address} did not respond.', @_;
+          'Nameserver {ns} did not respond.', @_;
     },
     NO_RESPONSE_SOA_QUERY => sub {
         __x    # ZONE:NO_RESPONSE_SOA_QUERY
@@ -268,7 +268,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_SOA_IN_RESPONSE => sub {
         __x    # ZONE:NO_SOA_IN_RESPONSE
-          'Response from nameserver {ns}/{address} on SOA queries does not contain SOA record.', @_;
+          'Response from nameserver {ns} on SOA queries does not contain SOA record.', @_;
     },
     MNAME_HAS_NO_ADDRESS => sub {
         __x    # ZONE:MNAME_HAS_NO_ADDRESS
@@ -294,7 +294,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     WRONG_SOA => sub {
         __x    # ZONE:WRONG_SOA
-          'Nameserver {ns}/{address} responds with a wrong owner name ({owner} instead of {name}) on SOA queries.', @_;
+          'Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on SOA queries.', @_;
     },
 );
 
@@ -333,21 +333,14 @@ sub zone01 {
                         push @results,
                           info(
                             MNAME_NOT_AUTHORITATIVE => {
-                                ns      => $soa_mname,
-                                address => $ip_address->short,
-                                zone    => $zone->name,
+                                ns   => $ns->string,
+                                zone => $zone->name,
                             }
                           );
                     }
                 }
                 else {
-                    push @results,
-                      info(
-                        MNAME_NO_RESPONSE => {
-                            ns      => $soa_mname,
-                            address => $ip_address->short,
-                        }
-                      );
+                    push @results, info( MNAME_NO_RESPONSE => { ns => $ns->string } );
                 }
             } ## end foreach my $ip_address ( Zonemaster::Engine::Recursor...)
             if ( none { $_ eq $soa_mname } @{ Zonemaster::Engine::TestMethods->method2( $zone ) } ) {
@@ -705,13 +698,7 @@ sub zone10 {
         my $p = $ns->query( $name, q{SOA} );
 
         if ( not $p ) {
-            push @results,
-              info(
-                NO_RESPONSE => {
-                    ns      => $ns->name->string,
-                    address => $ns->address->short,
-                }
-              );
+            push @results, info( NO_RESPONSE => { ns => $ns->string } );
             next;
         }
         else {
@@ -721,9 +708,8 @@ sub zone10 {
                     push @results,
                       info(
                         MULTIPLE_SOA => {
-                            ns      => $ns->name->string,
-                            address => $ns->address->short,
-                            count   => scalar @soa,
+                            ns    => $ns->string,
+                            count => scalar @soa,
                         }
                       );
                 }
@@ -731,22 +717,15 @@ sub zone10 {
                     push @results,
                       info(
                         WRONG_SOA => {
-                            ns      => $ns->name->string,
-                            address => $ns->address->short,
-                            owner   => lc( $soa[0]->owner ),
-                            name    => lc( $name->fqdn ),
+                            ns    => $ns->string,
+                            owner => lc( $soa[0]->owner ),
+                            name  => lc( $name->fqdn ),
                         }
                       );
                 }
             } ## end if ( scalar @soa )
             else {
-                push @results,
-                  info(
-                    NO_SOA_IN_RESPONSE => {
-                        ns      => $ns->name->string,
-                        address => $ns->address->short,
-                    }
-                  );
+                push @results, info( NO_SOA_IN_RESPONSE => { ns => $ns->string } );
             }
         } ## end else [ if ( not $p ) ]
     } ## end foreach my $ns ( @{ Zonemaster::Engine::TestMethods...})


### PR DESCRIPTION
This PR concerns itself with a very small number of argument names, but it's by far the most common ones so it's still a very big diff. I believe it is a good approach to establish a good pattern for the most common argument names first, and look into less common argument names afterwards.

The most common argument names in the current develop branch are by far "ns" and "address". I looked at the usage of these and came up with the following convention:
* {nsname} - a name server name
* {nsip} - a name server IP address
* {ns} - a name server identified by both name and IP, separated with a slash
* {nsnames} - a semicolon separated list of {nsname}
* {nsips} - a semicolon separated list of {nsip}
* {nss} - a semicolon separated list of {ns}

A reasonable alternative I could think of is to use "list" for pluralization instead of just using "s". I.e. the last three would become {nsnamelist}, {nsiplist} and {nslist}.
Another idea is to use snake_case or kebab-case for improved readability. E.g. {ns_name}, {ns_ip_list} or {ns-name}, {ns-ip-list}. IMO kebab-case is better looking, but snake_case names are accepted as Perl barewords which plays nicer in the source code.

Note: There are no examples of {nsips} or {nss} in this PR.

Note: There are examples of messages whose arguments get more confusing as a whole because of this rename. E.g. because {nsname} is combined with {name}. That'll be resolved in a future PR where we come up with a better name for the {name} argument, etc.

Note: Even more arguments should probably bare these names, but they weren't included here because they're currently named something other than the names listed here. We'll rename those in future PRs.

I'll make a separate PR for the SYSTEM messages. They aren't defined and used in the same file, so I figured reviewing them would be more difficult if they were included in this PR.

If you think this PR is too large to review properly, I can split off some modules into one or more separate PRs. The changes to the Nameserver and DNSSEC test modules are particularly voluminous.

This is a step towards resolving #713.