### PR TITLE
Changed numeric sorting to lexically resolving issue #851

### DIFF
--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -391,9 +391,9 @@ sub connectivity03 {
     } ## end foreach my $v6ip ( @v6ips )
 
     @v4asns = uniq sort { $a <=> $b } @v4asns;
-    @v4asnsets = uniq sort { $a <=> $b } @v4asnsets;
+    @v4asnsets = uniq sort @v4asnsets;
     @v6asns = uniq sort { $a <=> $b } @v6asns;
-    @v6asnsets = uniq sort { $a <=> $b } @v6asnsets;
+    @v6asnsets = uniq sort @v6asnsets;
 
     if ( scalar @v4asns ) {
         if ( @v4asns == 1 ) {

--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -337,7 +337,7 @@ sub connectivity03 {
                     }
                   );
                 push @v4asns, @{$asnref};
-                push @v4asnsets, join( q{,}, sort @{$asnref} );
+                push @v4asnsets, join( q{,}, sort { $a <=> $b } @{$asnref} );
             }
             if ( $prefix ) {
                 push @results,
@@ -375,7 +375,7 @@ sub connectivity03 {
                     }
                   );
                 push @v6asns, @{$asnref};
-                push @v6asnsets, join( q{,}, sort @{$asnref} );
+                push @v6asnsets, join( q{,}, sort { $a <=> $b } @{$asnref} );
             }
             if ( $prefix ) {
                 push @results,


### PR DESCRIPTION
The elements in the list (array) in the sort expression are not guaranteed to be numerical. Changed to lexical sorting. Resolves issue #851.