### PR TITLE
Remove path from find output i share/Makefile

### DIFF
--- a/share/Makefile
+++ b/share/Makefile
@@ -2,7 +2,7 @@
 .SUFFIXES: .po .mo
 .PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy touch-po update-po
 
-POFILES != find . -maxdepth 1 -type f -name '*.po'
+POFILES != find . -maxdepth 1 -type f -name '*.po' -exec basename {} \;
 MOFILES := $(POFILES:%.po=%.mo)
 POTFILE = Zonemaster-Engine.pot
 PMFILES != find ../lib -type f -name '*.pm' | sort


### PR DESCRIPTION
FreeBSD make does not consider "./sv.po" (as returned by `find`) to be the same thing as "sv.po" as written as target in `make sv.po`. This PR fixes that by making `find` removing the path "./" before printing the file names. 