### PR TITLE
Make Translator::initialize() accept its arguments

### DIFF
--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -118,11 +118,11 @@ Readonly my %TAG_DESCRIPTIONS => (
 ###
 
 around 'BUILDARGS' => sub {
-    my ( $orig, $class, %args ) = @_;
+    my ( $orig, $class, $args ) = @_;
 
-    $args{locale} //= _init_locale();
+    $args->{locale} //= _init_locale();
 
-    return $class->$orig( %args );
+    return $class->$orig( $args );
 };
 
 # Get the program's underlying LC_MESSAGES and make sure it can be effectively

--- a/t/translator.t
+++ b/t/translator.t
@@ -29,7 +29,7 @@ my $entry = Zonemaster::Engine::Logger::Entry->new(
 
 like(
     $trans->to_string( $entry ),
-    qr'   0.\d\d INFO      Parent domain \'nothing.nowhere\' was found for the tested domain.',
+    qr'   \d+.\d\d INFO      Parent domain \'nothing.nowhere\' was found for the tested domain.',
     'string to_stringd as expected'
 );
 


### PR DESCRIPTION
Two issues are reported in #817. One warning and one failing unit test. The two are in fact related.

The problem stems from not handling arguments to Translator::BUILDARGS in the correct way. This procedure receives an arguments hashref, but the implementation expected an arguments hash. This mix-up made the locale argument sent from the unit test get discarded. Consequently the Translator didn't override the environment locale settings with the C locale. With LANG=fr_FR.UTF-8 in the environment, the test failed.

The fix is to make Translator::BUILDARGS expect an arguments hashref.

While solving this problem I also uncovered another problem. For some reason one of my VMs is extremely slow. The translator unit test sets up Engine and translates a message through it. On my development machine (CentOS 8) this message is tagged at around 0.14 seconds. For unknown reasons one of my other VMs (FreeBSD 11) is much slower. On that machine the message clocks in at about 0.90 seconds, or sometimes just above one second. If it's tagged at one second or later, the unit test fails. Performance is something this unit test is supposed to test. I added a commit to this PR to make the test performance independent.

Fixes #817.