### PR TITLE
Fix locale initialization

### DIFF
--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -11,7 +11,7 @@ use Zonemaster::Engine;
 use Carp;
 use Locale::Messages qw[textdomain];
 use Locale::TextDomain qw[Zonemaster-Engine];
-use POSIX qw[setlocale LC_ALL LC_MESSAGES];
+use POSIX qw[setlocale LC_MESSAGES];
 use Readonly;
 
 use Moose;
@@ -137,21 +137,21 @@ around 'BUILDARGS' => sub {
 sub _init_locale {
     my $locale = setlocale( LC_MESSAGES, "" );
 
+    delete $ENV{LC_ALL};
+
     if ( !defined $locale ) {
         my $language = $ENV{LANGUAGE} // "";
         for my $value ( split /:/, $language ) {
             if ( $value ne "" && $value !~ /[.]/ ) {
                 $value .= ".UTF-8";
             }
-            $locale = setlocale( LC_ALL, $value );
+            $locale = setlocale( LC_MESSAGES, $value );
             if ( defined $locale ) {
                 last;
             }
         }
         $locale //= "C";
     }
-
-    delete $ENV{LC_ALL};
 
     return $locale;
 }

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -117,18 +117,16 @@ Readonly my %TAG_DESCRIPTIONS => (
 ### Builder Methods
 ###
 
-sub BUILD {
-    my ( $self ) = @_;
+around 'BUILDARGS' => sub {
+    my ( $orig, $class, %args ) = @_;
 
-    my $locale = $self->{locale} // _get_locale();
+    $args{locale} //= _get_locale();
 
     # Make sure LC_MESSAGES can be effectively set down the line.
     delete $ENV{LC_ALL};
 
-    $self->locale( $locale );
-
-    return $self;
-}
+    return $class->$orig( %args );
+};
 
 # Get the program's underlying LC_MESSAGES.
 #

--- a/share/Makefile
+++ b/share/Makefile
@@ -2,7 +2,7 @@
 .SUFFIXES: .po .mo
 .PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy touch-po update-po
 
-POFILES != find . -type f -name '*.po'
+POFILES != find . -maxdepth 1 -type f -name '*.po'
 MOFILES := $(POFILES:%.po=%.mo)
 POTFILE = Zonemaster-Engine.pot
 PMFILES != find ../lib -type f -name '*.pm' | sort


### PR DESCRIPTION
It seems #775 broke the initialization of the locale attribute. MooseX::Singleton doesn't call the BUILD method. This PR fixes that. It also fixes a problem on Debian 9 where setlocale() returns undef when the locale environment settings are invalid.

This also includes a drive-by improvement to share/Makefile.