### PR TITLE
Rename more message args

### DIFF
--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -2,13 +2,7 @@
 
 ## Aggregate list
 
-This table contains prefixes of argument names. An optional suffix may be added
-for disambiguation and/or clarity.
-Suffixes must be in snake_case, they must start with an underscore, and it must
-be unambiguous from the table where the base name ends and where the suffix
-begins.
-
-| Base name   | Type of value        | Description and formatting                                  |
+| Argument    | Type of value        | Description and formatting                                  |
 |-------------|----------------------|-------------------------------------------------------------|
 | nsname      | Domain name          | The domain name of a name server.                           |
 | ns_ip       | IP address           | The IP address of a name server.                            |

--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -2,7 +2,13 @@
 
 ## Aggregate list
 
-| Argument    | Type of value        | Description and formatting                                  |
+This table contains prefixes of argument names. An optional suffix may be added
+for disambiguation and/or clarity.
+Suffixes must be in snake_case, they must start with an underscore, and it must
+be unambiguous from the table where the base name ends and where the suffix
+begins.
+
+| Base name   | Type of value        | Description and formatting                                  |
 |-------------|----------------------|-------------------------------------------------------------|
 | nsname      | Domain name          | The domain name of a name server.                           |
 | ns_ip       | IP address           | The IP address of a name server.                            |

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -204,7 +204,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NS_SET => sub {
         __x    # CONSISTENCY:NS_SET
-          'Saw NS set ({nsset}) on following nameserver set : {servers}.', @_;
+          'Saw NS set ({nsset}) on following nameserver set : {ns_list}.', @_;
     },
     ONE_NS_SET => sub {
         __x    # CONSISTENCY:ONE_NS_SET
@@ -236,11 +236,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     SOA_RNAME => sub {
         __x    # CONSISTENCY:SOA_RNAME
-          "Found SOA rname {rname} on following nameserver set : {servers}.", @_;
+          "Found SOA rname {rname} on following nameserver set : {ns_list}.", @_;
     },
     SOA_SERIAL => sub {
         __x    # CONSISTENCY:SOA_SERIAL
-          'Saw SOA serial number {serial} on following nameserver set : {servers}.', @_;
+          'Saw SOA serial number {serial} on following nameserver set : {ns_list}.', @_;
     },
     SOA_SERIAL_VARIATION => sub {
         __x    # CONSISTENCY:SOA_SERIAL_VARIATION
@@ -250,7 +250,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     SOA_TIME_PARAMETER_SET => sub {
         __x    # CONSISTENCY:SOA_TIME_PARAMETER_SET
           'Saw SOA time parameter set (REFRESH={refresh},RETRY={retry},EXPIRE={expire},'
-          . 'MINIMUM={minimum}) on following nameserver set : {servers}.', @_;
+          . 'MINIMUM={minimum}) on following nameserver set : {ns_list}.', @_;
     },
     TEST_CASE_END => sub {
         __x    # CONSISTENCY:TEST_CASE_END
@@ -339,7 +339,7 @@ sub consistency01 {
           info(
             SOA_SERIAL => {
                 serial  => $serial,
-                servers => join( q{;}, sort @{ $serials{$serial} } ),
+                ns_list => join( q{;}, sort @{ $serials{$serial} } ),
             }
           );
     }
@@ -448,7 +448,7 @@ sub consistency02 {
               info(
                 SOA_RNAME => {
                     rname   => $rname,
-                    servers => join( q{;}, @{ $rnames{$rname} } ),
+                    ns_list => join( q{;}, @{ $rnames{$rname} } ),
                 }
               );
         }
@@ -542,7 +542,7 @@ sub consistency03 {
                     retry   => $retry,
                     expire  => $expire,
                     minimum => $minimum,
-                    servers => join( q{;}, sort @{ $time_parameter_sets{$time_parameter_set} } ),
+                    ns_list => join( q{;}, sort @{ $time_parameter_sets{$time_parameter_set} } ),
                 }
               );
         }
@@ -625,7 +625,7 @@ sub consistency04 {
               info(
                 NS_SET => {
                     nsset   => $ns_set,
-                    servers => join( q{;}, @{ $ns_sets{$ns_set} } ),
+                    ns_list => join( q{;}, @{ $ns_sets{$ns_set} } ),
                 }
               );
         }
@@ -874,7 +874,7 @@ sub consistency06 {
               info(
                 SOA_MNAME => {
                     mname   => $mname,
-                    servers => join( q{;}, @{ $mnames{$mname} } ),
+                    ns_list => join( q{;}, @{ $mnames{$mname} } ),
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -596,8 +596,8 @@ sub consistency04 {
             next;
         }
         else {
-            push @{ $ns_sets{ join( q{,}, @ns ) } }, $local_ns->name->string . q{/} . $local_ns->address->short;
-            $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short }++;
+            push @{ $ns_sets{ join( q{,}, @ns ) } }, $local_ns->string;
+            $nsnames_and_ip{ $local_ns->string }++;
         }
     } ## end foreach my $local_ns ( @{ Zonemaster::Engine::TestMethods...})
 

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -159,7 +159,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     IN_BAILIWICK_ADDR_MISMATCH => sub {
         __x    # CONSISTENCY:IN_BAILIWICK_ADDR_MISMATCH
           'In-bailiwick name server listed at parent has a mismatch between glue data at parent '
-          . '({parent_addresses}) and any equivalent address record in child zone ({zone_addresses}).',
+          . '({ns_list_parent}) and any equivalent address record in child zone ({ns_list_zone}).',
           @_;
     },
     IPV4_DISABLED => sub {
@@ -231,8 +231,8 @@ Readonly my %TAG_DESCRIPTIONS => (
     OUT_OF_BAILIWICK_ADDR_MISMATCH => sub {
         __x    # CONSISTENCY:OUT_OF_BAILIWICK_ADDR_MISMATCH
           'Out-of-bailiwick name server listed at parent with glue record has a mismatch between '
-          . 'the glue at the parent ({parent_addresses}) and any equivalent address record found '
-          . 'in authoritative zone ({zone_addresses}).', @_;
+          . 'the glue at the parent ({ns_list_parent}) and any equivalent address record found '
+          . 'in authoritative zone ({ns_list_zone}).', @_;
     },
     SOA_RNAME => sub {
         __x    # CONSISTENCY:SOA_RNAME
@@ -740,8 +740,8 @@ sub consistency05 {
         push @results,
           info(
             IN_BAILIWICK_ADDR_MISMATCH => {
-                parent_addresses => join( q{;}, sort keys %strict_glue ),
-                zone_addresses => join( q{;}, sort keys %child_ib_strings ),
+                ns_list_parent => join( q{;}, sort keys %strict_glue ),
+                ns_list_zone  => join( q{;}, sort keys %child_ib_strings ),
             }
           );
     }
@@ -781,8 +781,8 @@ sub consistency05 {
             push @results,
               info(
                 OUT_OF_BAILIWICK_ADDR_MISMATCH => {
-                    parent_addresses => join( q{;}, sort @glue_strings ),
-                    zone_addresses => join( q{;}, sort keys %child_oob_strings ),
+                    ns_list_parent => join( q{;}, sort @glue_strings ),
+                    ns_list_zone  => join( q{;}, sort keys %child_oob_strings ),
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -200,11 +200,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NS_SET => sub {
         __x    # CONSISTENCY:NS_SET
-          'Saw NS set ({nsset}) on following nameserver set : {ns_list}.', @_;
+          'Saw NS set ({nsname_list_response}) on following nameserver set : {ns_list_servers}.', @_;
     },
     ONE_NS_SET => sub {
         __x    # CONSISTENCY:ONE_NS_SET
-          "A single NS set was found ({nsset}).", @_;
+          "A single NS set was found ({nsname_list}).", @_;
     },
     ONE_SOA_MNAME => sub {
         __x    # CONSISTENCY:ONE_SOA_MNAME
@@ -596,18 +596,13 @@ sub consistency04 {
             next;
         }
         else {
-            push @{ $ns_sets{ join( q{,}, @ns ) } }, $local_ns->string;
+            push @{ $ns_sets{ join( q{;}, @ns ) } }, $local_ns->string;
             $nsnames_and_ip{ $local_ns->string }++;
         }
     } ## end foreach my $local_ns ( @{ Zonemaster::Engine::TestMethods...})
 
     if ( scalar( keys %ns_sets ) == 1 ) {
-        push @results,
-          info(
-            ONE_NS_SET => {
-                nsset => ( keys %ns_sets )[0],
-            }
-          );
+        push @results, info( ONE_NS_SET => { nsname_list => ( keys %ns_sets )[0] });
     }
     elsif ( scalar( keys %ns_sets ) ) {
         push @results,
@@ -620,8 +615,8 @@ sub consistency04 {
             push @results,
               info(
                 NS_SET => {
-                    nsset   => $ns_set,
-                    ns_list => join( q{;}, @{ $ns_sets{$ns_set} } ),
+                    nsname_list_response => $ns_set,
+                    ns_list_servers      => join( q{;}, @{ $ns_sets{$ns_set} } ),
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -200,7 +200,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NS_SET => sub {
         __x    # CONSISTENCY:NS_SET
-          'Saw NS set ({nsset}) on following nameserver set : {servers}.', @_;
+          'Saw NS set ({nsname_list}) on following nameserver set : {servers}.', @_;
     },
     ONE_NS_SET => sub {
         __x    # CONSISTENCY:ONE_NS_SET
@@ -615,8 +615,8 @@ sub consistency04 {
             push @results,
               info(
                 NS_SET => {
-                    nsset   => $ns_set,
-                    servers => join( q{;}, @{ $ns_sets{$ns_set} } ),
+                    nsname_list => $ns_set,
+                    servers     => join( q{;}, @{ $ns_sets{$ns_set} } ),
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -155,7 +155,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     IN_BAILIWICK_ADDR_MISMATCH => sub {
         __x    # CONSISTENCY:IN_BAILIWICK_ADDR_MISMATCH
           'In-bailiwick name server listed at parent has a mismatch between glue data at parent '
-          . '({ns_list_parent}) and any equivalent address record in child zone ({ns_list_zone}).',
+          . '({parent_addresses}) and any equivalent address record in child zone ({zone_addresses}).',
           @_;
     },
     IPV4_DISABLED => sub {
@@ -200,7 +200,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NS_SET => sub {
         __x    # CONSISTENCY:NS_SET
-          'Saw NS set ({nsname_list_response}) on following nameserver set : {ns_list_servers}.', @_;
+          'Saw NS set ({nsset}) on following nameserver set : {servers}.', @_;
     },
     ONE_NS_SET => sub {
         __x    # CONSISTENCY:ONE_NS_SET
@@ -227,8 +227,8 @@ Readonly my %TAG_DESCRIPTIONS => (
     OUT_OF_BAILIWICK_ADDR_MISMATCH => sub {
         __x    # CONSISTENCY:OUT_OF_BAILIWICK_ADDR_MISMATCH
           'Out-of-bailiwick name server listed at parent with glue record has a mismatch between '
-          . 'the glue at the parent ({ns_list_parent}) and any equivalent address record found '
-          . 'in authoritative zone ({ns_list_zone}).', @_;
+          . 'the glue at the parent ({parent_addresses}) and any equivalent address record found '
+          . 'in authoritative zone ({zone_addresses}).', @_;
     },
     SOA_RNAME => sub {
         __x    # CONSISTENCY:SOA_RNAME
@@ -615,8 +615,8 @@ sub consistency04 {
             push @results,
               info(
                 NS_SET => {
-                    nsname_list_response => $ns_set,
-                    ns_list_servers      => join( q{;}, @{ $ns_sets{$ns_set} } ),
+                    nsset   => $ns_set,
+                    servers => join( q{;}, @{ $ns_sets{$ns_set} } ),
                 }
               );
         }
@@ -731,8 +731,8 @@ sub consistency05 {
         push @results,
           info(
             IN_BAILIWICK_ADDR_MISMATCH => {
-                ns_list_parent => join( q{;}, sort keys %strict_glue ),
-                ns_list_zone  => join( q{;}, sort keys %child_ib_strings ),
+                parent_addresses => join( q{;}, sort keys %strict_glue ),
+                zone_addresses => join( q{;}, sort keys %child_ib_strings ),
             }
           );
     }
@@ -772,8 +772,8 @@ sub consistency05 {
             push @results,
               info(
                 OUT_OF_BAILIWICK_ADDR_MISMATCH => {
-                    ns_list_parent => join( q{;}, sort @glue_strings ),
-                    ns_list_zone  => join( q{;}, sort keys %child_oob_strings ),
+                    parent_addresses => join( q{;}, sort @glue_strings ),
+                    zone_addresses => join( q{;}, sort keys %child_oob_strings ),
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -150,11 +150,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     EXTRA_ADDRESS_CHILD => sub {
         __x    # CONSISTENCY:EXTRA_ADDRESS_CHILD
-          'Child has extra nameserver IP address(es) not listed at parent ({addresses}).', @_;
-    },
-    EXTRA_ADDRESS_PARENT => sub {
-        __x    # CONSISTENCY:EXTRA_ADDRESS_PARENT
-          'Parent has extra nameserver IP address(es) not listed at child ({addresses}).', @_;
+          'Child has extra nameserver IP address(es) not listed at parent ({ns_ip_list}).', @_;
     },
     IN_BAILIWICK_ADDR_MISMATCH => sub {
         __x    # CONSISTENCY:IN_BAILIWICK_ADDR_MISMATCH
@@ -749,7 +745,7 @@ sub consistency05 {
         push @results,
           info(
             EXTRA_ADDRESS_CHILD => {
-                addresses => join( q{;}, sort @ib_extra_child ),
+                ns_ip_list => join( q{;}, sort @ib_extra_child ),
             }
           );
     }
@@ -789,12 +785,7 @@ sub consistency05 {
     } ## end for my $glue_name ( keys...)
 
     if ( !@ib_extra_child && !@ib_mismatch && !@oob_mismatch ) {
-        push @results,
-          info(
-            ADDRESSES_MATCH => {
-                addresses => join( q{;}, sort @ib_match, @oob_match ),
-            }
-          );
+        push @results, info( ADDRESSES_MATCH => {} );
     }
 
     return ( @results, info( TEST_CASE_END => { testcase => (split /::/, (caller(0))[3])[-1] } ) );

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -138,7 +138,7 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     ARE_AUTHORITATIVE => sub {
         __x    # DELEGATION:ARE_AUTHORITATIVE
-          "All these nameservers are confirmed to be authoritative : {nsset}.", @_;
+          "All these nameservers are confirmed to be authoritative : {nsname_list}.", @_;
     },
     CHILD_DISTINCT_NS_IP => sub {
         __x    # DELEGATION:CHILD_DISTINCT_NS_IP
@@ -643,7 +643,7 @@ sub delegation04 {
         push @results,
           info(
             ARE_AUTHORITATIVE => {
-                nsset => join( q{,}, uniq sort @authoritatives ),
+                nsname_list => join( q{;}, uniq sort @authoritatives ),
             }
           );
     }

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -163,25 +163,25 @@ Readonly my %TAG_DESCRIPTIONS => (
     ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_IPV4_NS_CHILD
           "Child lists enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv4 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV4_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_IPV4_NS_DEL
           "Delegation lists enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv4 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV6_NS_CHILD => sub {
         __x    # DELEGATION:ENOUGH_IPV6_NS_CHILD
           "Child lists enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv6 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_IPV6_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_IPV6_NS_DEL
           "Delegation lists enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv6 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     ENOUGH_NS_CHILD => sub {
@@ -223,25 +223,25 @@ Readonly my %TAG_DESCRIPTIONS => (
     NOT_ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV4_NS_CHILD
           "Child does not list enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv4 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV4_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV4_NS_DEL
           "Delegation does not list enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv4 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv4 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV6_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV6_NS_CHILD
           "Child does not list enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv6 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_IPV6_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV6_NS_DEL
           "Delegation does not list enough ({count}) nameservers ({nsname_list}) "
-          . "that resolve to IPv6 addresses ({addrs}). Lower limit set to {minimum}.",
+          . "that resolve to IPv6 addresses ({ns_ip_list}). Lower limit set to {minimum}.",
           @_;
     },
     NOT_ENOUGH_NS_CHILD => sub {
@@ -384,13 +384,13 @@ sub delegation01 {
         count       => scalar( @child_ns_ipv4 ),
         minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
         nsname_list => join( q{;}, sort @child_ns_ipv4 ),
-        addrs       => join( q{;}, sort @child_ns_ipv4_addrs ),
+        ns_ip_list  => join( q{;}, sort @child_ns_ipv4_addrs ),
     };
     my $child_ns_ipv6_args = {
         count       => scalar( @child_ns_ipv6 ),
         minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
         nsname_list => join( q{;}, sort @child_ns_ipv6 ),
-        addrs       => join( q{;}, sort @child_ns_ipv6_addrs ),
+        ns_ip_list  => join( q{;}, sort @child_ns_ipv6_addrs ),
     };
 
     if ( scalar( @child_ns_ipv4 ) >= $MINIMUM_NUMBER_OF_NAMESERVERS ) {
@@ -424,13 +424,13 @@ sub delegation01 {
         count       => scalar( @del_ns_ipv4 ),
         minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
         nsname_list => join( q{;}, sort @del_ns_ipv4 ),
-        addrs       => join( q{;}, sort @del_ns_ipv4_addrs ),
+        ns_ip_list  => join( q{;}, sort @del_ns_ipv4_addrs ),
     };
     my $del_ns_ipv6_args = {
         count       => scalar( @del_ns_ipv6 ),
         minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
         nsname_list => join( q{;}, sort @del_ns_ipv6 ),
-        addrs       => join( q{;}, sort @del_ns_ipv6_addrs ),
+        ns_ip_list  => join( q{;}, sort @del_ns_ipv6_addrs ),
     };
 
     if ( scalar( @del_ns_ipv4 ) >= $MINIMUM_NUMBER_OF_NAMESERVERS ) {

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -381,16 +381,16 @@ sub delegation01 {
     my @child_ns_ipv6_addrs = uniq map { $_->address->short } grep { $_->address->version == 6 } @child_ns;
 
     my $child_ns_ipv4_args = {
-        count   => scalar( @child_ns_ipv4 ),
-        minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        ns_list => join( q{;}, sort @child_ns_ipv4 ),
-        addrs   => join( q{;}, sort @child_ns_ipv4_addrs ),
+        count       => scalar( @child_ns_ipv4 ),
+        minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
+        nsname_list => join( q{;}, sort @child_ns_ipv4 ),
+        addrs       => join( q{;}, sort @child_ns_ipv4_addrs ),
     };
     my $child_ns_ipv6_args = {
-        count   => scalar( @child_ns_ipv6 ),
-        minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        ns_list => join( q{;}, sort @child_ns_ipv6 ),
-        addrs   => join( q{;}, sort @child_ns_ipv6_addrs ),
+        count       => scalar( @child_ns_ipv6 ),
+        minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
+        nsname_list => join( q{;}, sort @child_ns_ipv6 ),
+        addrs       => join( q{;}, sort @child_ns_ipv6_addrs ),
     };
 
     if ( scalar( @child_ns_ipv4 ) >= $MINIMUM_NUMBER_OF_NAMESERVERS ) {

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -190,7 +190,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ENOUGH_NS_DEL => sub {
         __x    # DELEGATION:ENOUGH_NS_DEL
-          "Parent lists enough ({count}) nameservers ({glue}). Lower limit set to {minimum}.", @_;
+          "Parent lists enough ({count}) nameservers ({nsname_list}). Lower limit set to {minimum}.", @_;
     },
     EXTRA_NAME_CHILD => sub {
         __x    # DELEGATION:EXTRA_NAME_CHILD
@@ -250,7 +250,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NOT_ENOUGH_NS_DEL => sub {
         __x    # DELEGATION:NOT_ENOUGH_NS_DEL
-          "Parent does not list enough ({count}) nameservers ({glue}). Lower limit set to {minimum}.", @_;
+          "Parent does not list enough ({count}) nameservers ({nsname_list}). Lower limit set to {minimum}.", @_;
     },
     NO_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:NO_IPV4_NS_CHILD
@@ -342,9 +342,9 @@ sub delegation01 {
     # Determine delegation NS names
     my @del_nsnames = map { $_->string } @{ Zonemaster::Engine::TestMethods->method2( $zone ) };
     my $del_nsnames_args = {
-        count   => scalar( @del_nsnames ),
-        minimum => $MINIMUM_NUMBER_OF_NAMESERVERS,
-        glue    => join( q{;}, sort @del_nsnames ),
+        count       => scalar( @del_nsnames ),
+        minimum     => $MINIMUM_NUMBER_OF_NAMESERVERS,
+        nsname_list => join( q{;}, sort @del_nsnames ),
     };
 
     # Check delegation NS names
@@ -352,8 +352,7 @@ sub delegation01 {
         push @results, info( ENOUGH_NS_DEL => $del_nsnames_args );
     }
     else {
-        push @results,
-          info( NOT_ENOUGH_NS_DEL => $del_nsnames_args );
+        push @results, info( NOT_ENOUGH_NS_DEL => $del_nsnames_args );
     }
 
     # Determine child NS names
@@ -369,8 +368,7 @@ sub delegation01 {
         push @results, info( ENOUGH_NS_CHILD => $child_nsnames_args );
     }
     else {
-        push @results,
-          info( NOT_ENOUGH_NS_CHILD => $child_nsnames_args );
+        push @results, info( NOT_ENOUGH_NS_CHILD => $child_nsnames_args );
     }
 
     # Determine child NS names with addresses

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -234,7 +234,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     AAAA_WELL_PROCESSED => sub {
         __x    # NAMESERVER:AAAA_WELL_PROCESSED
-          'The following nameservers answer AAAA queries without problems : {names}.', @_;
+          'The following nameservers answer AAAA queries without problems : {ns_list}.', @_;
     },
     A_UNEXPECTED_RCODE => sub {
         __x    # NAMESERVER:A_UNEXPECTED_RCODE
@@ -258,7 +258,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CAN_NOT_BE_RESOLVED => sub {
         __x    # NAMESERVER:CAN_NOT_BE_RESOLVED
-          'The following nameservers failed to resolve to an IP address : {names}.', @_;
+          'The following nameservers failed to resolve to an IP address : {nsname_list}.', @_;
     },
     CASE_QUERIES_RESULTS_DIFFER => sub {
         __x    # NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
@@ -311,7 +311,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     EDNS0_SUPPORT => sub {
         __x    # NAMESERVER:EDNS0_SUPPORT
-          'The following nameservers support EDNS0 : {names}.', @_;
+          'The following nameservers support EDNS0 : {ns_list}.', @_;
     },
     IPV4_DISABLED => sub {
         __x    # NAMESERVER:IPV4_DISABLED
@@ -347,7 +347,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_UPWARD_REFERRAL => sub {
         __x    # NAMESERVER:NO_UPWARD_REFERRAL
-          'None of the following nameservers returns an upward referral : {names}.', @_;
+          'None of the following nameservers returns an upward referral : {nsname_list}.', @_;
     },
     NS_ERROR => sub {
         __x    # NAMESERVER:NS_ERROR
@@ -539,7 +539,7 @@ sub nameserver02 {
         push @results,
           info(
             EDNS0_SUPPORT => {
-                names => join( q{,}, keys %nsnames_and_ip ),
+                ns_list => join( q{;}, keys %nsnames_and_ip ),
             }
           );
     }
@@ -719,7 +719,7 @@ sub nameserver05 {
         push @results,
           info(
             AAAA_WELL_PROCESSED => {
-                names => join( q{,}, keys %nsnames_and_ip ),
+                ns_list => join( q{;}, keys %nsnames_and_ip ),
             }
           );
     }
@@ -745,7 +745,7 @@ sub nameserver06 {
         push @results,
           info(
             CAN_NOT_BE_RESOLVED => {
-                names => join( q{,}, @all_nsnames_without_ip ),
+                nsname_list => join( q{;}, @all_nsnames_without_ip ),
             }
           );
     }
@@ -799,7 +799,7 @@ sub nameserver07 {
             push @results,
               info(
                 NO_UPWARD_REFERRAL => {
-                    names => join( q{,}, sort keys %nsnames ),
+                    nsname_list => join( q{;}, sort keys %nsnames ),
                 }
               );
         }


### PR DESCRIPTION
Renames a bunch more name server related message arguments. No new argument names are introduced, except suffixes are appended to previously documented names, in order to provide disambiguation and context.

One unused message is also removed. In one case unused arguments are removed from the construction of a message.

This is a step towards solving #713.