### PR TITLE
Naming of domain message args

### DIFF
--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -7,6 +7,7 @@
 | algo_descr  | Text                 | The human readable description of a [DNSSEC algorithm].     |
 | algo_mnemo  | Text                 | The mnemonic of a [DNSSEC algorithm].                       |
 | algo_num    | Non-negative integer | The numeric value for a [DNSSEC algorithm].                 |
+| domain      | Domain name          | A domain name.                                              |
 | keytag      | Non-negative integer | A keytag for a DNSKEY record or a keytag used in a DS or RRSIG record. |
 | module      | A Zonemaster test module, or `all` | The name of a Zonemaster test module.         |
 | module_list | List of Zonemaster test modules | A list of Zonemaster test modules, separated by ":". |
@@ -29,7 +30,6 @@
 || DNSKEY key length| The key length for a DNSKEY. The interpretation of this value various quite a bit with the algorithm. Be careful when using it for algorithms that aren't RSA-based.|
 || DNSSEC delegation verification failure reason| A somewhat human-readable reason why the delegation step between the tested zone and its parent is not secure.|
 || DS digest type| The digest type used in a DS record.|
-| dname (?) | Domain name| A domain name.|
 | dlabel (?) | Domain name label| A single label from a domain name.|
 | dlength (?) | Domain name label length| The length of a domain name label.|
 || Duration in seconds| An integer number of seconds.|
@@ -56,8 +56,6 @@
 || Number of DNSKEY RRs in packet| The number of DNSKEY records found in a packet.|
 || Number of RRSIG RRs in packet| The number of RRSIG records found in a packet.|
 || Number of SOA RRs in packet| The number of SOA records found in a packet.|
-|| PTR query name| The domain name generated from an IP address for a reverse name lookup.|
-| pname (?) | Parent zone name| The name of a tested zone's parent zone.|
 || Protocol (UDP or TCP)| The protocol used for a query.|
 | rcode (?) | RCODE| An RCODE from a DNS packet.|
 || RFC reference| A reference to an RFC.|
@@ -79,7 +77,6 @@
 || Smallest SOA serial number seen| The smallest value seen in a SOA serial field in the tested zone.|
 || TLD| The name of a top-level domain.|
 || `time_t` value when RRSIG validation was attempted| The time when an RRSIG validation was attempted, in Unix `time_t` format.|
-| zname (?) | Zone name| The domain name of the zone being tested.|
 
 Message names maked with a question mark should not be considered stable.
 

--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -7,7 +7,7 @@
 | algo_descr  | Text                 | The human readable description of a [DNSSEC algorithm].     |
 | algo_mnemo  | Text                 | The mnemonic of a [DNSSEC algorithm].                       |
 | algo_num    | Non-negative integer | The numeric value for a [DNSSEC algorithm].                 |
-| domain      | Domain name          | A domain name.                                              |
+| domain      | Domain name          | A domain name. If nsname is also applicable, use that one instead. |
 | keytag      | Non-negative integer | A keytag for a DNSKEY record or a keytag used in a DS or RRSIG record. |
 | module      | A Zonemaster test module, or `all` | The name of a Zonemaster test module.         |
 | module_list | List of Zonemaster test modules | A list of Zonemaster test modules, separated by ":". |

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -392,7 +392,7 @@ sub _query {
             chomp( $msg );
             $msg =~ s/$trailing_info.*/\./;
             Zonemaster::Engine->logger->add( LOOKUP_ERROR =>
-                  { message => $msg, ns => "$self", name => "$name", type => $type, class => $href->{class} } );
+                  { message => $msg, ns => "$self", domain => "$name", type => $type, class => $href->{class} } );
             if ( not $href->{q{blacklisting_disabled}} ) {
                 $self->blacklisted->{ $flags{usevc} }{ $flags{dnssec} } = 1;
                 if ( !$flags{dnssec} ) {

--- a/lib/Zonemaster/Engine/Test.pm
+++ b/lib/Zonemaster/Engine/Test.pm
@@ -104,7 +104,7 @@ sub run_all_for {
         } ## end foreach my $mod ( __PACKAGE__...)
     } ## end if ( Zonemaster::Engine::Test::Basic...)
     else {
-        push @results, info( CANNOT_CONTINUE => { zone => $zone->name->string } );
+        push @results, info( CANNOT_CONTINUE => { domain => $zone->name->string } );
     }
 
     return @results;
@@ -146,7 +146,7 @@ sub run_module {
         }
     }
     else {
-        info( CANNOT_CONTINUE => { zone => $zone->name->string } );
+        info( CANNOT_CONTINUE => { domain => $zone->name->string } );
     }
 
     return;
@@ -200,7 +200,7 @@ sub run_one {
                 $zname = $arg->name;
             }
         }
-        info( CANNOT_CONTINUE => { zone => $zname } );
+        info( CANNOT_CONTINUE => { domain => $zname } );
     }
 
     return;

--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -103,7 +103,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE_PTR_QUERY => sub {
         __x    # ADDRESS:NO_RESPONSE_PTR_QUERY
-          'No response from nameserver(s) on PTR query ({reverse}).', @_;
+          'No response from nameserver(s) on PTR query ({domain}).', @_;
     },
     TEST_CASE_END => sub {
         __x    # ADDRESS:TEST_CASE_END
@@ -221,7 +221,7 @@ sub address02 {
             push @results,
               info(
                 NO_RESPONSE_PTR_QUERY => {
-                    reverse => $ptr_query,
+                    domain => $ptr_query,
                 }
               );
         }
@@ -289,7 +289,7 @@ sub address03 {
             push @results,
               info(
                 NO_RESPONSE_PTR_QUERY => {
-                    reverse => $ptr_query,
+                    domain => $ptr_query,
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -130,11 +130,11 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     DOMAIN_NAME_LABEL_TOO_LONG => sub {
         __x    # BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-          "Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max}).", @_;
+          "Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max}).", @_;
     },
     DOMAIN_NAME_ZERO_LENGTH_LABEL => sub {
         __x    # BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
-          "Domain name ({dname}) has a zero-length label.", @_;
+          "Domain name ({domain}) has a zero-length label.", @_;
     },
     DOMAIN_NAME_TOO_LONG => sub {
         __x    # BASIC:DOMAIN_NAME_TOO_LONG
@@ -150,11 +150,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     HAS_A_RECORDS => sub {
         __x    # BASIC:HAS_A_RECORDS
-          "Nameserver {ns} returned \"A\" record(s) for {dname}.", @_;
+          "Nameserver {ns} returned \"A\" record(s) for {domain}.", @_;
     },
     NO_A_RECORDS => sub {
         __x    # BASIC:NO_A_RECORDS
-          "Nameserver {ns} did not return \"A\" record(s) for {dname}.", @_;
+          "Nameserver {ns} did not return \"A\" record(s) for {domain}.", @_;
     },
     HAS_NAMESERVERS => sub {
         __x    # BASIC:HAS_NAMESERVERS
@@ -228,7 +228,7 @@ sub basic00 {
             push @results,
               info(
                 q{DOMAIN_NAME_LABEL_TOO_LONG} => {
-                    dname   => "$name",
+                    domain  => "$name",
                     dlabel  => $local_label,
                     dlength => length( $local_label ),
                     max     => $LABEL_MAX_LENGTH,
@@ -239,7 +239,7 @@ sub basic00 {
             push @results,
               info(
                 q{DOMAIN_NAME_ZERO_LENGTH_LABEL} => {
-                    dname => "$name",
+                    domain => "$name",
                 }
               );
         }
@@ -427,8 +427,8 @@ sub basic03 {
             push @results,
               info(
                 HAS_A_RECORDS => {
-                    ns    => $ns->string,
-                    dname => $name,
+                    ns     => $ns->string,
+                    domain => $name,
                 }
               );
         }
@@ -436,8 +436,8 @@ sub basic03 {
             push @results,
               info(
                 NO_A_RECORDS => {
-                    ns    => $ns->string,
-                    dname => $name,
+                    ns     => $ns->string,
+                    domain => $name,
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -256,10 +256,6 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # CONSISTENCY:TEST_CASE_START
           'TEST_CASE_START {testcase}.', @_;
     },
-    TOTAL_ADDRESS_MISMATCH => sub {
-        __x    # CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-          'No common nameserver IP addresses between child ({child}) and parent ({glue}).', @_;
-    },
 );
 
 sub tag_descriptions {

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -687,10 +687,6 @@ Readonly my %TAG_DESCRIPTIONS => (
           . 'Consistency is expected.',
           @_;
     },
-    INVALID_NAME_RCODE => sub {
-        __x    # DNSSEC:INVALID_NAME_RCODE
-          'When asked for the name {name}, which must not exist, the response had RCODE {rcode}.', @_;
-    },
     IPV4_DISABLED => sub {
         __x    # DNSSEC:IPV4_DISABLED
           'IPv4 is disabled, not sending "{rrtype}" query to {ns}.', @_;

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -1719,7 +1719,7 @@ sub dnssec10 {
                             foreach my $sig ( @sigs ) {
                                 my $msg = q{};
                                 if ( not scalar @dnskeys ) {
-                                    push @results, info( NSEC_SIG_VERIFY_ERROR => { error => q{DNSKEY missing}, sig => $sig->keytag } );
+                                    push @results, info( NSEC_SIG_VERIFY_ERROR => { error => q{DNSKEY missing}, keytag => $sig->keytag } );
                                 }
                                 elsif (
                                     $sig->verify_time(
@@ -1737,8 +1737,8 @@ sub dnssec10 {
                                     push @results,
                                       info(
                                         NSEC_SIG_VERIFY_ERROR => {
-                                            error => $msg,
-                                            sig   => $sig->keytag,
+                                            error  => $msg,
+                                            keytag => $sig->keytag,
                                         }
                                       );
                                 }

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -515,7 +515,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     BROKEN_DNSSEC => sub {
         __x    # DNSSEC:BROKEN_DNSSEC
-          'All nameservers for zone {zone} responds with neither NSEC nor NSEC3 records when such '
+          'All nameservers for zone {domain} responds with neither NSEC nor NSEC3 records when such '
           . 'records are expected.',
           @_;
     },
@@ -601,34 +601,34 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # DNSSEC:DS_ALGORITHM_NOT_DS
           '{ns} returned a DS record created by algorithm {algo_num} '
           . '({algo_mnemo}) which is not meant for DS. The DS record is for '
-          . 'the DNSKEY record with keytag {keytag} in zone {zone}.',
+          . 'the DNSKEY record with keytag {keytag} in zone {domain}.',
           @_;
     },
     DS_ALGORITHM_DEPRECATED => sub {
         __x    # DNSSEC:DS_ALGORITHM_DEPRECATED
           '{ns} returned a DS record created by algorithm {algo_num} '
           . '({algo_mnemo}), which is deprecated. The DS record is for the '
-          . 'DNSKEY record with keytag {keytag} in zone {zone}.',
+          . 'DNSKEY record with keytag {keytag} in zone {domain}.',
           @_;
     },
     DS_ALGORITHM_MISSING => sub {
         __x    # DNSSEC:DS_ALGORITHM_MISSING
           '{ns} returned no DS record created by algorithm {algo_num} '
-          . '({algo_mnemo}) for zone {zone}, which is required.',
+          . '({algo_mnemo}) for zone {domain}, which is required.',
           @_;
     },
     DS_ALGORITHM_OK => sub {
         __x    # DNSSEC:DS_ALGORITHM_OK
           '{ns} returned a DS record created by algorithm {algo_num} '
           . '({algo_mnemo}), which is OK. The DS record is for the DNSKEY '
-          . 'record with keytag {keytag} in zone {zone}.',
+          . 'record with keytag {keytag} in zone {domain}.',
           @_;
     },
     DS_ALGORITHM_RESERVED => sub {
         __x    # DNSSEC:DS_ALGORITHM_RESERVED
           '{ns} returned a DS record created by with an algorithm not assigned '
           . '(algorithm number {algo_num}), which is not OK. The DS record is '
-          . 'for the DNSKEY record with keytag {keytag} in zone {zone}.',
+          . 'for the DNSKEY record with keytag {keytag} in zone {domain}.',
           @_;
     },
     DS_ALGO_SHA1_DEPRECATED => sub {
@@ -636,7 +636,7 @@ Readonly my %TAG_DESCRIPTIONS => (
           'Nameserver {ns} returned a DS record created by algorithm '
           . '{algo_num} ({algo_mnemo}) which is deprecated, while it is still '
           . 'widely used. The DS record is for the DNSKEY record with keytag '
-          . '{keytag} in zone {zone}.',
+          . '{keytag} in zone {domain}.',
           @_;
     },
     DS_BUT_NOT_DNSKEY => sub {
@@ -677,13 +677,13 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     INCONSISTENT_DNSSEC => sub {
         __x    # DNSSEC:INCONSISTENT_DNSSEC
-          'Some, but not all, nameservers for zone {zone} respond with neither NSEC nor NSEC3 records when '
+          'Some, but not all, nameservers for zone {domain} respond with neither NSEC nor NSEC3 records when '
           . 'such records are expected.',
           @_;
     },
     INCONSISTENT_NSEC_NSEC3 => sub {
         __x    # DNSSEC:INCONSISTENT_NSEC_NSEC3
-          'Some nameservers for zone {zone} respond with NSEC records and others respond with NSEC3 records. '
+          'Some nameservers for zone {domain} respond with NSEC records and others respond with NSEC3 records. '
           . 'Consistency is expected.',
           @_;
     },
@@ -713,7 +713,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MIXED_NSEC_NSEC3 => sub {
         __x    # DNSSEC:MIXED_NSEC_NSEC3
-          'Nameserver {ns} for zone {zone} responds with both NSEC and NSEC3 '
+          'Nameserver {ns} for zone {domain} responds with both NSEC and NSEC3 '
           . 'records when only one record type is expected.',
           @_;
     },
@@ -754,8 +754,8 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_NSEC_NSEC3 => sub {
         __x    # DNSSEC:NO_NSEC_NSEC3
-          'Nameserver {ns} for zone {zone} responds with neither NSEC nor NSEC3 record when '
-          . 'when such records are expected.',
+          'Nameserver {ns} for zone {domain} responds with neither NSEC nor '
+          . 'NSEC3 record when when such records are expected.',
           @_;
     },
     NO_RESPONSE_DNSKEY => sub {
@@ -764,7 +764,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE_DS => sub {
         __x    # DNSSEC:NO_RESPONSE_DS
-          '{ns} returned no DS records for {zone}.', @_;
+          '{ns} returned no DS records for {domain}.', @_;
     },
     NO_RESPONSE_RRSET => sub {
         __x    # DNSSEC:NO_RESPONSE_RRSET
@@ -784,7 +784,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NSEC3_COVERS_NOT => sub {
         __x    # DNSSEC:NSEC3_COVERS_NOT
-          'NSEC3 record does not cover {name}.', @_;
+          'NSEC3 record does not cover {domain}.', @_;
     },
     NSEC3_NOT_SIGNED => sub {
         __x    # DNSSEC:NSEC3_NOT_SIGNED
@@ -796,7 +796,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NSEC_COVERS_NOT => sub {
         __x    # DNSSEC:NSEC_COVERS_NOT
-          'NSEC does not cover {name}.', @_;
+          'NSEC does not cover {domain}.', @_;
     },
     NSEC_NOT_SIGNED => sub {
         __x    # DNSSEC:NSEC_NOT_SIGNED
@@ -860,7 +860,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     TEST_ABORTED => sub {
         __x    # DNSSEC:TEST_ABORTED
-          'Nameserver {ns} for zone {zone} responds with RCODE "NOERROR" on a query that '
+          'Nameserver {ns} for zone {domain} responds with RCODE "NOERROR" on a query that '
           . 'is expected to give response with RCODE "NXDOMAIN". Test for NSEC and NSEC3 is aborted '
           . 'for this nameserver.',
           @_;
@@ -879,7 +879,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     UNEXPECTED_RESPONSE_DS => sub {
         __x    # DNSSEC:UNEXPECTED_RESPONSE_DS
-          'Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query for zone {zone}.', @_;
+          'Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query for zone {domain}.', @_;
     },
 );
 
@@ -929,8 +929,8 @@ sub dnssec01 {
                 push @results,
                   info(
                     NO_RESPONSE_DS => {
-                        ns   => $ns->string,
-                        zone => q{} . $zone->name,
+                        ns     => $ns->string,
+                        domain => q{} . $zone->name,
                     }
                   );
                 next;
@@ -939,9 +939,9 @@ sub dnssec01 {
                 push @results,
                   info(
                     UNEXPECTED_RESPONSE_DS => {
-                        ns    => $ns->string,
-                        zone  => q{} . $zone->name,
-                        rcode => $ds_p->rcode,
+                        ns     => $ns->string,
+                        domain => q{} . $zone->name,
+                        rcode  => $ds_p->rcode,
                     }
                   );
                 next;
@@ -956,7 +956,7 @@ sub dnssec01 {
                           info(
                             DS_ALGORITHM_NOT_DS => {
                                 ns         => $ns->string,
-                                zone       => q{} . $zone->name,
+                                domain     => q{} . $zone->name,
                                 keytag     => $ds->keytag,
                                 algo_num   => $ds->digtype,
                                 algo_mnemo => $mnemonic,
@@ -968,7 +968,7 @@ sub dnssec01 {
                           info(
                             DS_ALGO_SHA1_DEPRECATED => {
                                 ns         => $ns->string,
-                                zone       => q{} . $zone->name,
+                                domain     => q{} . $zone->name,
                                 keytag     => $ds->keytag,
                                 algo_num   => $ds->digtype,
                                 algo_mnemo => $mnemonic,
@@ -980,7 +980,7 @@ sub dnssec01 {
                           info(
                             DS_ALGORITHM_DEPRECATED => {
                                 ns         => $ns->string,
-                                zone       => q{} . $zone->name,
+                                domain     => q{} . $zone->name,
                                 keytag     => $ds->keytag,
                                 algo_num   => $ds->digtype,
                                 algo_mnemo => $mnemonic,
@@ -992,7 +992,7 @@ sub dnssec01 {
                           info(
                             DS_ALGORITHM_RESERVED => {
                                 ns         => $ns->string,
-                                zone       => q{} . $zone->name,
+                                domain     => q{} . $zone->name,
                                 keytag     => $ds->keytag,
                                 algo_num   => $ds->digtype,
                                 algo_mnemo => $mnemonic,
@@ -1005,7 +1005,7 @@ sub dnssec01 {
                           info(
                             DS_ALGORITHM_OK => {
                                 ns         => $ns->string,
-                                zone       => q{} . $zone->name,
+                                domain     => q{} . $zone->name,
                                 keytag     => $ds->keytag,
                                 algo_num   => $ds->digtype,
                                 algo_mnemo => $mnemonic,
@@ -1018,7 +1018,7 @@ sub dnssec01 {
                       info(
                         DS_ALGORITHM_MISSING => {
                             ns         => $ns->string,
-                            zone       => q{} . $zone->name,
+                            domain     => q{} . $zone->name,
                             algo_num   => 2,
                             algo_mnemo => $digest_algorithms{2},
                         }
@@ -1064,9 +1064,9 @@ sub dnssec02 {
                 push @results,
                   info(
                     UNEXPECTED_RESPONSE_DS => {
-                        ns    => $ns->string,
-                        zone  => q{} . $zone->name,
-                        rcode => $ds_p->rcode,
+                        ns     => $ns->string,
+                        domain => q{} . $zone->name,
+                        rcode  => $ds_p->rcode,
                     }
                   );
                 next;
@@ -1740,8 +1740,8 @@ sub dnssec10 {
             push @results,
               info(
                 TEST_ABORTED => {
-                    ns   => $ns->string,
-                    zone => $zone->name->string,
+                    ns     => $ns->string,
+                    domain => $zone->name->string,
                 }
               );
         }
@@ -1759,8 +1759,8 @@ sub dnssec10 {
                 push @results,
                   info(
                     MIXED_NSEC_NSEC3 => {
-                        ns   => $ns->string,
-                        zone => $zone->name->string,
+                        ns     => $ns->string,
+                        domain => $zone->name->string,
                     }
                   );
             }
@@ -1768,8 +1768,8 @@ sub dnssec10 {
                 push @results,
                   info(
                     NO_NSEC_NSEC3 => {
-                        ns   => $ns->string,
-                        zone => $zone->name->string,
+                        ns     => $ns->string,
+                        domain => $zone->name->string,
                     }
                   );
                 $no_dnssec_zone{$ns->address->short}++;
@@ -1822,7 +1822,7 @@ sub dnssec10 {
                     }
                 }
                 if ( not $covered ) {
-                    push @results, info( NSEC_COVERS_NOT => {} );
+                    push @results, info( NSEC_COVERS_NOT => { domain => $non_existent_domain_name } );
                 }
             }
             elsif ( not scalar @nsec and scalar @nsec3 ) {
@@ -1873,20 +1873,20 @@ sub dnssec10 {
                     }
                 }
                 if ( not $covered ) {
-                    push @results, info( NSEC3_COVERS_NOT => {} );
+                    push @results, info( NSEC3_COVERS_NOT => { domain => $non_existent_domain_name } );
                 }
             }
         }
     }
 
     if ( scalar keys %no_dnssec_zone and ( scalar keys %nsec_zone or scalar keys %nsec3_zone ) ) {
-        push @results, info( INCONSISTENT_DNSSEC => { zone => $zone->name->string } );
+        push @results, info( INCONSISTENT_DNSSEC => { domain => $zone->name->string } );
     }
     elsif ( scalar keys %no_dnssec_zone and not scalar keys %nsec_zone and not scalar keys %nsec3_zone ) {
-        push @results, info( BROKEN_DNSSEC => { zone => $zone->name->string } );
+        push @results, info( BROKEN_DNSSEC => { domain => $zone->name->string } );
     }
     elsif ( scalar keys %nsec_zone and scalar keys %nsec3_zone ) {
-        push @results, info( INCONSISTENT_NSEC_NSEC3 => { zone => $zone->name->string } );
+        push @results, info( INCONSISTENT_NSEC_NSEC3 => { domain => $zone->name->string } );
     }
     elsif ( scalar keys %nsec_zone and not grep { $_->tag eq q{MIXED_NSEC_NSEC3} } @results ) {
         push @results, info( HAS_NSEC => {} );

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -432,11 +432,13 @@ sub nameserver01 {
 
             my $p = $ns->query( $nonexistent_name, q{A}, { blacklisting_disabled => 1 } );
             if ( !$p ) {
-                my %name_args = (
-                    dname => $nonexistent_name,
-                    ns    => $ns->string,
-                );
-                push @results, info( NO_RESPONSE => \%name_args );
+                push @results,
+                  info(
+                    NO_RESPONSE => {
+                        ns    => $ns->string,
+                        dname => $nonexistent_name,
+                    }
+                  );
                 $is_no_recursor = 0;
             }
             else {

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -250,7 +250,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     BREAKS_ON_EDNS => sub {
         __x    # NAMESERVER:BREAKS_ON_EDNS
-          'No response from {ns} when EDNS is used in query asking for {dname}.', @_;
+          'No response from {ns} when EDNS is used in query asking for {domain}.', @_;
     },
     CAN_BE_RESOLVED => sub {
         __x    # NAMESERVER:CAN_BE_RESOLVED
@@ -262,11 +262,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CASE_QUERIES_RESULTS_DIFFER => sub {
         __x    # NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
-          'When asked for {type} records on "{query}" with different cases, all servers do not reply consistently.', @_;
+          'When asked for {type} records on "{domain}" with different cases, all servers do not reply consistently.', @_;
     },
     CASE_QUERIES_RESULTS_OK => sub {
         __x    # NAMESERVER:CASE_QUERIES_RESULTS_OK
-          'When asked for {type} records on "{query}" with different cases, all servers reply consistently.', @_;
+          'When asked for {type} records on "{domain}" with different cases, all servers reply consistently.', @_;
     },
     CASE_QUERY_DIFFERENT_ANSWER => sub {
         __x    # NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
@@ -282,7 +282,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CASE_QUERY_NO_ANSWER => sub {
         __x    # NAMESERVER:CASE_QUERY_NO_ANSWER
-          'When asked for {type} records on "{query}", nameserver {ns} returns nothing.', @_;
+          'When asked for {type} records on "{domain}", nameserver {ns} returns nothing.', @_;
     },
     CASE_QUERY_SAME_ANSWER => sub {
         __x    # NAMESERVER:CASE_QUERY_SAME_ANSWER
@@ -301,12 +301,12 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     EDNS_RESPONSE_WITHOUT_EDNS => sub {
         __x    # NAMESERVER:EDNS_RESPONSE_WITHOUT_EDNS
-          'Response without EDNS from {ns} on query with EDNS0 asking for {dname}.', @_;
+          'Response without EDNS from {ns} on query with EDNS0 asking for {domain}.', @_;
     },
     EDNS_VERSION_ERROR => sub {
         __x    # NAMESERVER:EDNS_VERSION_ERROR
           'Incorrect version of EDNS (expected 0) in response from {ns} '
-          . 'on query with EDNS (version 0) asking for {dname}.',
+          . 'on query with EDNS (version 0) asking for {domain}.',
           @_;
     },
     EDNS0_SUPPORT => sub {
@@ -343,7 +343,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE => sub {
         __x    # NAMESERVER:NO_RESPONSE
-          'No response from {ns} asking for {dname}.', @_;
+          'No response from {ns} asking for {domain}.', @_;
     },
     NO_UPWARD_REFERRAL => sub {
         __x    # NAMESERVER:NO_UPWARD_REFERRAL
@@ -355,11 +355,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     QNAME_CASE_INSENSITIVE => sub {
         __x    # NAMESERVER:QNAME_CASE_INSENSITIVE
-          'Nameserver {ns} does not preserve original case of the queried name ({dname}).', @_;
+          'Nameserver {ns} does not preserve original case of the queried name ({domain}).', @_;
     },
     QNAME_CASE_SENSITIVE => sub {
         __x    # NAMESERVER:QNAME_CASE_SENSITIVE
-          "Nameserver {ns} preserves original case of queried names ({dname}).", @_;
+          "Nameserver {ns} preserves original case of queried names ({domain}).", @_;
     },
     SAME_SOURCE_IP => sub {
         __x    # NAMESERVER:SAME_SOURCE_IP
@@ -435,8 +435,8 @@ sub nameserver01 {
                 push @results,
                   info(
                     NO_RESPONSE => {
-                        ns    => $ns->string,
-                        dname => $nonexistent_name,
+                        ns     => $ns->string,
+                        domain => $nonexistent_name,
                     }
                   );
                 $is_no_recursor = 0;
@@ -494,8 +494,8 @@ sub nameserver02 {
                 push @results,
                   info(
                     EDNS_RESPONSE_WITHOUT_EDNS => {
-                        ns    => $local_ns->string,
-                        dname => $zone->name,
+                        ns     => $local_ns->string,
+                        domain => $zone->name,
                     }
                   );
             }
@@ -503,8 +503,8 @@ sub nameserver02 {
                 push @results,
                   info(
                     EDNS_VERSION_ERROR => {
-                        ns    => $local_ns->string,
-                        dname => $zone->name,
+                        ns     => $local_ns->string,
+                        domain => $zone->name,
                     }
                   );
             }
@@ -518,8 +518,8 @@ sub nameserver02 {
                 push @results,
                   info(
                     BREAKS_ON_EDNS => {
-                        ns    => $local_ns->string,
-                        dname => $zone->name,
+                        ns     => $local_ns->string,
+                        domain => $zone->name,
                     }
                   );
             }
@@ -527,8 +527,8 @@ sub nameserver02 {
                 push @results,
                   info(
                     NO_RESPONSE => {
-                        ns    => $local_ns->string,
-                        dname => $zone->name,
+                        ns     => $local_ns->string,
+                        domain => $zone->name,
                     }
                   );
             }
@@ -665,8 +665,8 @@ sub nameserver05 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns    => $ns->string,
-                    dname => $zone->name,
+                    ns     => $ns->string,
+                    domain => $zone->name,
                 }
               );
         }
@@ -841,8 +841,8 @@ sub nameserver08 {
                 push @results,
                   info(
                     QNAME_CASE_SENSITIVE => {
-                        ns    => $local_ns->string,
-                        dname => $randomized_uc_name,
+                        ns     => $local_ns->string,
+                        domain => $randomized_uc_name,
                     }
                   );
             }
@@ -850,8 +850,8 @@ sub nameserver08 {
                 push @results,
                   info(
                     QNAME_CASE_INSENSITIVE => {
-                        ns    => $local_ns->string,
-                        dname => $randomized_uc_name,
+                        ns     => $local_ns->string,
+                        domain => $randomized_uc_name,
                     }
                   );
             }
@@ -968,9 +968,9 @@ sub nameserver09 {
             push @results,
               info(
                 CASE_QUERY_NO_ANSWER => {
-                    ns    => $local_ns->string,
-                    type  => $record_type,
-                    query => $p1 ? $randomized_uc_name1 : $randomized_uc_name2,
+                    ns     => $local_ns->string,
+                    type   => $record_type,
+                    domain => $p1 ? $randomized_uc_name1 : $randomized_uc_name2,
                 }
               );
         }
@@ -982,8 +982,8 @@ sub nameserver09 {
         push @results,
           info(
             CASE_QUERIES_RESULTS_OK => {
-                type  => $record_type,
-                query => $original_name,
+                type   => $record_type,
+                domain => $original_name,
             }
           );
     }
@@ -991,8 +991,8 @@ sub nameserver09 {
         push @results,
           info(
             CASE_QUERIES_RESULTS_DIFFER => {
-                type  => $record_type,
-                query => $original_name,
+                type   => $record_type,
+                domain => $original_name,
             }
           );
     }
@@ -1039,8 +1039,8 @@ sub nameserver10 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns    => $ns->string,
-                    dname => $zone->name,
+                    ns     => $ns->string,
+                    domain => $zone->name,
                 }
               );
         }
@@ -1095,8 +1095,8 @@ sub nameserver11 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns    => $ns->string,
-                    dname => $zone->name,
+                    ns     => $ns->string,
+                    domain => $zone->name,
                 }
               );
         }
@@ -1145,8 +1145,8 @@ sub nameserver12 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns    => $ns->string,
-                    dname => $zone->name,
+                    ns     => $ns->string,
+                    domain => $zone->name,
                 }
               );
         }
@@ -1194,8 +1194,8 @@ sub nameserver13 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns    => $ns->string,
-                    dname => $zone->name,
+                    ns     => $ns->string,
+                    domain => $zone->name,
                 }
               );
         }

--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -150,13 +150,13 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     DISCOURAGED_DOUBLE_DASH => sub {
         __x    # SYNTAX:DISCOURAGED_DOUBLE_DASH
-          'Domain name ({name}) has a label ({label}) with a double hyphen (\'--\') '
+          'Domain name ({domain}) has a label ({label}) with a double hyphen (\'--\') '
           . 'in position 3 and 4 (with a prefix which is not \'xn--\').',
           @_;
     },
     INITIAL_HYPHEN => sub {
         __x    # SYNTAX:INITIAL_HYPHEN
-          'Domain name ({name}) has a label ({label}) starting with an hyphen (\'-\').', @_;
+          'Domain name ({domain}) has a label ({label}) starting with an hyphen (\'-\').', @_;
     },
     IPV4_DISABLED => sub {
         __x    # SYNTAX:IPV4_DISABLED
@@ -168,75 +168,75 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MNAME_DISCOURAGED_DOUBLE_DASH => sub {
         __x    # SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
-          'SOA MNAME ({name}) has a label ({label}) with a double hyphen (\'--\') '
+          'SOA MNAME ({domain}) has a label ({label}) with a double hyphen (\'--\') '
           . 'in position 3 and 4 (with a prefix which is not \'xn--\').',
           @_;
     },
     MNAME_NON_ALLOWED_CHARS => sub {
         __x    # SYNTAX:MNAME_NON_ALLOWED_CHARS
-          'Found illegal characters in SOA MNAME ({name}).', @_;
+          'Found illegal characters in SOA MNAME ({domain}).', @_;
     },
     MNAME_NUMERIC_TLD => sub {
         __x    # SYNTAX:MNAME_NUMERIC_TLD
-          'SOA MNAME ({name}) within a \'numeric only\' TLD ({tld}).', @_;
+          'SOA MNAME ({domain}) within a \'numeric only\' TLD ({tld}).', @_;
     },
     MNAME_SYNTAX_OK => sub {
         __x    # SYNTAX:MNAME_SYNTAX_OK
-          'SOA MNAME ({name}) syntax is valid.', @_;
+          'SOA MNAME ({domain}) syntax is valid.', @_;
     },
     MX_DISCOURAGED_DOUBLE_DASH => sub {
         __x    # SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
-          'Domain name MX ({name}) has a label ({label}) with a double hyphen (\'--\') '
+          'Domain name MX ({domain}) has a label ({label}) with a double hyphen (\'--\') '
           . 'in position 3 and 4 (with a prefix which is not \'xn--\').',
           @_;
     },
     MX_NON_ALLOWED_CHARS => sub {
         __x    # SYNTAX:MX_NON_ALLOWED_CHARS
-          'Found illegal characters in MX ({name}).', @_;
+          'Found illegal characters in MX ({domain}).', @_;
     },
     MX_NUMERIC_TLD => sub {
         __x    # SYNTAX:MX_NUMERIC_TLD
-          'Domain name MX ({name}) within a \'numeric only\' TLD ({tld}).', @_;
+          'Domain name MX ({domain}) within a \'numeric only\' TLD ({tld}).', @_;
     },
     MX_SYNTAX_OK => sub {
         __x    # SYNTAX:MX_SYNTAX_OK
-          'Domain name MX ({name}) syntax is valid.', @_;
+          'Domain name MX ({domain}) syntax is valid.', @_;
     },
     NAMESERVER_DISCOURAGED_DOUBLE_DASH => sub {
         __x    # SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
-          'Nameserver ({name}) has a label ({label}) with a double hyphen (\'--\') '
+          'Nameserver ({domain}) has a label ({label}) with a double hyphen (\'--\') '
           . 'in position 3 and 4 (with a prefix which is not \'xn--\').',
           @_;
     },
     NAMESERVER_NON_ALLOWED_CHARS => sub {
         __x    # SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
-          'Found illegal characters in the nameserver ({name}).', @_;
+          'Found illegal characters in the nameserver ({domain}).', @_;
     },
     NAMESERVER_NUMERIC_TLD => sub {
         __x    # SYNTAX:NAMESERVER_NUMERIC_TLD
-          'Nameserver ({name}) within a \'numeric only\' TLD ({tld}).', @_;
+          'Nameserver ({domain}) within a \'numeric only\' TLD ({tld}).', @_;
     },
     NAMESERVER_SYNTAX_OK => sub {
         __x    # SYNTAX:NAMESERVER_SYNTAX_OK
-          'Nameserver ({name}) syntax is valid.', @_;
+          'Nameserver ({domain}) syntax is valid.', @_;
     },
     NON_ALLOWED_CHARS => sub {
         __x    # SYNTAX:NON_ALLOWED_CHARS
-          'Found illegal characters in the domain name ({name}).', @_;
+          'Found illegal characters in the domain name ({domain}).', @_;
     },
     NO_DOUBLE_DASH => sub {
         __x    # SYNTAX:NO_DOUBLE_DASH
-          'Domain name ({name}) has no label with a double hyphen (\'--\') '
+          'Domain name ({domain}) has no label with a double hyphen (\'--\') '
           . 'in position 3 and 4 (with a prefix which is not \'xn--\').',
           @_;
     },
     NO_ENDING_HYPHENS => sub {
         __x    # SYNTAX:NO_ENDING_HYPHENS
-          "Neither end of any label in the domain name ({name}) has a hyphen.", @_;
+          "Neither end of any label in the domain name ({domain}) has a hyphen.", @_;
     },
     NO_RESPONSE => sub {
         __x    # SYNTAX:NO_RESPONSE
-          'No response from {ns} asking for {dname}.', @_;
+          'No response from {ns} asking for {domain}.', @_;
     },
     NO_RESPONSE_MX_QUERY => sub {
         __x    # SYNTAX:NO_RESPONSE_MX_QUERY
@@ -248,7 +248,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ONLY_ALLOWED_CHARS => sub {
         __x    # SYNTAX:ONLY_ALLOWED_CHARS
-          'No illegal characters in the domain name ({name}).', @_;
+          'No illegal characters in the domain name ({domain}).', @_;
     },
     RNAME_MAIL_DOMAIN_INVALID => sub {
         __x    # SYNTAX:RNAME_MAIL_DOMAIN_INVALID
@@ -272,7 +272,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     TERMINAL_HYPHEN => sub {
         __x    # SYNTAX:TERMINAL_HYPHEN
-          "Domain name ({name}) has a label ({label}) ending with a hyphen ('-').", @_;
+          "Domain name ({domain}) has a label ({label}) ending with a hyphen ('-').", @_;
     },
     TEST_CASE_END => sub {
         __x    # SYNTAX:TEST_CASE_END
@@ -306,7 +306,7 @@ sub syntax01 {
         push @results,
           info(
             ONLY_ALLOWED_CHARS => {
-                name => $name,
+                domain => $name,
             }
           );
     }
@@ -314,7 +314,7 @@ sub syntax01 {
         push @results,
           info(
             NON_ALLOWED_CHARS => {
-                name => $name,
+                domain => $name,
             }
           );
     }
@@ -333,8 +333,8 @@ sub syntax02 {
             push @results,
               info(
                 INITIAL_HYPHEN => {
-                    label => $local_label,
-                    name  => $name,
+                    label  => $local_label,
+                    domain => $name,
                 }
               );
         }
@@ -342,8 +342,8 @@ sub syntax02 {
             push @results,
               info(
                 TERMINAL_HYPHEN => {
-                    label => $local_label,
-                    name  => $name,
+                    label  => $local_label,
+                    domain => $name,
                 }
               );
         }
@@ -353,7 +353,7 @@ sub syntax02 {
         push @results,
           info(
             NO_ENDING_HYPHENS => {
-                name => $name,
+                domain => $name,
             }
           );
     }
@@ -372,8 +372,8 @@ sub syntax03 {
             push @results,
               info(
                 DISCOURAGED_DOUBLE_DASH => {
-                    label => $local_label,
-                    name  => $name,
+                    label  => $local_label,
+                    domain => $name,
                 }
               );
         }
@@ -383,7 +383,7 @@ sub syntax03 {
         push @results,
           info(
             NO_DOUBLE_DASH => {
-                name => $name,
+                domain => $name,
             }
           );
     }
@@ -482,8 +482,8 @@ sub syntax06 {
             push @results,
               info(
                 NO_RESPONSE => {
-                    ns    => $ns->string,
-                    dname => $zone->name,
+                    ns     => $ns->string,
+                    domain => $zone->name,
                 }
               );
             next;
@@ -711,7 +711,7 @@ sub check_name_syntax {
           info(
             $info_label_prefix
               . q{_NON_ALLOWED_CHARS} => {
-                name => $name,
+                domain => $name,
               }
           );
     }
@@ -724,8 +724,8 @@ sub check_name_syntax {
                   info(
                     $info_label_prefix
                       . q{_DISCOURAGED_DOUBLE_DASH} => {
-                        label => $local_label,
-                        name  => "$name",
+                        label  => $local_label,
+                        domain => "$name",
                       }
                   );
             }
@@ -737,8 +737,8 @@ sub check_name_syntax {
               info(
                 $info_label_prefix
                   . q{_NUMERIC_TLD} => {
-                    name => "$name",
-                    tld  => $tld,
+                    domain => "$name",
+                    tld    => $tld,
                   }
               );
         }
@@ -750,7 +750,7 @@ sub check_name_syntax {
           info(
             $info_label_prefix
               . q{_SYNTAX_OK} => {
-                name => "$name",
+                domain => "$name",
               }
           );
     }

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -31,10 +31,6 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # SYSTEM:CANNOT_CONTINUE
           "Not enough data about {zone} was found to be able to run tests.", @_;
     },
-    PROFILE_FILE => sub {
-        __x    # SYSTEM:PROFILE_FILE
-          "Profile was read from {name}.", @_;
-    },
     DEPENDENCY_VERSION => sub {
         __x    # SYSTEM:DEPENDENCY_VERSION
           "Using prerequisite module {name} version {version}.", @_;

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -29,7 +29,7 @@ has '_last_language'       => ( is => 'rw', isa => 'Str', builder => '_build_las
 Readonly my %TAG_DESCRIPTIONS => (
     CANNOT_CONTINUE => sub {
         __x    # SYSTEM:CANNOT_CONTINUE
-          "Not enough data about {zone} was found to be able to run tests.", @_;
+          "Not enough data about {domain} was found to be able to run tests.", @_;
     },
     DEPENDENCY_VERSION => sub {
         __x    # SYSTEM:DEPENDENCY_VERSION
@@ -45,7 +45,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     LOOKUP_ERROR => sub {
         __x    # SYSTEM:LOOKUP_ERROR
-          "DNS query to {ns} for {name}/{type}/{class} failed with error: {message}", @_;
+          "DNS query to {ns} for {domain}/{type}/{class} failed with error: {message}", @_;
     },
     MODULE_ERROR => sub {
         __x    # SYSTEM:MODULE_ERROR

--- a/share/da.po
+++ b/share/da.po
@@ -80,7 +80,7 @@ msgid "TEST_CASE_START {testcase}."
 msgstr "TEST_CASE_START {testcase}."
 
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
 msgstr ""
@@ -88,7 +88,7 @@ msgstr ""
 "({dlength}/{max})."
 
 #. BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Domain name ({domain}) has a zero-length label."
 msgstr "Domænenavnet ({domain}) har en label med længden nul."
 
@@ -107,12 +107,12 @@ msgid "Parent domain '{pname}' was found for the tested domain."
 msgstr "Forælder-domænet '{pname}' blev fundet for det testede domæne."
 
 #. BASIC:HAS_A_RECORDS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Nameserver {ns} returned \"A\" record(s) for {domain}."
 msgstr "Navneserveren {ns} svarede A-record(s) for {domain}."
 
 #. BASIC:NO_A_RECORDS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Nameserver {ns} did not return \"A\" record(s) for {domain}."
 msgstr "Navneserveren {ns} returnerede ikke nogle A-records for {domain}."
 
@@ -515,7 +515,7 @@ msgstr ""
 "i DNSKEY RRset-svaret."
 
 #. DNSSEC:BROKEN_DNSSEC
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "All nameservers for zone {domain} responds with neither NSEC nor NSEC3 "
 "records when such records are expected."
@@ -649,7 +649,7 @@ msgstr ""
 "record med keytag {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_DEPRECATED
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is deprecated. The DS record is for the DNSKEY record with keytag "
@@ -660,7 +660,7 @@ msgstr ""
 "keytag {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_MISSING
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "{ns} returned no DS record created by algorithm {algo_num} ({algo_mnemo}) "
 "for zone {domain}, which is required."
@@ -669,7 +669,7 @@ msgstr ""
 "({algo_mnemo}) for zonen {domain}, hvilket er krævet."
 
 #. DNSSEC:DS_ALGORITHM_OK
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is OK. The DS record is for the DNSKEY record with keytag {keytag} in "
@@ -680,7 +680,7 @@ msgstr ""
 "{keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_RESERVED
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by with an algorithm not assigned "
 "(algorithm number {algo_num}), which is not OK. The DS record is for the "
@@ -691,7 +691,7 @@ msgstr ""
 "DNSKEY-record med keytag {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGO_SHA1_DEPRECATED
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Nameserver {ns} returned a DS record created by algorithm {algo_num} "
 "({algo_mnemo}) which is deprecated, while it is still widely used. The DS "
@@ -755,7 +755,7 @@ msgid "The zone has NSEC records."
 msgstr "Zonen indeholder NSEC-records."
 
 #. DNSSEC:INCONSISTENT_DNSSEC
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Some, but not all, nameservers for zone {domain} respond with neither NSEC "
 "nor NSEC3 records when such records are expected."
@@ -764,7 +764,7 @@ msgstr ""
 "eller NSEC3-records selvom disse records er forventet i svaret."
 
 #. DNSSEC:INCONSISTENT_NSEC_NSEC3
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Some nameservers for zone {domain} respond with NSEC records and others "
 "respond with NSEC3 records. Consistency is expected."
@@ -856,7 +856,7 @@ msgid "{server} returned no NSEC3PARAM records."
 msgstr "{server} returnerede ingen NSEC3PARAM-records."
 
 #. DNSSEC:NO_NSEC_NSEC3
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Nameserver {ns} for zone {domain} responds with neither NSEC nor NSEC3 "
 "record when when such records are expected."
@@ -870,7 +870,7 @@ msgid "Nameserver {ns} responded with no DNSKEY record(s)."
 msgstr "Navneserveren {ns} returnerede ingen DNSKEY record(s)."
 
 #. DNSSEC:NO_RESPONSE_DS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "{ns} returned no DS records for {domain}."
 msgstr "{ns} returnerede ingen DS-records for {domain}."
 
@@ -997,7 +997,7 @@ msgid "At least one RRSIG correctly signs the SOA RRset."
 msgstr "Mindst en RRSIG-record signerer SOA RRset korrekt."
 
 #. DNSSEC:TEST_ABORTED
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Nameserver {ns} for zone {domain} responds with RCODE \"NOERROR\" on a query "
 "that is expected to give response with RCODE \"NXDOMAIN\". Test for NSEC and "
@@ -1017,7 +1017,7 @@ msgstr ""
 "nøglelængden {keylength}."
 
 #. DNSSEC:UNEXPECTED_RESPONSE_DS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query "
 "for zone {domain}."
@@ -1328,7 +1328,7 @@ msgid "AXFR not available on nameserver {ns}."
 msgstr "AXFR er ikke tilgængeligt på navneserveren {ns}."
 
 #. NAMESERVER:BREAKS_ON_EDNS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "No response from {ns} when EDNS is used in query asking for {domain}."
 msgstr "Intet svar fra {ns} når EDNS er brugt i forespørgslen på {domain}."
 
@@ -1344,7 +1344,7 @@ msgstr ""
 "IP-adresser bag følgende navneservere kunne ikke findes : {nsname_list}."
 
 #. NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "When asked for {type} records on \"{domain}\" with different cases, all "
 "servers do not reply consistently."
@@ -1353,7 +1353,7 @@ msgstr ""
 "recordtype {type} på \"{domain}\" med en blanding af versaler og minuskler."
 
 #. NAMESERVER:CASE_QUERIES_RESULTS_OK
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "When asked for {type} records on \"{domain}\" with different cases, all "
 "servers reply consistently."
@@ -1381,7 +1381,7 @@ msgstr ""
 "og \"{query2}\"."
 
 #. NAMESERVER:CASE_QUERY_NO_ANSWER
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "When asked for {type} records on \"{domain}\", nameserver {ns} returns "
 "nothing."
@@ -1417,13 +1417,13 @@ msgstr ""
 "({source})."
 
 #. NAMESERVER:EDNS_RESPONSE_WITHOUT_EDNS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Response without EDNS from {ns} on query with EDNS0 asking for {domain}."
 msgstr "Svar uden EDNS fra {ns} på foregspørgsel med EDNS0 efter {domain}."
 
 #. NAMESERVER:EDNS_VERSION_ERROR
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Incorrect version of EDNS (expected 0) in response from {ns} on query with "
 "EDNS (version 0) asking for {domain}."
@@ -1466,7 +1466,7 @@ msgstr "IP-adresse ikke fundet for nogen af navneserverne."
 
 #. NAMESERVER:NO_RESPONSE
 #. SYNTAX:NO_RESPONSE
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "No response from {ns} asking for {domain}."
 msgstr "Intet svar fra {ns} på forespørgsel om {domain}."
 
@@ -1484,7 +1484,7 @@ msgid "Erroneous response from nameserver {ns}."
 msgstr "Fejlagtigt svar fra navneserver {ns}."
 
 #. NAMESERVER:QNAME_CASE_INSENSITIVE
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Nameserver {ns} does not preserve original case of the queried name "
 "({domain})."
@@ -1493,7 +1493,7 @@ msgstr ""
 "({domain})."
 
 #. NAMESERVER:QNAME_CASE_SENSITIVE
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Nameserver {ns} preserves original case of queried names ({domain})."
 msgstr ""
 "Navneserveren {ns} bevarede versaler og minuskler fra forespørgslen "
@@ -1528,7 +1528,7 @@ msgid "Nameserver {ns} has one or more unknown EDNS Z flag bits set."
 msgstr "Navneserveren {ns} har et eller flere EDNS Z flag bits sat."
 
 #. SYNTAX:DISCOURAGED_DOUBLE_DASH
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
@@ -1537,7 +1537,7 @@ msgstr ""
 "og 4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:INITIAL_HYPHEN
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Domain name ({domain}) has a label ({label}) starting with an hyphen ('-')."
 msgstr ""
@@ -1545,7 +1545,7 @@ msgstr ""
 "bindestreg."
 
 #. SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "SOA MNAME ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
@@ -1554,22 +1554,22 @@ msgstr ""
 "(og et præfix som ikke er 'xn--'."
 
 #. SYNTAX:MNAME_NON_ALLOWED_CHARS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Found illegal characters in SOA MNAME ({domain})."
 msgstr "Fandt ulovlige tegn i SOA MNAME ({domain})."
 
 #. SYNTAX:MNAME_NUMERIC_TLD
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "SOA MNAME ({domain}) within a 'numeric only' TLD ({tld})."
 msgstr "SOA MNAME ({domain}) indeholder et 'numerisk' TLD ({tld})."
 
 #. SYNTAX:MNAME_SYNTAX_OK
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "SOA MNAME ({domain}) syntax is valid."
 msgstr "SOA MNAME ({domain}) syntaks er valid."
 
 #. SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Domain name MX ({domain}) has a label ({label}) with a double hyphen ('--') "
 "in position 3 and 4 (with a prefix which is not 'xn--')."
@@ -1578,22 +1578,22 @@ msgstr ""
 "4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:MX_NON_ALLOWED_CHARS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Found illegal characters in MX ({domain})."
 msgstr "Fandt ulovlige tegn i MX ({domain})."
 
 #. SYNTAX:MX_NUMERIC_TLD
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Domain name MX ({domain}) within a 'numeric only' TLD ({tld})."
 msgstr "Domænets MX ({domain}) indeholder et 'numerisk' TLD ({tld})."
 
 #. SYNTAX:MX_SYNTAX_OK
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Domain name MX ({domain}) syntax is valid."
 msgstr "Domænenavnets MX-record ({domain}) syntaks er valid."
 
 #. SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
@@ -1602,27 +1602,27 @@ msgstr ""
 "og 4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Found illegal characters in the nameserver ({domain})."
 msgstr "Fandt ulovlige tegn i navneservernavnet ({domain})."
 
 #. SYNTAX:NAMESERVER_NUMERIC_TLD
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Nameserver ({domain}) within a 'numeric only' TLD ({tld})."
 msgstr "Navneserveren ({domain}) indeholder et 'numerisk' TLD ({tld})."
 
 #. SYNTAX:NAMESERVER_SYNTAX_OK
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Nameserver ({domain}) syntax is valid."
 msgstr "Navneserveren ({domain}) - syntaks er valid."
 
 #. SYNTAX:NON_ALLOWED_CHARS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Found illegal characters in the domain name ({domain})."
 msgstr "Ulovlige tegn fundet i domænenavnet ({domain})."
 
 #. SYNTAX:NO_DOUBLE_DASH
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Domain name ({domain}) has no label with a double hyphen ('--') in position "
 "3 and 4 (with a prefix which is not 'xn--')."
@@ -1631,7 +1631,7 @@ msgstr ""
 "præfiks, der ikke er 'xn--')."
 
 #. SYNTAX:NO_ENDING_HYPHENS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Neither end of any label in the domain name ({domain}) has a hyphen."
 msgstr ""
 "Alle labels i domænenavnet ({domain}) begynder eller slutter ikke med "
@@ -1648,7 +1648,7 @@ msgid "No response from nameserver(s) on SOA queries."
 msgstr "Intet svar fra navneserver(ne) på forespørgsel på SOA-record."
 
 #. SYNTAX:ONLY_ALLOWED_CHARS
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "No illegal characters in the domain name ({domain})."
 msgstr "Udelukkende lovlige tegn i domænenavnet ({domain})."
 
@@ -1682,7 +1682,7 @@ msgid "The SOA RNAME field ({rname}) is compliant with RFC2822."
 msgstr "SOA RNAME værdi ({rname}) overholder RFC2822."
 
 #. SYNTAX:TERMINAL_HYPHEN
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "Domain name ({domain}) has a label ({label}) ending with a hyphen ('-')."
 msgstr ""
@@ -1770,7 +1770,7 @@ msgstr ""
 "({highest_minimum})."
 
 #. ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_LOWER
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "SOA 'minimum' value ({minimum}) is less than the recommended one "
 "({lowest_minimum})."
@@ -1888,7 +1888,7 @@ msgstr ""
 "{name}) på SOA forespørgsler."
 
 #. SYSTEM:CANNOT_CONTINUE
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid "Not enough data about {domain} was found to be able to run tests."
 msgstr ""
 "Kunne ikke finde tilstrækkeligt med information om {domain} til at afvikle "
@@ -1911,7 +1911,7 @@ msgstr ""
 "Callback-funktionen for log-modulet døde med fejlmeddelelsen: {exception}."
 
 #. SYSTEM:LOOKUP_ERROR
-#, fuzzy, perl-brace-format
+#, perl-brace-format
 msgid ""
 "DNS query to {ns} for {domain}/{type}/{class} failed with error: {message}"
 msgstr ""

--- a/share/da.po
+++ b/share/da.po
@@ -1533,15 +1533,16 @@ msgid ""
 "Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domænenavnet ({domain}) har en label ({label}) med bindestreg i position 3 og "
-"4, og et præfiks som ikke er 'xn--'."
+"Domænenavnet ({domain}) har en label ({label}) med bindestreg i position 3 "
+"og 4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:INITIAL_HYPHEN
 #, fuzzy, perl-brace-format
 msgid ""
 "Domain name ({domain}) has a label ({label}) starting with an hyphen ('-')."
 msgstr ""
-"Domænenavnet ({domain}) har en label ({label}) som begynder med en bindestreg."
+"Domænenavnet ({domain}) har en label ({label}) som begynder med en "
+"bindestreg."
 
 #. SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
 #, fuzzy, perl-brace-format
@@ -1597,8 +1598,8 @@ msgid ""
 "Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Navneserveren ({domain}) har en label ({label}) med bindestreg i position 3 og "
-"4, og et præfiks som ikke er 'xn--'."
+"Navneserveren ({domain}) har en label ({label}) med bindestreg i position 3 "
+"og 4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 #, fuzzy, perl-brace-format

--- a/share/da.po
+++ b/share/da.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-17 13:33+0100\n"
+"POT-Creation-Date: 2020-11-28 04:26+0100\n"
 "PO-Revision-Date: 2020-11-03 16:56+0100\n"
 "Last-Translator: Niels Haarbo <haarbo@dk-hostmaster.dk>\n"
 "Language-Team: Zonemaster Team\n"
@@ -50,8 +50,8 @@ msgstr "Alle PTR-records matcher navneservernavne."
 
 #. ADDRESS:NO_RESPONSE_PTR_QUERY
 #, perl-brace-format
-msgid "No response from nameserver(s) on PTR query ({reverse})."
-msgstr "Intet svar fra navneserverne på PTR-forespørgsel ({reverse})."
+msgid "No response from nameserver(s) on PTR query ({domain})."
+msgstr "Intet svar fra navneserverne på PTR-forespørgsel ({domain})."
 
 #. ADDRESS:TEST_CASE_END
 #. BASIC:TEST_CASE_END
@@ -80,17 +80,17 @@ msgid "TEST_CASE_START {testcase}."
 msgstr "TEST_CASE_START {testcase}."
 
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
 msgstr ""
-"Domænenavnet ({dname}) indeholder en label ({dlabel}), der er for lang "
+"Domænenavnet ({domain}) indeholder en label ({dlabel}), der er for lang "
 "({dlength}/{max})."
 
 #. BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
-#, perl-brace-format
-msgid "Domain name ({dname}) has a zero-length label."
-msgstr "Domænenavnet ({dname}) har en label med længden nul."
+#, fuzzy, perl-brace-format
+msgid "Domain name ({domain}) has a zero-length label."
+msgstr "Domænenavnet ({domain}) har en label med længden nul."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG
 #, perl-brace-format
@@ -107,14 +107,14 @@ msgid "Parent domain '{pname}' was found for the tested domain."
 msgstr "Forælder-domænet '{pname}' blev fundet for det testede domæne."
 
 #. BASIC:HAS_A_RECORDS
-#, perl-brace-format
-msgid "Nameserver {ns} returned \"A\" record(s) for {dname}."
-msgstr "Navneserveren {ns} svarede A-record(s) for {dname}."
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns} returned \"A\" record(s) for {domain}."
+msgstr "Navneserveren {ns} svarede A-record(s) for {domain}."
 
 #. BASIC:NO_A_RECORDS
-#, perl-brace-format
-msgid "Nameserver {ns} did not return \"A\" record(s) for {dname}."
-msgstr "Navneserveren {ns} returnerede ikke nogle A-records for {dname}."
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns} did not return \"A\" record(s) for {domain}."
+msgstr "Navneserveren {ns} returnerede ikke nogle A-records for {domain}."
 
 #. BASIC:HAS_NAMESERVERS
 #, perl-brace-format
@@ -430,15 +430,6 @@ msgstr ""
 "Så dette SOA-tidsparametersæt (REFRESH={refresh},RETRY={retry},"
 "EXPIRE={expire},MINIMUM={minimum}) på følgende navneservere : {ns_list}."
 
-#. CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-#, perl-brace-format
-msgid ""
-"No common nameserver IP addresses between child ({child}) and parent "
-"({glue})."
-msgstr ""
-"Ingen fælles IP-adresser på navneservere mellem barnet ({child}) og "
-"forælderen ({glue})."
-
 #. DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr "Ingen DNSKEY-records fundet. Yderligere tests ignoreret."
@@ -524,12 +515,12 @@ msgstr ""
 "i DNSKEY RRset-svaret."
 
 #. DNSSEC:BROKEN_DNSSEC
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"All nameservers for zone {zone} responds with neither NSEC nor NSEC3 records "
-"when such records are expected."
+"All nameservers for zone {domain} responds with neither NSEC nor NSEC3 "
+"records when such records are expected."
 msgstr ""
-"Alle navneservere for zonen {zone} svarede hverken NSEC- eller NSEC3-"
+"Alle navneservere for zonen {domain} svarede hverken NSEC- eller NSEC3-"
 "records, selvom de var forventede."
 
 #. DNSSEC:BROKEN_DS
@@ -651,64 +642,64 @@ msgstr ""
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}) "
 "which is not meant for DS. The DS record is for the DNSKEY record with "
-"keytag {keytag} in zone {zone}."
+"keytag {keytag} in zone {domain}."
 msgstr ""
 "{ns} returnerede en DS-record oprettet af algoritme {algo_num} "
 "({algo_mnemo}) som ikke er beregnet til DS. DS-recorden tilhører DNSKEY-"
-"record med keytag {keytag} i zonen {zone}."
+"record med keytag {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_DEPRECATED
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is deprecated. The DS record is for the DNSKEY record with keytag "
-"{keytag} in zone {zone}."
+"{keytag} in zone {domain}."
 msgstr ""
 "{ns} returnerede en DS-record oprettet af algoritme {algo_num} "
 "({algo_mnemo}), der er forældet. DS-recorden tilhører DNSKEY-record med "
-"keytag {keytag} i zonen {zone}."
+"keytag {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_MISSING
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "{ns} returned no DS record created by algorithm {algo_num} ({algo_mnemo}) "
-"for zone {zone}, which is required."
+"for zone {domain}, which is required."
 msgstr ""
 "{ns} returnerede ingen DS-record oprettet af algoritme {algo_num} "
-"({algo_mnemo}) for zonen {zone}, hvilket er krævet."
+"({algo_mnemo}) for zonen {domain}, hvilket er krævet."
 
 #. DNSSEC:DS_ALGORITHM_OK
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is OK. The DS record is for the DNSKEY record with keytag {keytag} in "
-"zone {zone}."
+"zone {domain}."
 msgstr ""
 "{ns} returnerede en DS-record oprettet af algoritme {algo_num} "
 "({algo_mnemo}), hvilket er OK. DS-recorden tilhører DNSKEY-record med keytag "
-"{keytag} i zonen {zone}."
+"{keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_RESERVED
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by with an algorithm not assigned "
 "(algorithm number {algo_num}), which is not OK. The DS record is for the "
-"DNSKEY record with keytag {keytag} in zone {zone}."
+"DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "{ns} returnerede en DS-record oprettet af algoritme, der ikke er tildelt "
 "(algoritmenummer {algo_num}, hvilket ikke er okay. DS-recorden tilhører "
-"DNSKEY-record med keytag {keytag} i zonen {zone}."
+"DNSKEY-record med keytag {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGO_SHA1_DEPRECATED
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "Nameserver {ns} returned a DS record created by algorithm {algo_num} "
 "({algo_mnemo}) which is deprecated, while it is still widely used. The DS "
-"record is for the DNSKEY record with keytag {keytag} in zone {zone}."
+"record is for the DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "Navneserveren {ns} returnerede en DS-record oprettet med algoritme "
 "{algo_num} ({algo_mnemo}) som er forældet, men stadigvæk benyttet af mange. "
-"DS-recorden er tilknyttet DNSKEY med keytag {keytag} i zonen {zone}."
+"DS-recorden er tilknyttet DNSKEY med keytag {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_BUT_NOT_DNSKEY
 #, perl-brace-format
@@ -764,31 +755,22 @@ msgid "The zone has NSEC records."
 msgstr "Zonen indeholder NSEC-records."
 
 #. DNSSEC:INCONSISTENT_DNSSEC
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Some, but not all, nameservers for zone {zone} respond with neither NSEC nor "
-"NSEC3 records when such records are expected."
+"Some, but not all, nameservers for zone {domain} respond with neither NSEC "
+"nor NSEC3 records when such records are expected."
 msgstr ""
-"Nogle, men ikke alle, navneservere for zonen {zone} svarede hverken NSEC- "
+"Nogle, men ikke alle, navneservere for zonen {domain} svarede hverken NSEC- "
 "eller NSEC3-records selvom disse records er forventet i svaret."
 
 #. DNSSEC:INCONSISTENT_NSEC_NSEC3
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Some nameservers for zone {zone} respond with NSEC records and others "
+"Some nameservers for zone {domain} respond with NSEC records and others "
 "respond with NSEC3 records. Consistency is expected."
 msgstr ""
-"Nogle af navneserverne for zonen {zone} returnerede NSEC-records og andre "
+"Nogle af navneserverne for zonen {domain} returnerede NSEC-records og andre "
 "returnerede NSEC3-records. Konsistens forventes."
-
-#. DNSSEC:INVALID_NAME_RCODE
-#, perl-brace-format
-msgid ""
-"When asked for the name {name}, which must not exist, the response had RCODE "
-"{rcode}."
-msgstr ""
-"Svaret på en forespørgsel om navnet {name}, som ikke må eksistere, "
-"returnerede RCODE {rcode}."
 
 #. DNSSEC:ITERATIONS_OK
 #, perl-brace-format
@@ -816,10 +798,10 @@ msgstr "Antallet af NSEC3-iterationer er {count}, hvilket er relativt højt."
 #. DNSSEC:MIXED_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with both NSEC and NSEC3 records "
+"Nameserver {ns} for zone {domain} responds with both NSEC and NSEC3 records "
 "when only one record type is expected."
 msgstr ""
-"Navneserveren {ns} for zonen {zone} svarede både NSEC- og NSEC3-records på "
+"Navneserveren {ns} for zonen {domain} svarede både NSEC- og NSEC3-records på "
 "trods af, at kun en recordtype er forventet i svaret."
 
 #. DNSSEC:NEITHER_DNSKEY_NOR_DS
@@ -874,12 +856,12 @@ msgid "{server} returned no NSEC3PARAM records."
 msgstr "{server} returnerede ingen NSEC3PARAM-records."
 
 #. DNSSEC:NO_NSEC_NSEC3
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with neither NSEC nor NSEC3 record "
-"when when such records are expected."
+"Nameserver {ns} for zone {domain} responds with neither NSEC nor NSEC3 "
+"record when when such records are expected."
 msgstr ""
-"Navneserveren {ns} for zonen {zone} svarede hverken NSEC- eller NSEC3-"
+"Navneserveren {ns} for zonen {domain} svarede hverken NSEC- eller NSEC3-"
 "records selvom disse records er forventet i svaret."
 
 #. DNSSEC:NO_RESPONSE_DNSKEY
@@ -888,9 +870,9 @@ msgid "Nameserver {ns} responded with no DNSKEY record(s)."
 msgstr "Navneserveren {ns} returnerede ingen DNSKEY record(s)."
 
 #. DNSSEC:NO_RESPONSE_DS
-#, perl-brace-format
-msgid "{ns} returned no DS records for {zone}."
-msgstr "{ns} returnerede ingen DS-records for {zone}."
+#, fuzzy, perl-brace-format
+msgid "{ns} returned no DS records for {domain}."
+msgstr "{ns} returnerede ingen DS-records for {domain}."
 
 #. DNSSEC:NO_RESPONSE_RRSET
 #, perl-brace-format
@@ -910,8 +892,8 @@ msgstr "Zonen er ikke signeret med DNSSEC."
 
 #. DNSSEC:NSEC3_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC3 record does not cover {name}."
-msgstr "NSEC3-record dækker ikke {name}."
+msgid "NSEC3 record does not cover {domain}."
+msgstr "NSEC3-record dækker ikke {domain}."
 
 #. DNSSEC:NSEC3_NOT_SIGNED
 msgid "No signature correctly signed the NSEC3 RRset."
@@ -926,8 +908,8 @@ msgstr ""
 
 #. DNSSEC:NSEC_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC does not cover {name}."
-msgstr "NSEC dækker ikke {name}."
+msgid "NSEC does not cover {domain}."
+msgstr "NSEC dækker ikke {domain}."
 
 #. DNSSEC:NSEC_NOT_SIGNED
 msgid "No signature correctly signed the NSEC RRset."
@@ -1015,13 +997,13 @@ msgid "At least one RRSIG correctly signs the SOA RRset."
 msgstr "Mindst en RRSIG-record signerer SOA RRset korrekt."
 
 #. DNSSEC:TEST_ABORTED
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with RCODE \"NOERROR\" on a query "
+"Nameserver {ns} for zone {domain} responds with RCODE \"NOERROR\" on a query "
 "that is expected to give response with RCODE \"NXDOMAIN\". Test for NSEC and "
 "NSEC3 is aborted for this nameserver."
 msgstr ""
-"Navneserveren {ns} bag zonen {zone} svarer RCODE \"NOERROR\" på en "
+"Navneserveren {ns} bag zonen {domain} svarer RCODE \"NOERROR\" på en "
 "forespørgsel som forventes at give svaret RCODE \"NXDOMAIN\". Test af NSEC "
 "and NSEC3 er afbrudt for denne navneserver."
 
@@ -1035,13 +1017,13 @@ msgstr ""
 "nøglelængden {keylength}."
 
 #. DNSSEC:UNEXPECTED_RESPONSE_DS
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"for zone {domain}."
 msgstr ""
 "Navneserveren {ns} besvarede DS-forespørgsel med en uventet RCODE ({rcode}) "
-"for zonen {zone}."
+"for zonen {domain}."
 
 #. DELEGATION:ARE_AUTHORITATIVE
 #, perl-brace-format
@@ -1346,9 +1328,9 @@ msgid "AXFR not available on nameserver {ns}."
 msgstr "AXFR er ikke tilgængeligt på navneserveren {ns}."
 
 #. NAMESERVER:BREAKS_ON_EDNS
-#, perl-brace-format
-msgid "No response from {ns} when EDNS is used in query asking for {dname}."
-msgstr "Intet svar fra {ns} når EDNS er brugt i forespørgslen på {dname}."
+#, fuzzy, perl-brace-format
+msgid "No response from {ns} when EDNS is used in query asking for {domain}."
+msgstr "Intet svar fra {ns} når EDNS er brugt i forespørgslen på {domain}."
 
 #. NAMESERVER:CAN_BE_RESOLVED
 msgid "All nameservers succeeded to resolve to an IP address."
@@ -1362,22 +1344,22 @@ msgstr ""
 "IP-adresser bag følgende navneservere kunne ikke findes : {nsname_list}."
 
 #. NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers do not reply consistently."
 msgstr ""
 "Ikke alle navneservere svarede konsistent på forespørgsler vedrørende "
-"recordtype {type} på \"{query}\" med en blanding af versaler og minuskler."
+"recordtype {type} på \"{domain}\" med en blanding af versaler og minuskler."
 
 #. NAMESERVER:CASE_QUERIES_RESULTS_OK
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers reply consistently."
 msgstr ""
 "Alle navneservere svarede konsistent på forespørgsler vedrørende recordtype "
-"{type} på \"{query}\" med en blanding af versaler og minuskler."
+"{type} på \"{domain}\" med en blanding af versaler og minuskler."
 
 #. NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
 #, perl-brace-format
@@ -1399,13 +1381,13 @@ msgstr ""
 "og \"{query2}\"."
 
 #. NAMESERVER:CASE_QUERY_NO_ANSWER
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\", nameserver {ns} returns "
+"When asked for {type} records on \"{domain}\", nameserver {ns} returns "
 "nothing."
 msgstr ""
 "Navneserveren {ns} returnerede intet svar på forespørgsel vedrørende "
-"recordtype {type} på \"{query}\"."
+"recordtype {type} på \"{domain}\"."
 
 #. NAMESERVER:CASE_QUERY_SAME_ANSWER
 #, perl-brace-format
@@ -1435,18 +1417,19 @@ msgstr ""
 "({source})."
 
 #. NAMESERVER:EDNS_RESPONSE_WITHOUT_EDNS
-#, perl-brace-format
-msgid "Response without EDNS from {ns} on query with EDNS0 asking for {dname}."
-msgstr "Svar uden EDNS fra {ns} på foregspørgsel med EDNS0 efter {dname}."
+#, fuzzy, perl-brace-format
+msgid ""
+"Response without EDNS from {ns} on query with EDNS0 asking for {domain}."
+msgstr "Svar uden EDNS fra {ns} på foregspørgsel med EDNS0 efter {domain}."
 
 #. NAMESERVER:EDNS_VERSION_ERROR
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "Incorrect version of EDNS (expected 0) in response from {ns} on query with "
-"EDNS (version 0) asking for {dname}."
+"EDNS (version 0) asking for {domain}."
 msgstr ""
 "Ugyldig version af EDNS (forventede 0) i svaret fra {ns} på forespørgsel via "
-"EDNS (version 0) efter {dname}."
+"EDNS (version 0) efter {domain}."
 
 #. NAMESERVER:EDNS0_SUPPORT
 #, perl-brace-format
@@ -1483,9 +1466,9 @@ msgstr "IP-adresse ikke fundet for nogen af navneserverne."
 
 #. NAMESERVER:NO_RESPONSE
 #. SYNTAX:NO_RESPONSE
-#, perl-brace-format
-msgid "No response from {ns} asking for {dname}."
-msgstr "Intet svar fra {ns} på forespørgsel om {dname}."
+#, fuzzy, perl-brace-format
+msgid "No response from {ns} asking for {domain}."
+msgstr "Intet svar fra {ns} på forespørgsel om {domain}."
 
 #. NAMESERVER:NO_UPWARD_REFERRAL
 #, perl-brace-format
@@ -1501,20 +1484,20 @@ msgid "Erroneous response from nameserver {ns}."
 msgstr "Fejlagtigt svar fra navneserver {ns}."
 
 #. NAMESERVER:QNAME_CASE_INSENSITIVE
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "Nameserver {ns} does not preserve original case of the queried name "
-"({dname})."
+"({domain})."
 msgstr ""
 "Navneserveren {ns} bevarede ikke versaler og minuskler fra forespørgslen "
-"({dname})."
+"({domain})."
 
 #. NAMESERVER:QNAME_CASE_SENSITIVE
-#, perl-brace-format
-msgid "Nameserver {ns} preserves original case of queried names ({dname})."
+#, fuzzy, perl-brace-format
+msgid "Nameserver {ns} preserves original case of queried names ({domain})."
 msgstr ""
 "Navneserveren {ns} bevarede versaler og minuskler fra forespørgslen "
-"({dname})."
+"({domain})."
 
 #. NAMESERVER:SAME_SOURCE_IP
 msgid "All nameservers reply with same IP used to query them."
@@ -1545,112 +1528,112 @@ msgid "Nameserver {ns} has one or more unknown EDNS Z flag bits set."
 msgstr "Navneserveren {ns} har et eller flere EDNS Z flag bits sat."
 
 #. SYNTAX:DISCOURAGED_DOUBLE_DASH
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domænenavnet ({name}) har en label ({label}) med bindestreg i position 3 og "
+"Domænenavnet ({domain}) har en label ({label}) med bindestreg i position 3 og "
 "4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:INITIAL_HYPHEN
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+"Domain name ({domain}) has a label ({label}) starting with an hyphen ('-')."
 msgstr ""
-"Domænenavnet ({name}) har en label ({label}) som begynder med en bindestreg."
+"Domænenavnet ({domain}) har en label ({label}) som begynder med en bindestreg."
 
 #. SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"SOA MNAME ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"SOA MNAME ({name}) har en label ({label}) med bindestreg i position 3 og 4 "
+"SOA MNAME ({domain}) har en label ({label}) med bindestreg i position 3 og 4 "
 "(og et præfix som ikke er 'xn--'."
 
 #. SYNTAX:MNAME_NON_ALLOWED_CHARS
-#, perl-brace-format
-msgid "Found illegal characters in SOA MNAME ({name})."
-msgstr "Fandt ulovlige tegn i SOA MNAME ({name})."
+#, fuzzy, perl-brace-format
+msgid "Found illegal characters in SOA MNAME ({domain})."
+msgstr "Fandt ulovlige tegn i SOA MNAME ({domain})."
 
 #. SYNTAX:MNAME_NUMERIC_TLD
-#, perl-brace-format
-msgid "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "SOA MNAME ({name}) indeholder et 'numerisk' TLD ({tld})."
+#, fuzzy, perl-brace-format
+msgid "SOA MNAME ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "SOA MNAME ({domain}) indeholder et 'numerisk' TLD ({tld})."
 
 #. SYNTAX:MNAME_SYNTAX_OK
-#, perl-brace-format
-msgid "SOA MNAME ({name}) syntax is valid."
-msgstr "SOA MNAME ({name}) syntaks er valid."
+#, fuzzy, perl-brace-format
+msgid "SOA MNAME ({domain}) syntax is valid."
+msgstr "SOA MNAME ({domain}) syntaks er valid."
 
 #. SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
-"position 3 and 4 (with a prefix which is not 'xn--')."
+"Domain name MX ({domain}) has a label ({label}) with a double hyphen ('--') "
+"in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domænets MX ({name}) har en label ({label}) med bindestreg i position 3 og "
+"Domænets MX ({domain}) har en label ({label}) med bindestreg i position 3 og "
 "4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:MX_NON_ALLOWED_CHARS
-#, perl-brace-format
-msgid "Found illegal characters in MX ({name})."
-msgstr "Fandt ulovlige tegn i MX ({name})."
+#, fuzzy, perl-brace-format
+msgid "Found illegal characters in MX ({domain})."
+msgstr "Fandt ulovlige tegn i MX ({domain})."
 
 #. SYNTAX:MX_NUMERIC_TLD
-#, perl-brace-format
-msgid "Domain name MX ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Domænets MX ({name}) indeholder et 'numerisk' TLD ({tld})."
+#, fuzzy, perl-brace-format
+msgid "Domain name MX ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "Domænets MX ({domain}) indeholder et 'numerisk' TLD ({tld})."
 
 #. SYNTAX:MX_SYNTAX_OK
-#, perl-brace-format
-msgid "Domain name MX ({name}) syntax is valid."
-msgstr "Domænenavnets MX-record ({name}) syntaks er valid."
+#, fuzzy, perl-brace-format
+msgid "Domain name MX ({domain}) syntax is valid."
+msgstr "Domænenavnets MX-record ({domain}) syntaks er valid."
 
 #. SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Navneserveren ({name}) har en label ({label}) med bindestreg i position 3 og "
+"Navneserveren ({domain}) har en label ({label}) med bindestreg i position 3 og "
 "4, og et præfiks som ikke er 'xn--'."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
-#, perl-brace-format
-msgid "Found illegal characters in the nameserver ({name})."
-msgstr "Fandt ulovlige tegn i navneservernavnet ({name})."
+#, fuzzy, perl-brace-format
+msgid "Found illegal characters in the nameserver ({domain})."
+msgstr "Fandt ulovlige tegn i navneservernavnet ({domain})."
 
 #. SYNTAX:NAMESERVER_NUMERIC_TLD
-#, perl-brace-format
-msgid "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Navneserveren ({name}) indeholder et 'numerisk' TLD ({tld})."
+#, fuzzy, perl-brace-format
+msgid "Nameserver ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "Navneserveren ({domain}) indeholder et 'numerisk' TLD ({tld})."
 
 #. SYNTAX:NAMESERVER_SYNTAX_OK
-#, perl-brace-format
-msgid "Nameserver ({name}) syntax is valid."
-msgstr "Navneserveren ({name}) - syntaks er valid."
+#, fuzzy, perl-brace-format
+msgid "Nameserver ({domain}) syntax is valid."
+msgstr "Navneserveren ({domain}) - syntaks er valid."
 
 #. SYNTAX:NON_ALLOWED_CHARS
-#, perl-brace-format
-msgid "Found illegal characters in the domain name ({name})."
-msgstr "Ulovlige tegn fundet i domænenavnet ({name})."
+#, fuzzy, perl-brace-format
+msgid "Found illegal characters in the domain name ({domain})."
+msgstr "Ulovlige tegn fundet i domænenavnet ({domain})."
 
 #. SYNTAX:NO_DOUBLE_DASH
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
-"and 4 (with a prefix which is not 'xn--')."
+"Domain name ({domain}) has no label with a double hyphen ('--') in position "
+"3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domænenavnet ({name}) indeholder ikke bindestreg i position 3 og 4 (med et "
+"Domænenavnet ({domain}) indeholder ikke bindestreg i position 3 og 4 (med et "
 "præfiks, der ikke er 'xn--')."
 
 #. SYNTAX:NO_ENDING_HYPHENS
-#, perl-brace-format
-msgid "Neither end of any label in the domain name ({name}) has a hyphen."
+#, fuzzy, perl-brace-format
+msgid "Neither end of any label in the domain name ({domain}) has a hyphen."
 msgstr ""
-"Alle labels i domænenavnet ({name}) begynder eller slutter ikke med "
+"Alle labels i domænenavnet ({domain}) begynder eller slutter ikke med "
 "bindestreg."
 
 #. SYNTAX:NO_RESPONSE_MX_QUERY
@@ -1664,9 +1647,9 @@ msgid "No response from nameserver(s) on SOA queries."
 msgstr "Intet svar fra navneserver(ne) på forespørgsel på SOA-record."
 
 #. SYNTAX:ONLY_ALLOWED_CHARS
-#, perl-brace-format
-msgid "No illegal characters in the domain name ({name})."
-msgstr "Udelukkende lovlige tegn i domænenavnet ({name})."
+#, fuzzy, perl-brace-format
+msgid "No illegal characters in the domain name ({domain})."
+msgstr "Udelukkende lovlige tegn i domænenavnet ({domain})."
 
 #. SYNTAX:RNAME_MAIL_DOMAIN_INVALID
 #, perl-brace-format
@@ -1698,10 +1681,11 @@ msgid "The SOA RNAME field ({rname}) is compliant with RFC2822."
 msgstr "SOA RNAME værdi ({rname}) overholder RFC2822."
 
 #. SYNTAX:TERMINAL_HYPHEN
-#, perl-brace-format
-msgid "Domain name ({name}) has a label ({label}) ending with a hyphen ('-')."
+#, fuzzy, perl-brace-format
+msgid ""
+"Domain name ({domain}) has a label ({label}) ending with a hyphen ('-')."
 msgstr ""
-"Domænenavnet ({name}) har en label ({label}) som slutter med en bindestreg."
+"Domænenavnet ({domain}) har en label ({label}) som slutter med en bindestreg."
 
 #. ZONE:RETRY_MINIMUM_VALUE_LOWER
 #, perl-brace-format
@@ -1785,7 +1769,7 @@ msgstr ""
 "({highest_minimum})."
 
 #. ZONE:SOA_DEFAULT_TTL_MAXIMUM_VALUE_LOWER
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
 "SOA 'minimum' value ({minimum}) is less than the recommended one "
 "({lowest_minimum})."
@@ -1903,16 +1887,11 @@ msgstr ""
 "{name}) på SOA forespørgsler."
 
 #. SYSTEM:CANNOT_CONTINUE
-#, perl-brace-format
-msgid "Not enough data about {zone} was found to be able to run tests."
+#, fuzzy, perl-brace-format
+msgid "Not enough data about {domain} was found to be able to run tests."
 msgstr ""
-"Kunne ikke finde tilstrækkeligt med information om {zone} til at afvikle "
+"Kunne ikke finde tilstrækkeligt med information om {domain} til at afvikle "
 "test."
-
-#. SYSTEM:PROFILE_FILE
-#, perl-brace-format
-msgid "Profile was read from {name}."
-msgstr "Profil blev hentet fra {name}."
 
 #. SYSTEM:DEPENDENCY_VERSION
 #, perl-brace-format
@@ -1931,11 +1910,11 @@ msgstr ""
 "Callback-funktionen for log-modulet døde med fejlmeddelelsen: {exception}."
 
 #. SYSTEM:LOOKUP_ERROR
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid ""
-"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+"DNS query to {ns} for {domain}/{type}/{class} failed with error: {message}"
 msgstr ""
-"DNS-forespørgsel til {ns} på {name}/{type}/{class} fejlede med beskeden: "
+"DNS-forespørgsel til {ns} på {domain}/{type}/{class} fejlede med beskeden: "
 "{message}."
 
 #. SYSTEM:MODULE_ERROR

--- a/share/fr.po
+++ b/share/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-17 13:33+0100\n"
+"POT-Creation-Date: 2020-11-28 04:26+0100\n"
 "PO-Revision-Date: 2020-09-07\n"
 "Last-Translator: vincent.levigneron@afnic.fr\n"
 "Language-Team: Zonemaster Team\n"
@@ -54,10 +54,10 @@ msgstr "Tous les enregistrements PTR correspondent aux serveurs de noms."
 
 #. ADDRESS:NO_RESPONSE_PTR_QUERY
 #, perl-brace-format
-msgid "No response from nameserver(s) on PTR query ({reverse})."
+msgid "No response from nameserver(s) on PTR query ({domain})."
 msgstr ""
 "Aucune réponse des serveurs de noms sur une requête de type \"PTR"
-"\" ({reverse})."
+"\" ({domain})."
 
 #. ADDRESS:TEST_CASE_END
 #. BASIC:TEST_CASE_END
@@ -88,15 +88,15 @@ msgstr "TEST_CASE_START {testcase}."
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
 msgstr ""
-"Le nom de domaine '{dname}' a un label ({dlabel}) trop long ({dlength}/"
+"Le nom de domaine '{domain}' a un label ({dlabel}) trop long ({dlength}/"
 "{max})."
 
 #. BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
 #, perl-brace-format
-msgid "Domain name ({dname}) has a zero-length label."
-msgstr "Le nom de domaine '{dname}' a un label de taille zéro."
+msgid "Domain name ({domain}) has a zero-length label."
+msgstr "Le nom de domaine '{domain}' a un label de taille zéro."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG
 #, perl-brace-format
@@ -115,17 +115,17 @@ msgstr ""
 
 #. BASIC:HAS_A_RECORDS
 #, perl-brace-format
-msgid "Nameserver {ns} returned \"A\" record(s) for {dname}."
+msgid "Nameserver {ns} returned \"A\" record(s) for {domain}."
 msgstr ""
 "Le serveur de noms {ns} renvoie un enregistrement de type \"A\" en réponse à "
-"une requête pour '{dname}'."
+"une requête pour '{domain}'."
 
 #. BASIC:NO_A_RECORDS
 #, perl-brace-format
-msgid "Nameserver {ns} did not return \"A\" record(s) for {dname}."
+msgid "Nameserver {ns} did not return \"A\" record(s) for {domain}."
 msgstr ""
 "Le serveur de noms {ns} ne renvoie pas d'enregistrement de type \"A\" en "
-"réponse à une requête pour '{dname}'."
+"réponse à une requête pour '{domain}'."
 
 #. BASIC:HAS_NAMESERVERS
 #, perl-brace-format
@@ -496,16 +496,6 @@ msgstr ""
 "EXPIRE={expire},MINIMUM={minimum}) a été récupérée sur les serveurs "
 "suivants : {ns_list}."
 
-#. CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-#, perl-brace-format
-msgid ""
-"No common nameserver IP addresses between child ({child}) and parent "
-"({glue})."
-msgstr ""
-"La liste des adresses IP des serveurs de nom retournée par les serveurs de "
-"noms de la zone parente ({glue}) et par ceux de la zone ({child}) est "
-"complètement différente."
-
 #. DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr ""
@@ -595,10 +585,10 @@ msgstr ""
 #. DNSSEC:BROKEN_DNSSEC
 #, perl-brace-format
 msgid ""
-"All nameservers for zone {zone} responds with neither NSEC nor NSEC3 records "
-"when such records are expected."
+"All nameservers for zone {domain} responds with neither NSEC nor NSEC3 "
+"records when such records are expected."
 msgstr ""
-"Aucun des serveurs de noms de la zone {zone} ne retourne d'enregistrements "
+"Aucun des serveurs de noms de la zone {domain} ne retourne d'enregistrements "
 "de type \"NSEC\" ou \"NSEC3\" alors que ceux-ci sont attendus."
 
 #. DNSSEC:BROKEN_DS
@@ -731,33 +721,33 @@ msgstr ""
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}) "
 "which is not meant for DS. The DS record is for the DNSKEY record with "
-"keytag {keytag} in zone {zone}."
+"keytag {keytag} in zone {domain}."
 msgstr ""
 "Le serveur de noms {ns} retourne un enregistrement de type \"DS\" créé à "
 "partir d'un algorithme ({algo_num}/{algo_mnemo}) qui n'est pas destiné à la "
 "signature. Cet enregistrement de type \"DS\" correspond à la clé (DNSKEY) "
-"avec le tag {keytag} dans la zone {zone}."
+"avec le tag {keytag} dans la zone {domain}."
 
 #. DNSSEC:DS_ALGORITHM_DEPRECATED
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is deprecated. The DS record is for the DNSKEY record with keytag "
-"{keytag} in zone {zone}."
+"{keytag} in zone {domain}."
 msgstr ""
 "Le serveur de noms {ns} retourne un enregistrement de type \"DS\" créé à "
 "partir d'un algorithme obsolète ({algo_num}/{algo_mnemo}), ce qui est "
 "incorrect. Cet enregistrement de type \"DS\" correspond à la clé (DNSKEY) "
-"avec le tag {keytag} dans la zone {zone}."
+"avec le tag {keytag} dans la zone {domain}."
 
 #. DNSSEC:DS_ALGORITHM_MISSING
 #, perl-brace-format
 msgid ""
 "{ns} returned no DS record created by algorithm {algo_num} ({algo_mnemo}) "
-"for zone {zone}, which is required."
+"for zone {domain}, which is required."
 msgstr ""
 "Le serveur de noms {ns} ne retourne aucun enregistrement de type \"DS\" créé "
-"à partir de l'algorithme {algo_num}/{algo_mnemo} pour la zone {zone}, alors "
+"à partir de l'algorithme {algo_num}/{algo_mnemo} pour la zone {domain}, alors "
 "que c'est nécessaire."
 
 #. DNSSEC:DS_ALGORITHM_OK
@@ -765,37 +755,37 @@ msgstr ""
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is OK. The DS record is for the DNSKEY record with keytag {keytag} in "
-"zone {zone}."
+"zone {domain}."
 msgstr ""
 "Le serveur de noms {ns} retourne un enregistrement de type \"DS\" créé à "
 "partir de l'algorithme ({algo_num}/{algo_mnemo}), ce qui est correct. Cet "
 "enregistrement de type \"DS\" correspond à la clé (DNSKEY) avec le tag "
-"{keytag} dans la zone {zone}."
+"{keytag} dans la zone {domain}."
 
 #. DNSSEC:DS_ALGORITHM_RESERVED
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by with an algorithm not assigned "
 "(algorithm number {algo_num}), which is not OK. The DS record is for the "
-"DNSKEY record with keytag {keytag} in zone {zone}."
+"DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "Le serveur de noms {ns} retourne un enregistrement de type \"DS\" créé à "
 "partir d'un algorithme non assigné ({algo_num}), ce qui est incorrect. Cet "
 "enregistrement de type \"DS\" correspond à la clé (DNSKEY) avec le tag "
-"{keytag} dans la zone {zone}."
+"{keytag} dans la zone {domain}."
 
 #. DNSSEC:DS_ALGO_SHA1_DEPRECATED
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} returned a DS record created by algorithm {algo_num} "
 "({algo_mnemo}) which is deprecated, while it is still widely used. The DS "
-"record is for the DNSKEY record with keytag {keytag} in zone {zone}."
+"record is for the DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "Le serveur de noms {ns} retourne un enregistrement de type \"DS\" créé à "
 "partir d'un algorithme obsolète ({algo_num}/{algo_mnemo}), ce qui est "
 "incorrect (bien que cet algorithme soit encore très largement utilisé). Cet "
 "enregistrement de type \"DS\" correspond à la clé (DNSKEY) avec le tag "
-"{keytag} dans la zone {zone}."
+"{keytag} dans la zone {domain}."
 
 #. DNSSEC:DS_BUT_NOT_DNSKEY
 #, perl-brace-format
@@ -859,31 +849,22 @@ msgstr "La zone a des enregistrements de type \"NSEC\"."
 #. DNSSEC:INCONSISTENT_DNSSEC
 #, perl-brace-format
 msgid ""
-"Some, but not all, nameservers for zone {zone} respond with neither NSEC nor "
-"NSEC3 records when such records are expected."
+"Some, but not all, nameservers for zone {domain} respond with neither NSEC "
+"nor NSEC3 records when such records are expected."
 msgstr ""
-"Certains serveurs de noms de la zone {zone}, mais pas tous, ne retournent "
+"Certains serveurs de noms de la zone {domain}, mais pas tous, ne retournent "
 "pas d'enregistrements de type \"NSEC\" ou \"NSEC3\" alors que ceux-ci "
 "étaient attendus."
 
 #. DNSSEC:INCONSISTENT_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Some nameservers for zone {zone} respond with NSEC records and others "
+"Some nameservers for zone {domain} respond with NSEC records and others "
 "respond with NSEC3 records. Consistency is expected."
 msgstr ""
-"Certains serveurs de noms de la zone {zone} retournent des enregistrements "
+"Certains serveurs de noms de la zone {domain} retournent des enregistrements "
 "de \"NSEC\" alors que d'autres retournent des enregistrements de type "
 "\"NSEC3\" ce qui n'est pas consistent."
-
-#. DNSSEC:INVALID_NAME_RCODE
-#, perl-brace-format
-msgid ""
-"When asked for the name {name}, which must not exist, the response had RCODE "
-"{rcode}."
-msgstr ""
-"Lors d'une requête sur un nom de domaine qui ne devrait pas exister "
-"({name}), on obtient une réponse avec le code retour (RCODE) {rcode}."
 
 #. DNSSEC:ITERATIONS_OK
 #, perl-brace-format
@@ -913,10 +894,10 @@ msgstr ""
 #. DNSSEC:MIXED_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with both NSEC and NSEC3 records "
+"Nameserver {ns} for zone {domain} responds with both NSEC and NSEC3 records "
 "when only one record type is expected."
 msgstr ""
-"Le serveur de noms {ns} pour la zone {zone} répond avec un mélange "
+"Le serveur de noms {ns} pour la zone {domain} répond avec un mélange "
 "d'enregistrements de types \"NSEC\" et \"NSEC3\" alors qu'un seul type est "
 "attendu."
 
@@ -982,10 +963,10 @@ msgstr ""
 #. DNSSEC:NO_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with neither NSEC nor NSEC3 record "
-"when when such records are expected."
+"Nameserver {ns} for zone {domain} responds with neither NSEC nor NSEC3 "
+"record when when such records are expected."
 msgstr ""
-"Le serveur de noms {ns} pour la zone {zone} ne répond avec aucun des "
+"Le serveur de noms {ns} pour la zone {domain} ne répond avec aucun des "
 "enregistrements de types \"NSEC\" ou \"NSEC3\" alors que c'est ce que l'on "
 "attend."
 
@@ -998,10 +979,10 @@ msgstr ""
 
 #. DNSSEC:NO_RESPONSE_DS
 #, perl-brace-format
-msgid "{ns} returned no DS records for {zone}."
+msgid "{ns} returned no DS records for {domain}."
 msgstr ""
 "Le serveur de noms {ns} ne retourne aucun enregistrement de type \"DS\" pour "
-"la zone '{zone}'."
+"la zone '{domain}'."
 
 #. DNSSEC:NO_RESPONSE_RRSET
 #, perl-brace-format
@@ -1024,8 +1005,8 @@ msgstr "La zone n'est pas signée avec DNSSEC."
 
 #. DNSSEC:NSEC3_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC3 record does not cover {name}."
-msgstr "NSEC3 ne couvre pas le nom {name}."
+msgid "NSEC3 record does not cover {domain}."
+msgstr "NSEC3 ne couvre pas le nom {domain}."
 
 #. DNSSEC:NSEC3_NOT_SIGNED
 msgid "No signature correctly signed the NSEC3 RRset."
@@ -1042,8 +1023,8 @@ msgstr ""
 
 #. DNSSEC:NSEC_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC does not cover {name}."
-msgstr "NSEC ne couvre pas le nom {name}."
+msgid "NSEC does not cover {domain}."
+msgstr "NSEC ne couvre pas le nom {domain}."
 
 #. DNSSEC:NSEC_NOT_SIGNED
 msgid "No signature correctly signed the NSEC RRset."
@@ -1149,11 +1130,11 @@ msgstr ""
 #. DNSSEC:TEST_ABORTED
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with RCODE \"NOERROR\" on a query "
+"Nameserver {ns} for zone {domain} responds with RCODE \"NOERROR\" on a query "
 "that is expected to give response with RCODE \"NXDOMAIN\". Test for NSEC and "
 "NSEC3 is aborted for this nameserver."
 msgstr ""
-"Le serveur de noms {ns} pour la zone {zone} répond avec un code retour "
+"Le serveur de noms {ns} pour la zone {domain} répond avec un code retour "
 "\"NOERROR\" alors que le code retour \"NXDOMAIN\" était attendu. La suite "
 "des tests \"NSEC\" et \"NSEC3\" est avortée pour ce serveur de nom."
 
@@ -1170,10 +1151,10 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"for zone {domain}."
 msgstr ""
 "Le serveur de noms {ns} a répondu à une requête de type \"AAAA\" avec un "
-"code retour inattendu ({rcode}) pour la zone '{zone}'."
+"code retour inattendu ({rcode}) pour la zone '{domain}'."
 
 #. DELEGATION:ARE_AUTHORITATIVE
 #, perl-brace-format
@@ -1515,9 +1496,9 @@ msgstr ""
 
 #. NAMESERVER:BREAKS_ON_EDNS
 #, perl-brace-format
-msgid "No response from {ns} when EDNS is used in query asking for {dname}."
+msgid "No response from {ns} when EDNS is used in query asking for {domain}."
 msgstr ""
-"Aucune réponse de {ns} sur le nom de domaine '{dname}' lorsque EDNS est "
+"Aucune réponse de {ns} sur le nom de domaine '{domain}' lorsque EDNS est "
 "utilisé."
 
 #. NAMESERVER:CAN_BE_RESOLVED
@@ -1537,20 +1518,20 @@ msgstr ""
 #. NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers do not reply consistently."
 msgstr ""
-"Lors d'une requête de type {type} pour la ressource \"{query}\" avec des "
+"Lors d'une requête de type {type} pour la ressource \"{domain}\" avec des "
 "casses différentes, tous les serveurs ne répondent pas de manière "
 "consistante."
 
 #. NAMESERVER:CASE_QUERIES_RESULTS_OK
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers reply consistently."
 msgstr ""
-"Lors d'une requête de type {type} pour la ressource \"{query}\" avec des "
+"Lors d'une requête de type {type} pour la ressource \"{domain}\" avec des "
 "casses différentes, tous les serveurs retournent les mêmes résultats."
 
 #. NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
@@ -1575,10 +1556,10 @@ msgstr ""
 #. NAMESERVER:CASE_QUERY_NO_ANSWER
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\", nameserver {ns} returns "
+"When asked for {type} records on \"{domain}\", nameserver {ns} returns "
 "nothing."
 msgstr ""
-"Lors d'une requête de type {type} pour la ressource\"{query}\", le serveur "
+"Lors d'une requête de type {type} pour la ressource\"{domain}\", le serveur "
 "de noms {ns} ne répond pas."
 
 #. NAMESERVER:CASE_QUERY_SAME_ANSWER
@@ -1611,18 +1592,19 @@ msgstr ""
 
 #. NAMESERVER:EDNS_RESPONSE_WITHOUT_EDNS
 #, perl-brace-format
-msgid "Response without EDNS from {ns} on query with EDNS0 asking for {dname}."
+msgid ""
+"Response without EDNS from {ns} on query with EDNS0 asking for {domain}."
 msgstr ""
 "Réponse sans enregistrement de type OPT de {ns} sur le nom de domaine "
-"'{dname}' lorsque EDNS est utilisé."
+"'{domain}' lorsque EDNS est utilisé."
 
 #. NAMESERVER:EDNS_VERSION_ERROR
 #, perl-brace-format
 msgid ""
 "Incorrect version of EDNS (expected 0) in response from {ns} on query with "
-"EDNS (version 0) asking for {dname}."
+"EDNS (version 0) asking for {domain}."
 msgstr ""
-"Réponse incorrecte de {ns} sur le nom de domaine '{dname}' lorsque EDNS est "
+"Réponse incorrecte de {ns} sur le nom de domaine '{domain}' lorsque EDNS est "
 "utilisé (La version EDNS devrait être 0)."
 
 #. NAMESERVER:EDNS0_SUPPORT
@@ -1663,8 +1645,8 @@ msgstr ""
 #. NAMESERVER:NO_RESPONSE
 #. SYNTAX:NO_RESPONSE
 #, perl-brace-format
-msgid "No response from {ns} asking for {dname}."
-msgstr "Aucune réponse de {ns} sur le nom de domaine '{dname}'."
+msgid "No response from {ns} asking for {domain}."
+msgstr "Aucune réponse de {ns} sur le nom de domaine '{domain}'."
 
 #. NAMESERVER:NO_UPWARD_REFERRAL
 #, perl-brace-format
@@ -1683,17 +1665,17 @@ msgstr "Le serveur de noms {ns} n'a pas répondu aux requêtes de type \"NS\"."
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} does not preserve original case of the queried name "
-"({dname})."
+"({domain})."
 msgstr ""
 "Le serveur de noms {ns} ne conserve pas la casse des noms requêtés dans les "
-"réponses '{dname}'."
+"réponses '{domain}'."
 
 #. NAMESERVER:QNAME_CASE_SENSITIVE
 #, perl-brace-format
-msgid "Nameserver {ns} preserves original case of queried names ({dname})."
+msgid "Nameserver {ns} preserves original case of queried names ({domain})."
 msgstr ""
 "Le serveur de noms {ns} conserve la casse des noms requêtés dans les "
-"réponses '{dname}'."
+"réponses '{domain}'."
 
 #. NAMESERVER:SAME_SOURCE_IP
 msgid "All nameservers reply with same IP used to query them."
@@ -1733,126 +1715,126 @@ msgstr ""
 #. SYNTAX:DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le nom de domaine '{name}' contient un label ({label}) avec un double tiret "
+"Le nom de domaine '{domain}' contient un label ({label}) avec un double tiret "
 "('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #. SYNTAX:INITIAL_HYPHEN
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+"Domain name ({domain}) has a label ({label}) starting with an hyphen ('-')."
 msgstr ""
-"Le nom de domaine '{name}' contient un label ({label})commençant par un "
+"Le nom de domaine '{domain}' contient un label ({label})commençant par un "
 "tiret ('-')."
 
 #. SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"SOA MNAME ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le serveur maître défini dans le SOA, 'mname' ({name}), contient un label "
+"Le serveur maître défini dans le SOA, 'mname' ({domain}), contient un label "
 "({label}) avec un double tiret ('--') en positions 3 et 4 (avec un préfixe "
 "différent de 'xn--')."
 
 #. SYNTAX:MNAME_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in SOA MNAME ({name})."
+msgid "Found illegal characters in SOA MNAME ({domain})."
 msgstr ""
 "Des caractères interdits ont été trouvés dans le nom du serveur maître "
-"défini dans le SOA, 'mname' ({name})."
+"défini dans le SOA, 'mname' ({domain})."
 
 #. SYNTAX:MNAME_NUMERIC_TLD
 #, perl-brace-format
-msgid "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
+msgid "SOA MNAME ({domain}) within a 'numeric only' TLD ({tld})."
 msgstr ""
-"Le serveur maître défini dans le SOA, 'mname' ({name}), se trouve dans un "
+"Le serveur maître défini dans le SOA, 'mname' ({domain}), se trouve dans un "
 "TLD 'numeric only' ({tld})."
 
 #. SYNTAX:MNAME_SYNTAX_OK
 #, perl-brace-format
-msgid "SOA MNAME ({name}) syntax is valid."
+msgid "SOA MNAME ({domain}) syntax is valid."
 msgstr ""
-"La syntaxe du nom du serveur maître défini dans le SOA, 'mname' ({name}) est "
+"La syntaxe du nom du serveur maître défini dans le SOA, 'mname' ({domain}) est "
 "valide."
 
 #. SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
-"position 3 and 4 (with a prefix which is not 'xn--')."
+"Domain name MX ({domain}) has a label ({label}) with a double hyphen ('--') "
+"in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le relais de messagerie ({name}) contient un label ({label}) avec un double "
+"Le relais de messagerie ({domain}) contient un label ({label}) avec un double "
 "tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #. SYNTAX:MX_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in MX ({name})."
+msgid "Found illegal characters in MX ({domain})."
 msgstr ""
 "Des caractères interdits ont été trouvés dans le nom du relais de messagerie "
-"({name})."
+"({domain})."
 
 #. SYNTAX:MX_NUMERIC_TLD
 #, perl-brace-format
-msgid "Domain name MX ({name}) within a 'numeric only' TLD ({tld})."
+msgid "Domain name MX ({domain}) within a 'numeric only' TLD ({tld})."
 msgstr ""
-"Le relais de messagerie ({name}) se trouve dans un TLD 'numeric "
+"Le relais de messagerie ({domain}) se trouve dans un TLD 'numeric "
 "only' ({tld})."
 
 #. SYNTAX:MX_SYNTAX_OK
 #, perl-brace-format
-msgid "Domain name MX ({name}) syntax is valid."
-msgstr "La syntaxe du nom du relais de messagerie ({name}) est valide."
+msgid "Domain name MX ({domain}) syntax is valid."
+msgstr "La syntaxe du nom du relais de messagerie ({domain}) est valide."
 
 #. SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le serveur de noms ({name}) contient un label ({label}) avec un double tiret "
+"Le serveur de noms ({domain}) contient un label ({label}) avec un double tiret "
 "('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in the nameserver ({name})."
+msgid "Found illegal characters in the nameserver ({domain})."
 msgstr ""
 "Des caractères interdits ont été trouvés dans le nom du serveur de noms "
-"({name})."
+"({domain})."
 
 #. SYNTAX:NAMESERVER_NUMERIC_TLD
 #, perl-brace-format
-msgid "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
+msgid "Nameserver ({domain}) within a 'numeric only' TLD ({tld})."
 msgstr ""
-"Le serveur de noms ({name}) se trouve dans un TLD 'numeric only' ({tld})."
+"Le serveur de noms ({domain}) se trouve dans un TLD 'numeric only' ({tld})."
 
 #. SYNTAX:NAMESERVER_SYNTAX_OK
 #, perl-brace-format
-msgid "Nameserver ({name}) syntax is valid."
-msgstr "La syntaxe du nom du serveur de noms ({name}) est valide."
+msgid "Nameserver ({domain}) syntax is valid."
+msgstr "La syntaxe du nom du serveur de noms ({domain}) est valide."
 
 #. SYNTAX:NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in the domain name ({name})."
+msgid "Found illegal characters in the domain name ({domain})."
 msgstr ""
-"Des caractères interdits ont été trouvés dans le nom de domaine '{name}'."
+"Des caractères interdits ont été trouvés dans le nom de domaine '{domain}'."
 
 #. SYNTAX:NO_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
-"and 4 (with a prefix which is not 'xn--')."
+"Domain name ({domain}) has no label with a double hyphen ('--') in position "
+"3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le nom de domaine '{name}' n'a aucun label contenant un double tiret ('--') "
+"Le nom de domaine '{domain}' n'a aucun label contenant un double tiret ('--') "
 "en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #. SYNTAX:NO_ENDING_HYPHENS
 #, perl-brace-format
-msgid "Neither end of any label in the domain name ({name}) has a hyphen."
+msgid "Neither end of any label in the domain name ({domain}) has a hyphen."
 msgstr ""
-"Aucune des extrémités des labels du nom de domain '{name}' n'est un tiret "
+"Aucune des extrémités des labels du nom de domain '{domain}' n'est un tiret "
 "'-'."
 
 #. SYNTAX:NO_RESPONSE_MX_QUERY
@@ -1867,8 +1849,8 @@ msgstr "Aucune réponse des serveurs de noms sur une requête de type \"SOA\"."
 
 #. SYNTAX:ONLY_ALLOWED_CHARS
 #, perl-brace-format
-msgid "No illegal characters in the domain name ({name})."
-msgstr "Le nom de domaine '{name}' ne contient aucun caractère interdit."
+msgid "No illegal characters in the domain name ({domain})."
+msgstr "Le nom de domaine '{domain}' ne contient aucun caractère interdit."
 
 #. SYNTAX:RNAME_MAIL_DOMAIN_INVALID
 #, perl-brace-format
@@ -1906,9 +1888,10 @@ msgstr ""
 
 #. SYNTAX:TERMINAL_HYPHEN
 #, perl-brace-format
-msgid "Domain name ({name}) has a label ({label}) ending with a hyphen ('-')."
+msgid ""
+"Domain name ({domain}) has a label ({label}) ending with a hyphen ('-')."
 msgstr ""
-"Le nom de domaine '{name}' contient un label ({label}) se terminant par un "
+"Le nom de domaine '{domain}' contient un label ({label}) se terminant par un "
 "tiret '-'."
 
 #. ZONE:RETRY_MINIMUM_VALUE_LOWER
@@ -2131,15 +2114,10 @@ msgstr ""
 
 #. SYSTEM:CANNOT_CONTINUE
 #, perl-brace-format
-msgid "Not enough data about {zone} was found to be able to run tests."
+msgid "Not enough data about {domain} was found to be able to run tests."
 msgstr ""
-"Pas assez d'informations obtenues sur la zone '{zone}' pour permettre la "
+"Pas assez d'informations obtenues sur la zone '{domain}' pour permettre la "
 "poursuite des tests."
-
-#. SYSTEM:PROFILE_FILE
-#, perl-brace-format
-msgid "Profile was read from {name}."
-msgstr "Le profile a été lu depuis le fichier {name}."
 
 #. SYSTEM:DEPENDENCY_VERSION
 #, perl-brace-format
@@ -2161,9 +2139,9 @@ msgstr ""
 #. SYSTEM:LOOKUP_ERROR
 #, perl-brace-format
 msgid ""
-"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+"DNS query to {ns} for {domain}/{type}/{class} failed with error: {message}"
 msgstr ""
-"La requête DNS {name}/{type}/{class} au serveur de noms {ns} a échoué avec "
+"La requête DNS {domain}/{type}/{class} au serveur de noms {ns} a échoué avec "
 "le message d'erreur suivant: {message}."
 
 #. SYSTEM:MODULE_ERROR

--- a/share/fr.po
+++ b/share/fr.po
@@ -747,8 +747,8 @@ msgid ""
 "for zone {domain}, which is required."
 msgstr ""
 "Le serveur de noms {ns} ne retourne aucun enregistrement de type \"DS\" créé "
-"à partir de l'algorithme {algo_num}/{algo_mnemo} pour la zone {domain}, alors "
-"que c'est nécessaire."
+"à partir de l'algorithme {algo_num}/{algo_mnemo} pour la zone {domain}, "
+"alors que c'est nécessaire."
 
 #. DNSSEC:DS_ALGORITHM_OK
 #, perl-brace-format
@@ -1718,8 +1718,8 @@ msgid ""
 "Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le nom de domaine '{domain}' contient un label ({label}) avec un double tiret "
-"('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+"Le nom de domaine '{domain}' contient un label ({label}) avec un double "
+"tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #. SYNTAX:INITIAL_HYPHEN
 #, perl-brace-format
@@ -1757,8 +1757,8 @@ msgstr ""
 #, perl-brace-format
 msgid "SOA MNAME ({domain}) syntax is valid."
 msgstr ""
-"La syntaxe du nom du serveur maître défini dans le SOA, 'mname' ({domain}) est "
-"valide."
+"La syntaxe du nom du serveur maître défini dans le SOA, 'mname' ({domain}) "
+"est valide."
 
 #. SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
@@ -1766,8 +1766,9 @@ msgid ""
 "Domain name MX ({domain}) has a label ({label}) with a double hyphen ('--') "
 "in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le relais de messagerie ({domain}) contient un label ({label}) avec un double "
-"tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+"Le relais de messagerie ({domain}) contient un label ({label}) avec un "
+"double tiret ('--') en positions 3 et 4 (avec un préfixe différent de "
+"'xn--')."
 
 #. SYNTAX:MX_NON_ALLOWED_CHARS
 #, perl-brace-format
@@ -1794,8 +1795,8 @@ msgid ""
 "Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le serveur de noms ({domain}) contient un label ({label}) avec un double tiret "
-"('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+"Le serveur de noms ({domain}) contient un label ({label}) avec un double "
+"tiret ('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 #, perl-brace-format
@@ -1827,8 +1828,8 @@ msgid ""
 "Domain name ({domain}) has no label with a double hyphen ('--') in position "
 "3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Le nom de domaine '{domain}' n'a aucun label contenant un double tiret ('--') "
-"en positions 3 et 4 (avec un préfixe différent de 'xn--')."
+"Le nom de domaine '{domain}' n'a aucun label contenant un double tiret "
+"('--') en positions 3 et 4 (avec un préfixe différent de 'xn--')."
 
 #. SYNTAX:NO_ENDING_HYPHENS
 #, perl-brace-format

--- a/share/nb.po
+++ b/share/nb.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-17 13:33+0100\n"
+"POT-Creation-Date: 2020-11-28 04:26+0100\n"
 "PO-Revision-Date: 2020-10-19 12:47+0200\n"
 "Last-Translator: richard.persson@norid.no\n"
 "Language-Team: Zonemaster Team\n"
@@ -50,8 +50,8 @@ msgstr "Hvert reversoppslag matcher tilsvarende navnetjenernavn."
 
 #. ADDRESS:NO_RESPONSE_PTR_QUERY
 #, perl-brace-format
-msgid "No response from nameserver(s) on PTR query ({reverse})."
-msgstr "Ikke svar fra navnetjener på PTR-spørring ({reverse})."
+msgid "No response from nameserver(s) on PTR query ({domain})."
+msgstr "Ikke svar fra navnetjener på PTR-spørring ({domain})."
 
 #. ADDRESS:TEST_CASE_END
 #. BASIC:TEST_CASE_END
@@ -82,15 +82,15 @@ msgstr "TEST_CASE_START {testcase}."
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
 msgstr ""
-"Domenenavnet ({dname}) har et ledd ({dlabel}) som er for langt ({dlength}/"
+"Domenenavnet ({domain}) har et ledd ({dlabel}) som er for langt ({dlength}/"
 "{max})."
 
 #. BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
 #, perl-brace-format
-msgid "Domain name ({dname}) has a zero-length label."
-msgstr "Domenenavnet ({dname}) har et ledd med lengde null."
+msgid "Domain name ({domain}) has a zero-length label."
+msgstr "Domenenavnet ({domain}) har et ledd med lengde null."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG
 #, perl-brace-format
@@ -108,13 +108,13 @@ msgstr "Foreldredomene ({pname}) funnet for domenet som testes."
 
 #. BASIC:HAS_A_RECORDS
 #, perl-brace-format
-msgid "Nameserver {ns} returned \"A\" record(s) for {dname}."
-msgstr "Navnetjener {ns} svarte med A-poster for {dname}."
+msgid "Nameserver {ns} returned \"A\" record(s) for {domain}."
+msgstr "Navnetjener {ns} svarte med A-poster for {domain}."
 
 #. BASIC:NO_A_RECORDS
 #, perl-brace-format
-msgid "Nameserver {ns} did not return \"A\" record(s) for {dname}."
-msgstr "Navnetjener {ns} svarte ikke med A-poster for {dname}."
+msgid "Nameserver {ns} did not return \"A\" record(s) for {domain}."
+msgstr "Navnetjener {ns} svarte ikke med A-poster for {domain}."
 
 #. BASIC:HAS_NAMESERVERS
 #, perl-brace-format
@@ -437,15 +437,6 @@ msgstr ""
 "Fant SOA-postvariant (REFRESH={refresh},RETRY={retry},EXPIRE={expire},"
 "MINIMUM={minimum}) på følgende navnetjerere: {ns_list}."
 
-#. CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-#, perl-brace-format
-msgid ""
-"No common nameserver IP addresses between child ({child}) and parent "
-"({glue})."
-msgstr ""
-"Ingen felles navnetjener-IP-adresse mellom underdomene ({child}) og "
-"foreldredomene ({glue})."
-
 #. DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr "Ingen DNSKEY-poster ble returnert. Hopper over videre DNSKEY-tester."
@@ -534,10 +525,10 @@ msgstr ""
 #. DNSSEC:BROKEN_DNSSEC
 #, perl-brace-format
 msgid ""
-"All nameservers for zone {zone} responds with neither NSEC nor NSEC3 records "
-"when such records are expected."
+"All nameservers for zone {domain} responds with neither NSEC nor NSEC3 "
+"records when such records are expected."
 msgstr ""
-"Ingen navnetjenere for sonen {zone} svarer med NSEC eller NSEC3-poster når "
+"Ingen navnetjenere for sonen {domain} svarer med NSEC eller NSEC3-poster når "
 "dette er forventet."
 
 #. DNSSEC:BROKEN_DS
@@ -662,64 +653,64 @@ msgstr ""
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}) "
 "which is not meant for DS. The DS record is for the DNSKEY record with "
-"keytag {keytag} in zone {zone}."
+"keytag {keytag} in zone {domain}."
 msgstr ""
 "Navnetjener {ns} svarte med en DS-post som er laget med algoritme {algo_num} "
 "({algo_mnemo}), som ikke er ment for DS. DS-posten gjelder DNSKEY-posten med "
-"\"key tag\" {keytag} i sonen {zone}."
+"\"key tag\" {keytag} i sonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_DEPRECATED
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is deprecated. The DS record is for the DNSKEY record with keytag "
-"{keytag} in zone {zone}."
+"{keytag} in zone {domain}."
 msgstr ""
 "Navnetjener {ns} svarte med en DS-post som er laget med algoritme {algo_num} "
 "({algo_mnemo}), som er foreldet. DS-posten gjelder for DNSKEY-posten med "
-"\"key tag\" {keytag} i sonen {zone}."
+"\"key tag\" {keytag} i sonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_MISSING
 #, perl-brace-format
 msgid ""
 "{ns} returned no DS record created by algorithm {algo_num} ({algo_mnemo}) "
-"for zone {zone}, which is required."
+"for zone {domain}, which is required."
 msgstr ""
 "Navnetjener {ns} svarte ikke med en DS-post som er laget med algoritme "
-"{algo_num} ({algo_mnemo}) for sonen {zone}, noe som er et krav."
+"{algo_num} ({algo_mnemo}) for sonen {domain}, noe som er et krav."
 
 #. DNSSEC:DS_ALGORITHM_OK
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is OK. The DS record is for the DNSKEY record with keytag {keytag} in "
-"zone {zone}."
+"zone {domain}."
 msgstr ""
 "Navnetjener {ns} svarte med en DS-post som er laget med algoritme {algo_num} "
 "({algo_mnemo}), som er OK. DS-posten gjelder for DNSKEY-posten med \"key tag"
-"\" {keytag} i sonen {zone}."
+"\" {keytag} i sonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_RESERVED
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by with an algorithm not assigned "
 "(algorithm number {algo_num}), which is not OK. The DS record is for the "
-"DNSKEY record with keytag {keytag} in zone {zone}."
+"DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "Navnetjener {ns} svarte med en DS-post som er laget med algoritme {algo_num} "
 "som ikke er i bruk. DS-posten gjelder for DNSKEY-posten med \"key tag"
-"\" {keytag} i sonen {zone}."
+"\" {keytag} i sonen {domain}."
 
 #. DNSSEC:DS_ALGO_SHA1_DEPRECATED
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} returned a DS record created by algorithm {algo_num} "
 "({algo_mnemo}) which is deprecated, while it is still widely used. The DS "
-"record is for the DNSKEY record with keytag {keytag} in zone {zone}."
+"record is for the DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "Navnetjener {ns} svarte med en DS-post som er laget med algoritme {algo_num} "
 "({algo_mnemo}), som er foreldet, men fortsatt i bruk. DS-posten gjelder "
-"DNSKEY-posten med \"key tag\" {keytag} i sonen {zone}."
+"DNSKEY-posten med \"key tag\" {keytag} i sonen {domain}."
 
 #. DNSSEC:DS_BUT_NOT_DNSKEY
 #, perl-brace-format
@@ -773,28 +764,20 @@ msgstr "Sonen har NSEC-poster."
 #. DNSSEC:INCONSISTENT_DNSSEC
 #, perl-brace-format
 msgid ""
-"Some, but not all, nameservers for zone {zone} respond with neither NSEC nor "
-"NSEC3 records when such records are expected."
+"Some, but not all, nameservers for zone {domain} respond with neither NSEC "
+"nor NSEC3 records when such records are expected."
 msgstr ""
-"Noen navnetjenere for sonen {zone} svarer verken med NSEC- eller NSEC3-"
+"Noen navnetjenere for sonen {domain} svarer verken med NSEC- eller NSEC3-"
 "poster der slike poster er forventet."
 
 #. DNSSEC:INCONSISTENT_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Some nameservers for zone {zone} respond with NSEC records and others "
+"Some nameservers for zone {domain} respond with NSEC records and others "
 "respond with NSEC3 records. Consistency is expected."
 msgstr ""
-"Noen navnetjenere for sonen {zone} svarar med NSEC-poster og andre med NSEC3-"
+"Noen navnetjenere for sonen {domain} svarar med NSEC-poster og andre med NSEC3-"
 "poster. Det er foventet at alle navnetjenere svarer med samme posttype."
-
-#. DNSSEC:INVALID_NAME_RCODE
-#, perl-brace-format
-msgid ""
-"When asked for the name {name}, which must not exist, the response had RCODE "
-"{rcode}."
-msgstr ""
-"På spørring om {name}, som ikke skal eksisterer, hadde svaret RCODE {rcode}."
 
 #. DNSSEC:ITERATIONS_OK
 #, perl-brace-format
@@ -822,10 +805,10 @@ msgstr "Antall NSEC3-iterasjoner er {count}, som er litt høyt."
 #. DNSSEC:MIXED_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with both NSEC and NSEC3 records "
+"Nameserver {ns} for zone {domain} responds with both NSEC and NSEC3 records "
 "when only one record type is expected."
 msgstr ""
-"Navnetjener {ns} for sonen {zone} svarte med både NSEC- og NSEC3-poster når "
+"Navnetjener {ns} for sonen {domain} svarte med både NSEC- og NSEC3-poster når "
 "bare den ene typen er forventet."
 
 #. DNSSEC:NEITHER_DNSKEY_NOR_DS
@@ -882,10 +865,10 @@ msgstr "{server} returnerte ingen NSEC3PARAM-poster."
 #. DNSSEC:NO_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with neither NSEC nor NSEC3 record "
-"when when such records are expected."
+"Nameserver {ns} for zone {domain} responds with neither NSEC nor NSEC3 "
+"record when when such records are expected."
 msgstr ""
-"Navnetjener {ns} for sonen {zone} svarte ikke verken med NSEC- eller NSEC3-"
+"Navnetjener {ns} for sonen {domain} svarte ikke verken med NSEC- eller NSEC3-"
 "poster, noe som var forventet."
 
 #. DNSSEC:NO_RESPONSE_DNSKEY
@@ -895,8 +878,8 @@ msgstr "Navnetjener {ns} svarte ikke med noen DNSKEY-post."
 
 #. DNSSEC:NO_RESPONSE_DS
 #, perl-brace-format
-msgid "{ns} returned no DS records for {zone}."
-msgstr "Navnetjener {ns} returnerte ingen DS-poster for sonen {zone}."
+msgid "{ns} returned no DS records for {domain}."
+msgstr "Navnetjener {ns} returnerte ingen DS-poster for sonen {domain}."
 
 #. DNSSEC:NO_RESPONSE_RRSET
 #, perl-brace-format
@@ -915,8 +898,8 @@ msgstr "Sonen er ikke signert med DNSSEC."
 
 #. DNSSEC:NSEC3_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC3 record does not cover {name}."
-msgstr "NSEC3 dekker ikke {name}."
+msgid "NSEC3 record does not cover {domain}."
+msgstr "NSEC3 dekker ikke {domain}."
 
 #. DNSSEC:NSEC3_NOT_SIGNED
 msgid "No signature correctly signed the NSEC3 RRset."
@@ -930,8 +913,8 @@ msgstr ""
 
 #. DNSSEC:NSEC_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC does not cover {name}."
-msgstr "NSEC dekker ikke {name}."
+msgid "NSEC does not cover {domain}."
+msgstr "NSEC dekker ikke {domain}."
 
 #. DNSSEC:NSEC_NOT_SIGNED
 msgid "No signature correctly signed the NSEC RRset."
@@ -1020,11 +1003,11 @@ msgstr "Det finnes minst én RRSIG-post som signerer SOA-posten korrekt."
 #. DNSSEC:TEST_ABORTED
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with RCODE \"NOERROR\" on a query "
+"Nameserver {ns} for zone {domain} responds with RCODE \"NOERROR\" on a query "
 "that is expected to give response with RCODE \"NXDOMAIN\". Test for NSEC and "
 "NSEC3 is aborted for this nameserver."
 msgstr ""
-"Navnetjener {ns} for sonen {zone} svarte med RCODE \"NOERROR\" på en "
+"Navnetjener {ns} for sonen {domain} svarte med RCODE \"NOERROR\" på en "
 "spørring som forventes å gi RCODE \"NXDOMAIN\". Test av NSEC og NSEC3 er "
 "avbrutt for denne navnetjeneren."
 
@@ -1041,9 +1024,9 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"for zone {domain}."
 msgstr ""
-"Navnetjener {ns} svarte på en DS-spørring for sonen {zone} med svarkoden "
+"Navnetjener {ns} svarte på en DS-spørring for sonen {domain} med svarkoden "
 "({rcode}), som ikke var forventet."
 
 #. DELEGATION:ARE_AUTHORITATIVE
@@ -1354,8 +1337,8 @@ msgstr "AXFR er ikke tilgjengelig for nameserver {ns}."
 
 #. NAMESERVER:BREAKS_ON_EDNS
 #, perl-brace-format
-msgid "No response from {ns} when EDNS is used in query asking for {dname}."
-msgstr "Ingen svar fra {ns} når EDNS brukes til å spørre etter {dname}."
+msgid "No response from {ns} when EDNS is used in query asking for {domain}."
+msgstr "Ingen svar fra {ns} når EDNS brukes til å spørre etter {domain}."
 
 #. NAMESERVER:CAN_BE_RESOLVED
 msgid "All nameservers succeeded to resolve to an IP address."
@@ -1372,20 +1355,20 @@ msgstr ""
 #. NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers do not reply consistently."
 msgstr ""
 "Alle navnetjenere svarer ikke konsistent på spørring etter {type}-poster på "
-"\"{query}\"."
+"\"{domain}\"."
 
 #. NAMESERVER:CASE_QUERIES_RESULTS_OK
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers reply consistently."
 msgstr ""
 "Alle navnetjenere svarer konsistent på spørring etter {type}-poster på "
-"\"{query}\"."
+"\"{domain}\"."
 
 #. NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
 #, perl-brace-format
@@ -1408,10 +1391,10 @@ msgstr ""
 #. NAMESERVER:CASE_QUERY_NO_ANSWER
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\", nameserver {ns} returns "
+"When asked for {type} records on \"{domain}\", nameserver {ns} returns "
 "nothing."
 msgstr ""
-"Navnetjener {ns} svarer ingenting ved spørring om \"{query}\" med posttypen "
+"Navnetjener {ns} svarer ingenting ved spørring om \"{domain}\" med posttypen "
 "{type}."
 
 #. NAMESERVER:CASE_QUERY_SAME_ANSWER
@@ -1443,17 +1426,18 @@ msgstr ""
 
 #. NAMESERVER:EDNS_RESPONSE_WITHOUT_EDNS
 #, perl-brace-format
-msgid "Response without EDNS from {ns} on query with EDNS0 asking for {dname}."
-msgstr "Svar uten EDNS fra {ns} på EDNS0-spørring etter {dname}."
+msgid ""
+"Response without EDNS from {ns} on query with EDNS0 asking for {domain}."
+msgstr "Svar uten EDNS fra {ns} på EDNS0-spørring etter {domain}."
 
 #. NAMESERVER:EDNS_VERSION_ERROR
 #, perl-brace-format
 msgid ""
 "Incorrect version of EDNS (expected 0) in response from {ns} on query with "
-"EDNS (version 0) asking for {dname}."
+"EDNS (version 0) asking for {domain}."
 msgstr ""
 "Feil versjon av EDNS (forventet versjon var 0) i svar fra {ns} på spørring "
-"med EDNS (versjon 0) for {dname}."
+"med EDNS (versjon 0) for {domain}."
 
 #. NAMESERVER:EDNS0_SUPPORT
 #, perl-brace-format
@@ -1490,8 +1474,8 @@ msgstr "Det var ikke mulig å slå opp IP-adresse for noen navnetjenere."
 #. NAMESERVER:NO_RESPONSE
 #. SYNTAX:NO_RESPONSE
 #, perl-brace-format
-msgid "No response from {ns} asking for {dname}."
-msgstr "Ingen respons fra {ns} på spørring om {dname}."
+msgid "No response from {ns} asking for {domain}."
+msgstr "Ingen respons fra {ns} på spørring om {domain}."
 
 #. NAMESERVER:NO_UPWARD_REFERRAL
 #, perl-brace-format
@@ -1508,17 +1492,17 @@ msgstr "Feil svar fra navnetjener {ns}."
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} does not preserve original case of the queried name "
-"({dname})."
+"({domain})."
 msgstr ""
 "Navnetjener {ns} besvarer ikke store og små bokstaver som i den opprinnelige "
-"spørringen ({dname})."
+"spørringen ({domain})."
 
 #. NAMESERVER:QNAME_CASE_SENSITIVE
 #, perl-brace-format
-msgid "Nameserver {ns} preserves original case of queried names ({dname})."
+msgid "Nameserver {ns} preserves original case of queried names ({domain})."
 msgstr ""
 "Navnetjener {ns} besvarer store og små bokstaver som i den opprinnelige "
-"spørringen ({dname})."
+"spørringen ({domain})."
 
 #. NAMESERVER:SAME_SOURCE_IP
 msgid "All nameservers reply with same IP used to query them."
@@ -1551,111 +1535,111 @@ msgstr "Navnetjener {ns} har en eller flere ukjente EDNS Z-flagg-bits satt."
 #. SYNTAX:DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domenenavnet ({name}) har et ledd ({label}) med bindestrek i posisjon 3 og 4 "
+"Domenenavnet ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 og 4 "
 "uten at det innledes med IDN-prefikset \"xn--\"."
 
 #. SYNTAX:INITIAL_HYPHEN
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+"Domain name ({domain}) has a label ({label}) starting with an hyphen ('-')."
 msgstr ""
-"Domenenavnet ({name}) har et ledd ({label}) som innledes med en bindestrek "
+"Domenenavnet ({domain}) har et ledd ({label}) som innledes med en bindestrek "
 "(\"-\")."
 
 #. SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"SOA MNAME ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"SOA/MNAME-post ({name}) har et ledd ({label}) med doble bindestreker (\"--"
+"SOA/MNAME-post ({domain}) har et ledd ({label}) med doble bindestreker (\"--"
 "\") i posisjon 3 og 4 (med en prefiks som ikke er \"xn--\")."
 
 #. SYNTAX:MNAME_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in SOA MNAME ({name})."
-msgstr "Fant tegn i SOA/MNAME-post ({name}) som ikke er tillatt."
+msgid "Found illegal characters in SOA MNAME ({domain})."
+msgstr "Fant tegn i SOA/MNAME-post ({domain}) som ikke er tillatt."
 
 #. SYNTAX:MNAME_NUMERIC_TLD
 #, perl-brace-format
-msgid "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "SOA/MNAME-post ({name}) ligger i et helnumerisk TLD ({tld})."
+msgid "SOA MNAME ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "SOA/MNAME-post ({domain}) ligger i et helnumerisk TLD ({tld})."
 
 #. SYNTAX:MNAME_SYNTAX_OK
 #, perl-brace-format
-msgid "SOA MNAME ({name}) syntax is valid."
-msgstr "Syntaks på SOA/MNAME-post ({name}) er OK."
+msgid "SOA MNAME ({domain}) syntax is valid."
+msgstr "Syntaks på SOA/MNAME-post ({domain}) er OK."
 
 #. SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
-"position 3 and 4 (with a prefix which is not 'xn--')."
+"Domain name MX ({domain}) has a label ({label}) with a double hyphen ('--') "
+"in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domenets MX-post ({name}) har et ledd ({label}) med bindestrek i posisjon 3 "
+"Domenets MX-post ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 "
 "og 4 uten at det innledes med IDN-prefikset (\"xn--\")."
 
 #. SYNTAX:MX_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in MX ({name})."
-msgstr "Fant tegn i MX-post ({name}) som ikke er tillatt."
+msgid "Found illegal characters in MX ({domain})."
+msgstr "Fant tegn i MX-post ({domain}) som ikke er tillatt."
 
 #. SYNTAX:MX_NUMERIC_TLD
 #, perl-brace-format
-msgid "Domain name MX ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Domenets MX-post ({name}) er i et helnumerisk TLD ({tld})."
+msgid "Domain name MX ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "Domenets MX-post ({domain}) er i et helnumerisk TLD ({tld})."
 
 #. SYNTAX:MX_SYNTAX_OK
 #, perl-brace-format
-msgid "Domain name MX ({name}) syntax is valid."
-msgstr "Domenets MX-post ({name}) har gyldig syntaks."
+msgid "Domain name MX ({domain}) syntax is valid."
+msgstr "Domenets MX-post ({domain}) har gyldig syntaks."
 
 #. SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Navnetjener ({name}) har et ledd ({label}) med bindestrek i posisjon 3 og 4 "
+"Navnetjener ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 og 4 "
 "uten at det innledes med IDN-prefikset \"xn--\"."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in the nameserver ({name})."
-msgstr "Fant tegn i navnetjenernavnet ({name}) som ikke er tillatt."
+msgid "Found illegal characters in the nameserver ({domain})."
+msgstr "Fant tegn i navnetjenernavnet ({domain}) som ikke er tillatt."
 
 #. SYNTAX:NAMESERVER_NUMERIC_TLD
 #, perl-brace-format
-msgid "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Navnetjener ({name}) er i et helnumerisk TLD ({tld})."
+msgid "Nameserver ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "Navnetjener ({domain}) er i et helnumerisk TLD ({tld})."
 
 #. SYNTAX:NAMESERVER_SYNTAX_OK
 #, perl-brace-format
-msgid "Nameserver ({name}) syntax is valid."
-msgstr "Navnetjener ({name}) har gyldig syntaks."
+msgid "Nameserver ({domain}) syntax is valid."
+msgstr "Navnetjener ({domain}) har gyldig syntaks."
 
 #. SYNTAX:NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in the domain name ({name})."
-msgstr "Fant tegn i domenenavnet ({name}) som ikke er tillatt."
+msgid "Found illegal characters in the domain name ({domain})."
+msgstr "Fant tegn i domenenavnet ({domain}) som ikke er tillatt."
 
 #. SYNTAX:NO_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
-"and 4 (with a prefix which is not 'xn--')."
+"Domain name ({domain}) has no label with a double hyphen ('--') in position "
+"3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domenenavnet ({name}) har ingen ledd med bindestrek i posisjon 3 og 4 uten "
+"Domenenavnet ({domain}) har ingen ledd med bindestrek i posisjon 3 og 4 uten "
 "at det innledes med IDN-prefikset (\"xn--\")."
 
 #. SYNTAX:NO_ENDING_HYPHENS
 #, perl-brace-format
-msgid "Neither end of any label in the domain name ({name}) has a hyphen."
+msgid "Neither end of any label in the domain name ({domain}) has a hyphen."
 msgstr ""
-"Ingen del av domenenavnet ({name}) begynner eller slutter med et bindestrek."
+"Ingen del av domenenavnet ({domain}) begynner eller slutter med et bindestrek."
 
 #. SYNTAX:NO_RESPONSE_MX_QUERY
 #. ZONE:NO_RESPONSE_MX_QUERY
@@ -1669,8 +1653,8 @@ msgstr "Ingen svar fra navnetjenere på SOA-spørringer."
 
 #. SYNTAX:ONLY_ALLOWED_CHARS
 #, perl-brace-format
-msgid "No illegal characters in the domain name ({name})."
-msgstr "Bare tillatte tegn i domenavnet ({name})."
+msgid "No illegal characters in the domain name ({domain})."
+msgstr "Bare tillatte tegn i domenavnet ({domain})."
 
 #. SYNTAX:RNAME_MAIL_DOMAIN_INVALID
 #, perl-brace-format
@@ -1703,9 +1687,10 @@ msgstr "Verdien på SOA/RNAME ({rname}) er i henhold til RFC2822."
 
 #. SYNTAX:TERMINAL_HYPHEN
 #, perl-brace-format
-msgid "Domain name ({name}) has a label ({label}) ending with a hyphen ('-')."
+msgid ""
+"Domain name ({domain}) has a label ({label}) ending with a hyphen ('-')."
 msgstr ""
-"Domenenavnet ({name}) har et ledd ({label}) som slutter med en bindestrek "
+"Domenenavnet ({domain}) har et ledd ({label}) som slutter med en bindestrek "
 "(\"-\")."
 
 #. ZONE:RETRY_MINIMUM_VALUE_LOWER
@@ -1908,14 +1893,9 @@ msgstr ""
 
 #. SYSTEM:CANNOT_CONTINUE
 #, perl-brace-format
-msgid "Not enough data about {zone} was found to be able to run tests."
+msgid "Not enough data about {domain} was found to be able to run tests."
 msgstr ""
-"Fant ikke tilstrekkelig med data for sonen {zone} for å kunne kjøre tester."
-
-#. SYSTEM:PROFILE_FILE
-#, perl-brace-format
-msgid "Profile was read from {name}."
-msgstr "Profilen ble lest fra {name}."
+"Fant ikke tilstrekkelig med data for sonen {domain} for å kunne kjøre tester."
 
 #. SYSTEM:DEPENDENCY_VERSION
 #, perl-brace-format
@@ -1936,9 +1916,9 @@ msgstr ""
 #. SYSTEM:LOOKUP_ERROR
 #, perl-brace-format
 msgid ""
-"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+"DNS query to {ns} for {domain}/{type}/{class} failed with error: {message}"
 msgstr ""
-"DNS-spørring til {ns} for {name}/{type}/{class} mislyktes med følgende feil: "
+"DNS-spørring til {ns} for {domain}/{type}/{class} mislyktes med følgende feil: "
 "{message}."
 
 #. SYSTEM:MODULE_ERROR

--- a/share/nb.po
+++ b/share/nb.po
@@ -776,8 +776,8 @@ msgid ""
 "Some nameservers for zone {domain} respond with NSEC records and others "
 "respond with NSEC3 records. Consistency is expected."
 msgstr ""
-"Noen navnetjenere for sonen {domain} svarar med NSEC-poster og andre med NSEC3-"
-"poster. Det er foventet at alle navnetjenere svarer med samme posttype."
+"Noen navnetjenere for sonen {domain} svarar med NSEC-poster og andre med "
+"NSEC3-poster. Det er foventet at alle navnetjenere svarer med samme posttype."
 
 #. DNSSEC:ITERATIONS_OK
 #, perl-brace-format
@@ -808,8 +808,8 @@ msgid ""
 "Nameserver {ns} for zone {domain} responds with both NSEC and NSEC3 records "
 "when only one record type is expected."
 msgstr ""
-"Navnetjener {ns} for sonen {domain} svarte med både NSEC- og NSEC3-poster når "
-"bare den ene typen er forventet."
+"Navnetjener {ns} for sonen {domain} svarte med både NSEC- og NSEC3-poster "
+"når bare den ene typen er forventet."
 
 #. DNSSEC:NEITHER_DNSKEY_NOR_DS
 msgid "There are neither DS nor DNSKEY records for the zone."
@@ -1538,8 +1538,8 @@ msgid ""
 "Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domenenavnet ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 og 4 "
-"uten at det innledes med IDN-prefikset \"xn--\"."
+"Domenenavnet ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 og "
+"4 uten at det innledes med IDN-prefikset \"xn--\"."
 
 #. SYNTAX:INITIAL_HYPHEN
 #, perl-brace-format
@@ -1579,8 +1579,8 @@ msgid ""
 "Domain name MX ({domain}) has a label ({label}) with a double hyphen ('--') "
 "in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domenets MX-post ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 "
-"og 4 uten at det innledes med IDN-prefikset (\"xn--\")."
+"Domenets MX-post ({domain}) har et ledd ({label}) med bindestrek i posisjon "
+"3 og 4 uten at det innledes med IDN-prefikset (\"xn--\")."
 
 #. SYNTAX:MX_NON_ALLOWED_CHARS
 #, perl-brace-format
@@ -1603,8 +1603,8 @@ msgid ""
 "Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Navnetjener ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 og 4 "
-"uten at det innledes med IDN-prefikset \"xn--\"."
+"Navnetjener ({domain}) har et ledd ({label}) med bindestrek i posisjon 3 og "
+"4 uten at det innledes med IDN-prefikset \"xn--\"."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 #, perl-brace-format
@@ -1639,7 +1639,8 @@ msgstr ""
 #, perl-brace-format
 msgid "Neither end of any label in the domain name ({domain}) has a hyphen."
 msgstr ""
-"Ingen del av domenenavnet ({domain}) begynner eller slutter med et bindestrek."
+"Ingen del av domenenavnet ({domain}) begynner eller slutter med et "
+"bindestrek."
 
 #. SYNTAX:NO_RESPONSE_MX_QUERY
 #. ZONE:NO_RESPONSE_MX_QUERY
@@ -1918,8 +1919,8 @@ msgstr ""
 msgid ""
 "DNS query to {ns} for {domain}/{type}/{class} failed with error: {message}"
 msgstr ""
-"DNS-spørring til {ns} for {domain}/{type}/{class} mislyktes med følgende feil: "
-"{message}."
+"DNS-spørring til {ns} for {domain}/{type}/{class} mislyktes med følgende "
+"feil: {message}."
 
 #. SYSTEM:MODULE_ERROR
 #, perl-brace-format

--- a/share/sv.po
+++ b/share/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-17 13:33+0100\n"
+"POT-Creation-Date: 2020-11-28 04:26+0100\n"
 "PO-Revision-Date: 2020-11-03 19:44+0100\n"
 "Last-Translator: mats.dufberg@iis.se\n"
 "Language-Team: Zonemaster Team\n"
@@ -50,8 +50,8 @@ msgstr "Varje bakåtuppslagning (PTR) stämmer med motsvarande namnservernamn."
 
 #. ADDRESS:NO_RESPONSE_PTR_QUERY
 #, perl-brace-format
-msgid "No response from nameserver(s) on PTR query ({reverse})."
-msgstr "Inget svar från namnservern på PTR-fråga ({reverse})."
+msgid "No response from nameserver(s) on PTR query ({domain})."
+msgstr "Inget svar från namnservern på PTR-fråga ({domain})."
 
 #. ADDRESS:TEST_CASE_END
 #. BASIC:TEST_CASE_END
@@ -82,15 +82,15 @@ msgstr "TEST_CASE_START {testcase}."
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({dname}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
 msgstr ""
-"Domändelen '{dlabel}' i domännamnet {dname} är för lång ({dlength}). Maximal "
+"Domändelen '{dlabel}' i domännamnet {domain} är för lång ({dlength}). Maximal "
 "längd är {max}."
 
 #. BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
 #, perl-brace-format
-msgid "Domain name ({dname}) has a zero-length label."
-msgstr "Domännamnet '{dname}' har en domändel med längden noll."
+msgid "Domain name ({domain}) has a zero-length label."
+msgstr "Domännamnet '{domain}' har en domändel med längden noll."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG
 #, perl-brace-format
@@ -108,13 +108,13 @@ msgstr "Moderdomänen '{pname}' till den testade domänen har identifierats."
 
 #. BASIC:HAS_A_RECORDS
 #, perl-brace-format
-msgid "Nameserver {ns} returned \"A\" record(s) for {dname}."
-msgstr "Namnserver {ns} svarade med A-poster för '{dname}'."
+msgid "Nameserver {ns} returned \"A\" record(s) for {domain}."
+msgstr "Namnserver {ns} svarade med A-poster för '{domain}'."
 
 #. BASIC:NO_A_RECORDS
 #, perl-brace-format
-msgid "Nameserver {ns} did not return \"A\" record(s) for {dname}."
-msgstr "Namnserver {ns} svarade inte med några A-poster för '{dname}'."
+msgid "Nameserver {ns} did not return \"A\" record(s) for {domain}."
+msgstr "Namnserver {ns} svarade inte med några A-poster för '{domain}'."
 
 #. BASIC:HAS_NAMESERVERS
 #, perl-brace-format
@@ -440,15 +440,6 @@ msgstr ""
 "SOA-tidsparametrarna (REFRESH={refresh}, RETRY={retry}, EXPIRE={expire}, "
 "MINIMUM={minimum}) hittades på följande uppsättning namnservrar: {ns_list}."
 
-#. CONSISTENCY:TOTAL_ADDRESS_MISMATCH
-#, perl-brace-format
-msgid ""
-"No common nameserver IP addresses between child ({child}) and parent "
-"({glue})."
-msgstr ""
-"Det finns inga gemensamma namnserver-IP-adresser mellan moderzon ({glue}) "
-"och dotterzon ({child})."
-
 #. DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
 msgid "No DNSKEYs found. Additional tests skipped."
 msgstr "Inga DNSKEY-poster hittades. Resterande DNSSEC-tester hoppas över."
@@ -537,10 +528,10 @@ msgstr ""
 #. DNSSEC:BROKEN_DNSSEC
 #, perl-brace-format
 msgid ""
-"All nameservers for zone {zone} responds with neither NSEC nor NSEC3 records "
-"when such records are expected."
+"All nameservers for zone {domain} responds with neither NSEC nor NSEC3 "
+"records when such records are expected."
 msgstr ""
-"Inga namnservrar för zonen {zone} svarade med varken NSEC- eller NSEC3-"
+"Inga namnservrar för zonen {domain} svarade med varken NSEC- eller NSEC3-"
 "poster trots att endera är förväntat."
 
 #. DNSSEC:BROKEN_DS
@@ -669,64 +660,64 @@ msgstr ""
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}) "
 "which is not meant for DS. The DS record is for the DNSKEY record with "
-"keytag {keytag} in zone {zone}."
+"keytag {keytag} in zone {domain}."
 msgstr ""
 "Namnserver {ns} svarade med en DS-post skapad med hash-algoritm {algo_num} "
 "({algo_mnemo}) som inte är avsedd för DS. DS-posten gäller DNSKEY-posten med "
-"'keytag' {keytag} i zonen {zone}."
+"'keytag' {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_DEPRECATED
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is deprecated. The DS record is for the DNSKEY record with keytag "
-"{keytag} in zone {zone}."
+"{keytag} in zone {domain}."
 msgstr ""
 "Namnserver {ns} svarade med en DS-post skapad med hash-algoritm {algo_num} "
 "({algo_mnemo}) som är föråldrad. DS-posten gäller DNSKEY-posten med "
-"'keytag' {keytag} i zonen {zone}."
+"'keytag' {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_MISSING
 #, perl-brace-format
 msgid ""
 "{ns} returned no DS record created by algorithm {algo_num} ({algo_mnemo}) "
-"for zone {zone}, which is required."
+"for zone {domain}, which is required."
 msgstr ""
 "Namnserver {ns} svarade inte med någon DS-post skapad med hash-algoritm "
-"{algo_num} ({algo_mnemo}) för zonen {zone}, vilket är ett krav att den gör."
+"{algo_num} ({algo_mnemo}) för zonen {domain}, vilket är ett krav att den gör."
 
 #. DNSSEC:DS_ALGORITHM_OK
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by algorithm {algo_num} ({algo_mnemo}), "
 "which is OK. The DS record is for the DNSKEY record with keytag {keytag} in "
-"zone {zone}."
+"zone {domain}."
 msgstr ""
 "Namnserver {ns} svarade med en DS-post skapad med hash-algoritm {algo_num} "
 "({algo_mnemo}), vilken är OK. DS-posten gäller DNSKEY-posten med "
-"'keytag' {keytag} i zonen {zone}."
+"'keytag' {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGORITHM_RESERVED
 #, perl-brace-format
 msgid ""
 "{ns} returned a DS record created by with an algorithm not assigned "
 "(algorithm number {algo_num}), which is not OK. The DS record is for the "
-"DNSKEY record with keytag {keytag} in zone {zone}."
+"DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "Namnserver {ns} svarade med en DS-post skapad med hash-algoritm {algo_num} "
 "som inte är satt till någon hash-algoritm, vilket inte är OK. DS-posten "
-"gäller DNSKEY-posten med 'keytag' {keytag} i zonen {zone}."
+"gäller DNSKEY-posten med 'keytag' {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_ALGO_SHA1_DEPRECATED
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} returned a DS record created by algorithm {algo_num} "
 "({algo_mnemo}) which is deprecated, while it is still widely used. The DS "
-"record is for the DNSKEY record with keytag {keytag} in zone {zone}."
+"record is for the DNSKEY record with keytag {keytag} in zone {domain}."
 msgstr ""
 "Namnserver {ns} svarade med en DS-post skapad med hash-algoritm {algo_num} "
 "({algo_mnemo}) som är föråldrad, men fortfarande allmänt använd. DS-posten "
-"gäller DNSKEY-posten med 'keytag' {keytag} i zonen {zone}."
+"gäller DNSKEY-posten med 'keytag' {keytag} i zonen {domain}."
 
 #. DNSSEC:DS_BUT_NOT_DNSKEY
 #, perl-brace-format
@@ -783,29 +774,20 @@ msgstr "Zonen har NSEC-poster."
 #. DNSSEC:INCONSISTENT_DNSSEC
 #, perl-brace-format
 msgid ""
-"Some, but not all, nameservers for zone {zone} respond with neither NSEC nor "
-"NSEC3 records when such records are expected."
+"Some, but not all, nameservers for zone {domain} respond with neither NSEC "
+"nor NSEC3 records when such records are expected."
 msgstr ""
-"Några av namnservrarna för zonen {zone} svarar med varken NSEC- eller NSEC3-"
+"Några av namnservrarna för zonen {domain} svarar med varken NSEC- eller NSEC3-"
 "post trots att endera förväntas."
 
 #. DNSSEC:INCONSISTENT_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Some nameservers for zone {zone} respond with NSEC records and others "
+"Some nameservers for zone {domain} respond with NSEC records and others "
 "respond with NSEC3 records. Consistency is expected."
 msgstr ""
-"Några av namnservrarna för zonen {zone} svarar med NSEC-poster och andra med "
+"Några av namnservrarna för zonen {domain} svarar med NSEC-poster och andra med "
 "NSEC3-poster. Det förväntade är att alla namnservrar ger samma posttyp."
-
-#. DNSSEC:INVALID_NAME_RCODE
-#, perl-brace-format
-msgid ""
-"When asked for the name {name}, which must not exist, the response had RCODE "
-"{rcode}."
-msgstr ""
-"Förfrågan om namnet '{name}', som inte får existera, gav i svaret den "
-"oväntade RCODE '{rcode}'."
 
 #. DNSSEC:ITERATIONS_OK
 #, perl-brace-format
@@ -833,10 +815,10 @@ msgstr "Antalet NSEC3-iterationer är {count}, vilket är högt."
 #. DNSSEC:MIXED_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with both NSEC and NSEC3 records "
+"Nameserver {ns} for zone {domain} responds with both NSEC and NSEC3 records "
 "when only one record type is expected."
 msgstr ""
-"Namnservern {ns} för zonen '{zone}' svarade med både NSEC och NSEC3 poster "
+"Namnservern {ns} för zonen '{domain}' svarade med både NSEC och NSEC3 poster "
 "när bara den ena posttypen är förväntad."
 
 #. DNSSEC:NEITHER_DNSKEY_NOR_DS
@@ -893,10 +875,10 @@ msgstr "'{server}' gav inga NSEC3PARAM-poster i svaret."
 #. DNSSEC:NO_NSEC_NSEC3
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with neither NSEC nor NSEC3 record "
-"when when such records are expected."
+"Nameserver {ns} for zone {domain} responds with neither NSEC nor NSEC3 "
+"record when when such records are expected."
 msgstr ""
-"Nameservern {ns} för zonen {zone} svarar varken med NSEC- eller NSEC3-poster "
+"Nameservern {ns} för zonen {domain} svarar varken med NSEC- eller NSEC3-poster "
 "trots att sådana var förväntade."
 
 #. DNSSEC:NO_RESPONSE_DNSKEY
@@ -906,8 +888,8 @@ msgstr "Svarspaketet från namnservern {ns} har ingen DNSKEY-post."
 
 #. DNSSEC:NO_RESPONSE_DS
 #, perl-brace-format
-msgid "{ns} returned no DS records for {zone}."
-msgstr "Namnserver {ns} returnerade inga DS-poster för zonen '{zone}'."
+msgid "{ns} returned no DS records for {domain}."
+msgstr "Namnserver {ns} returnerade inga DS-poster för zonen '{domain}'."
 
 #. DNSSEC:NO_RESPONSE_RRSET
 #, perl-brace-format
@@ -929,8 +911,8 @@ msgstr "Zonen är inte signerad med DNSSEC."
 
 #. DNSSEC:NSEC3_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC3 record does not cover {name}."
-msgstr "Det finns ingen NSEC3-post som täcker '{name}'."
+msgid "NSEC3 record does not cover {domain}."
+msgstr "Det finns ingen NSEC3-post som täcker '{domain}'."
 
 #. DNSSEC:NSEC3_NOT_SIGNED
 msgid "No signature correctly signed the NSEC3 RRset."
@@ -944,8 +926,8 @@ msgstr ""
 
 #. DNSSEC:NSEC_COVERS_NOT
 #, perl-brace-format
-msgid "NSEC does not cover {name}."
-msgstr "NSEC täcker inte '{name}'."
+msgid "NSEC does not cover {domain}."
+msgstr "NSEC täcker inte '{domain}'."
 
 #. DNSSEC:NSEC_NOT_SIGNED
 msgid "No signature correctly signed the NSEC RRset."
@@ -1037,11 +1019,11 @@ msgstr "Det finns minst en RRSIG-post som korrekt signerar SOA-posten."
 #. DNSSEC:TEST_ABORTED
 #, perl-brace-format
 msgid ""
-"Nameserver {ns} for zone {zone} responds with RCODE \"NOERROR\" on a query "
+"Nameserver {ns} for zone {domain} responds with RCODE \"NOERROR\" on a query "
 "that is expected to give response with RCODE \"NXDOMAIN\". Test for NSEC and "
 "NSEC3 is aborted for this nameserver."
 msgstr ""
-"Namnservern {ns} för zonen {zone} svarade med statuskod (RCODE) 'NOERROR' på "
+"Namnservern {ns} för zonen {domain} svarade med statuskod (RCODE) 'NOERROR' på "
 "en förfrågan som förväntades ge statuskoden (RCODE) 'NXDOMAIN'. Test av NSEC "
 "och NSEC3 avbröts för denna namnserver."
 
@@ -1058,9 +1040,9 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query "
-"for zone {zone}."
+"for zone {domain}."
 msgstr ""
-"Namnserver {ns} besvarade en DS-fråga för zonen {zone} med den icke-väntade "
+"Namnserver {ns} besvarade en DS-fråga för zonen {domain} med den icke-väntade "
 "svarskoden \"{rcode}\"."
 
 #. DELEGATION:ARE_AUTHORITATIVE
@@ -1381,8 +1363,8 @@ msgstr "AXFR är inte tillgänglig från namnserver {ns}."
 
 #. NAMESERVER:BREAKS_ON_EDNS
 #, perl-brace-format
-msgid "No response from {ns} when EDNS is used in query asking for {dname}."
-msgstr "Inget svar från {ns} på förfrågan med EDNS (fråga efter {dname})."
+msgid "No response from {ns} when EDNS is used in query asking for {domain}."
+msgstr "Inget svar från {ns} på förfrågan med EDNS (fråga efter {domain})."
 
 #. NAMESERVER:CAN_BE_RESOLVED
 msgid "All nameservers succeeded to resolve to an IP address."
@@ -1399,19 +1381,19 @@ msgstr ""
 #. NAMESERVER:CASE_QUERIES_RESULTS_DIFFER
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers do not reply consistently."
 msgstr ""
-"Alla servrar svarar inte konsekvent när förfrågade om '{query}' med olika "
+"Alla servrar svarar inte konsekvent när förfrågade om '{domain}' med olika "
 "skiftlägen och posttypen '{type}'."
 
 #. NAMESERVER:CASE_QUERIES_RESULTS_OK
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\" with different cases, all "
+"When asked for {type} records on \"{domain}\" with different cases, all "
 "servers reply consistently."
 msgstr ""
-"Alla servrar svarar konsekvent när förfrågade om '{query}' med olika "
+"Alla servrar svarar konsekvent när förfrågade om '{domain}' med olika "
 "skiftlägen och posttypen '{type}'."
 
 #. NAMESERVER:CASE_QUERY_DIFFERENT_ANSWER
@@ -1435,10 +1417,10 @@ msgstr ""
 #. NAMESERVER:CASE_QUERY_NO_ANSWER
 #, perl-brace-format
 msgid ""
-"When asked for {type} records on \"{query}\", nameserver {ns} returns "
+"When asked for {type} records on \"{domain}\", nameserver {ns} returns "
 "nothing."
 msgstr ""
-"Nameserver {ns} svarar ingenting när den får frågan om '{query}' med "
+"Nameserver {ns} svarar ingenting när den får frågan om '{domain}' med "
 "posttypen '{type}'."
 
 #. NAMESERVER:CASE_QUERY_SAME_ANSWER
@@ -1469,17 +1451,18 @@ msgstr ""
 
 #. NAMESERVER:EDNS_RESPONSE_WITHOUT_EDNS
 #, perl-brace-format
-msgid "Response without EDNS from {ns} on query with EDNS0 asking for {dname}."
-msgstr "Svar utan EDNS från {ns} på förfrågan med EDNS0 (fråga efter {dname})."
+msgid ""
+"Response without EDNS from {ns} on query with EDNS0 asking for {domain}."
+msgstr "Svar utan EDNS från {ns} på förfrågan med EDNS0 (fråga efter {domain})."
 
 #. NAMESERVER:EDNS_VERSION_ERROR
 #, perl-brace-format
 msgid ""
 "Incorrect version of EDNS (expected 0) in response from {ns} on query with "
-"EDNS (version 0) asking for {dname}."
+"EDNS (version 0) asking for {domain}."
 msgstr ""
 "Felaktig EDNS-version (förväntad version var 0) i svar från {ns} på "
-"förfrågan med EDNS version 0 (fråga efter {dname})."
+"förfrågan med EDNS version 0 (fråga efter {domain})."
 
 #. NAMESERVER:EDNS0_SUPPORT
 #, perl-brace-format
@@ -1517,8 +1500,8 @@ msgstr "Det gick inte att slå upp IP-adressen för någon namnserver."
 #. NAMESERVER:NO_RESPONSE
 #. SYNTAX:NO_RESPONSE
 #, perl-brace-format
-msgid "No response from {ns} asking for {dname}."
-msgstr "Inget svar från {ns} på förfrågan efter {dname}."
+msgid "No response from {ns} asking for {domain}."
+msgstr "Inget svar från {ns} på förfrågan efter {domain}."
 
 #. NAMESERVER:NO_UPWARD_REFERRAL
 #, perl-brace-format
@@ -1537,15 +1520,15 @@ msgstr "Felaktigt svar från namnserver {ns}."
 #, perl-brace-format
 msgid ""
 "Nameserver {ns} does not preserve original case of the queried name "
-"({dname})."
+"({domain})."
 msgstr ""
 "Nameserver {ns} bevarar inte skillnaden mellan versaler och gemener från "
-"frågan ({dname})."
+"frågan ({domain})."
 
 #. NAMESERVER:QNAME_CASE_SENSITIVE
 #, perl-brace-format
-msgid "Nameserver {ns} preserves original case of queried names ({dname})."
-msgstr "Namnserver {ns} bevarade versaler och gemener från frågan ({dname})."
+msgid "Nameserver {ns} preserves original case of queried names ({domain})."
+msgstr "Namnserver {ns} bevarade versaler och gemener från frågan ({domain})."
 
 #. NAMESERVER:SAME_SOURCE_IP
 msgid "All nameservers reply with same IP used to query them."
@@ -1585,111 +1568,111 @@ msgstr ""
 #. SYNTAX:DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Domain name ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domännamnet '{name}' har domändelen '{label}' med bindestreck i position 3 "
+"Domännamnet '{domain}' har domändelen '{label}' med bindestreck i position 3 "
 "och 4 utan att börja med IDN-prefixet 'xn--'."
 
 #. SYNTAX:INITIAL_HYPHEN
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has a label ({label}) starting with an hyphen ('-')."
+"Domain name ({domain}) has a label ({label}) starting with an hyphen ('-')."
 msgstr ""
-"Domännamnet '{name}' har en domändel '{label}' som börjar med ett "
+"Domännamnet '{domain}' har en domändel '{label}' som börjar med ett "
 "bindestreck."
 
 #. SYNTAX:MNAME_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"SOA MNAME ({name}) has a label ({label}) with a double hyphen ('--') in "
+"SOA MNAME ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"SOA MNAME '{name}' har domändelen '{label}' med bindestreck i position 3 och "
+"SOA MNAME '{domain}' har domändelen '{label}' med bindestreck i position 3 och "
 "4 utan att börja med IDN-prefixet 'xn--'."
 
 #. SYNTAX:MNAME_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in SOA MNAME ({name})."
-msgstr "Otillåtna tecken hittades i SOA MNAME ({name})."
+msgid "Found illegal characters in SOA MNAME ({domain})."
+msgstr "Otillåtna tecken hittades i SOA MNAME ({domain})."
 
 #. SYNTAX:MNAME_NUMERIC_TLD
 #, perl-brace-format
-msgid "SOA MNAME ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "SOA MNAME '{name}' är i en helnumerisk TLD ({tld})."
+msgid "SOA MNAME ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "SOA MNAME '{domain}' är i en helnumerisk TLD ({tld})."
 
 #. SYNTAX:MNAME_SYNTAX_OK
 #, perl-brace-format
-msgid "SOA MNAME ({name}) syntax is valid."
-msgstr "SOA MNAME '{name}' har tillåtet format."
+msgid "SOA MNAME ({domain}) syntax is valid."
+msgstr "SOA MNAME '{domain}' har tillåtet format."
 
 #. SYNTAX:MX_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name MX ({name}) has a label ({label}) with a double hyphen ('--') in "
-"position 3 and 4 (with a prefix which is not 'xn--')."
+"Domain name MX ({domain}) has a label ({label}) with a double hyphen ('--') "
+"in position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domänens MX ({name}) har domändelen '{label}' med bindestreck i position 3 "
+"Domänens MX ({domain}) har domändelen '{label}' med bindestreck i position 3 "
 "och 4 utan att börja med IDN-prefixet 'xn--'."
 
 #. SYNTAX:MX_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in MX ({name})."
-msgstr "Otillåtna tecken hittades i MX ({name})."
+msgid "Found illegal characters in MX ({domain})."
+msgstr "Otillåtna tecken hittades i MX ({domain})."
 
 #. SYNTAX:MX_NUMERIC_TLD
 #, perl-brace-format
-msgid "Domain name MX ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Domänens MX ('{name}') är i en helnumerisk TLD ({tld})."
+msgid "Domain name MX ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "Domänens MX ('{domain}') är i en helnumerisk TLD ({tld})."
 
 #. SYNTAX:MX_SYNTAX_OK
 #, perl-brace-format
-msgid "Domain name MX ({name}) syntax is valid."
-msgstr "MX-namnet '{name}' är giltigt."
+msgid "Domain name MX ({domain}) syntax is valid."
+msgstr "MX-namnet '{domain}' är giltigt."
 
 #. SYNTAX:NAMESERVER_DISCOURAGED_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Nameserver ({name}) has a label ({label}) with a double hyphen ('--') in "
+"Nameserver ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Namnservern '{name}' har domändelen ({label}) med bindestreck i position 3 "
+"Namnservern '{domain}' har domändelen ({label}) med bindestreck i position 3 "
 "och 4 utan att börja med IDN-prefixet 'xn--'."
 
 #. SYNTAX:NAMESERVER_NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in the nameserver ({name})."
-msgstr "Det finns otillåtna tecken i namnservernamnet '{name}'."
+msgid "Found illegal characters in the nameserver ({domain})."
+msgstr "Det finns otillåtna tecken i namnservernamnet '{domain}'."
 
 #. SYNTAX:NAMESERVER_NUMERIC_TLD
 #, perl-brace-format
-msgid "Nameserver ({name}) within a 'numeric only' TLD ({tld})."
-msgstr "Namnserver '{name}' finns under en helnumerisk TLD ('{tld}')."
+msgid "Nameserver ({domain}) within a 'numeric only' TLD ({tld})."
+msgstr "Namnserver '{domain}' finns under en helnumerisk TLD ('{tld}')."
 
 #. SYNTAX:NAMESERVER_SYNTAX_OK
 #, perl-brace-format
-msgid "Nameserver ({name}) syntax is valid."
-msgstr "Namnservernamnet '{name}' är giltigt."
+msgid "Nameserver ({domain}) syntax is valid."
+msgstr "Namnservernamnet '{domain}' är giltigt."
 
 #. SYNTAX:NON_ALLOWED_CHARS
 #, perl-brace-format
-msgid "Found illegal characters in the domain name ({name})."
-msgstr "Det finns otillåtna tecken i domännamnet '{name}'."
+msgid "Found illegal characters in the domain name ({domain})."
+msgstr "Det finns otillåtna tecken i domännamnet '{domain}'."
 
 #. SYNTAX:NO_DOUBLE_DASH
 #, perl-brace-format
 msgid ""
-"Domain name ({name}) has no label with a double hyphen ('--') in position 3 "
-"and 4 (with a prefix which is not 'xn--')."
+"Domain name ({domain}) has no label with a double hyphen ('--') in position "
+"3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domändelarna i domännamnet '{name}' har antingen inte bindestreck i position "
+"Domändelarna i domännamnet '{domain}' har antingen inte bindestreck i position "
 "3 och 4 eller har IDN-prefixet 'xn--'."
 
 #. SYNTAX:NO_ENDING_HYPHENS
 #, perl-brace-format
-msgid "Neither end of any label in the domain name ({name}) has a hyphen."
+msgid "Neither end of any label in the domain name ({domain}) has a hyphen."
 msgstr ""
-"Domännamnet '{name}' har ingen domändel som börjar eller slutar med ett "
+"Domännamnet '{domain}' har ingen domändel som börjar eller slutar med ett "
 "bindestreck."
 
 #. SYNTAX:NO_RESPONSE_MX_QUERY
@@ -1704,8 +1687,8 @@ msgstr "Inget svar från namnserver på fråga efter SOA-post."
 
 #. SYNTAX:ONLY_ALLOWED_CHARS
 #, perl-brace-format
-msgid "No illegal characters in the domain name ({name})."
-msgstr "Endast tillåtna tecken i namnet '{name}'."
+msgid "No illegal characters in the domain name ({domain})."
+msgstr "Endast tillåtna tecken i namnet '{domain}'."
 
 #. SYNTAX:RNAME_MAIL_DOMAIN_INVALID
 #, perl-brace-format
@@ -1738,9 +1721,10 @@ msgstr "Adressen i SOA RNAME ({rname}) är giltig enligt RFC822."
 
 #. SYNTAX:TERMINAL_HYPHEN
 #, perl-brace-format
-msgid "Domain name ({name}) has a label ({label}) ending with a hyphen ('-')."
+msgid ""
+"Domain name ({domain}) has a label ({label}) ending with a hyphen ('-')."
 msgstr ""
-"Domännamnet '{name}' har domändelen '{label}' som slutar med ett bindestreck."
+"Domännamnet '{domain}' har domändelen '{label}' som slutar med ett bindestreck."
 
 #. ZONE:RETRY_MINIMUM_VALUE_LOWER
 #, perl-brace-format
@@ -1945,14 +1929,9 @@ msgstr ""
 
 #. SYSTEM:CANNOT_CONTINUE
 #, perl-brace-format
-msgid "Not enough data about {zone} was found to be able to run tests."
+msgid "Not enough data about {domain} was found to be able to run tests."
 msgstr ""
-"Det finns inte tillräckligt med data om '{zone}' för att kunna köra tester."
-
-#. SYSTEM:PROFILE_FILE
-#, perl-brace-format
-msgid "Profile was read from {name}."
-msgstr "Profil lästes från '{name}'."
+"Det finns inte tillräckligt med data om '{domain}' för att kunna köra tester."
 
 #. SYSTEM:DEPENDENCY_VERSION
 #, perl-brace-format
@@ -1973,9 +1952,9 @@ msgstr ""
 #. SYSTEM:LOOKUP_ERROR
 #, perl-brace-format
 msgid ""
-"DNS query to {ns} for {name}/{type}/{class} failed with error: {message}"
+"DNS query to {ns} for {domain}/{type}/{class} failed with error: {message}"
 msgstr ""
-"DNS-fråga till {ns} för {name}/{type}/{class} misslyckades med felet: "
+"DNS-fråga till {ns} för {domain}/{type}/{class} misslyckades med felet: "
 "'{message}'."
 
 #. SYSTEM:MODULE_ERROR

--- a/share/sv.po
+++ b/share/sv.po
@@ -84,8 +84,8 @@ msgstr "TEST_CASE_START {testcase}."
 msgid ""
 "Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
 msgstr ""
-"Domändelen '{dlabel}' i domännamnet {domain} är för lång ({dlength}). Maximal "
-"längd är {max}."
+"Domändelen '{dlabel}' i domännamnet {domain} är för lång ({dlength}). "
+"Maximal längd är {max}."
 
 #. BASIC:DOMAIN_NAME_ZERO_LENGTH_LABEL
 #, perl-brace-format
@@ -777,8 +777,8 @@ msgid ""
 "Some, but not all, nameservers for zone {domain} respond with neither NSEC "
 "nor NSEC3 records when such records are expected."
 msgstr ""
-"Några av namnservrarna för zonen {domain} svarar med varken NSEC- eller NSEC3-"
-"post trots att endera förväntas."
+"Några av namnservrarna för zonen {domain} svarar med varken NSEC- eller "
+"NSEC3-post trots att endera förväntas."
 
 #. DNSSEC:INCONSISTENT_NSEC_NSEC3
 #, perl-brace-format
@@ -786,8 +786,8 @@ msgid ""
 "Some nameservers for zone {domain} respond with NSEC records and others "
 "respond with NSEC3 records. Consistency is expected."
 msgstr ""
-"Några av namnservrarna för zonen {domain} svarar med NSEC-poster och andra med "
-"NSEC3-poster. Det förväntade är att alla namnservrar ger samma posttyp."
+"Några av namnservrarna för zonen {domain} svarar med NSEC-poster och andra "
+"med NSEC3-poster. Det förväntade är att alla namnservrar ger samma posttyp."
 
 #. DNSSEC:ITERATIONS_OK
 #, perl-brace-format
@@ -878,8 +878,8 @@ msgid ""
 "Nameserver {ns} for zone {domain} responds with neither NSEC nor NSEC3 "
 "record when when such records are expected."
 msgstr ""
-"Nameservern {ns} för zonen {domain} svarar varken med NSEC- eller NSEC3-poster "
-"trots att sådana var förväntade."
+"Nameservern {ns} för zonen {domain} svarar varken med NSEC- eller NSEC3-"
+"poster trots att sådana var förväntade."
 
 #. DNSSEC:NO_RESPONSE_DNSKEY
 #, perl-brace-format
@@ -1023,9 +1023,9 @@ msgid ""
 "that is expected to give response with RCODE \"NXDOMAIN\". Test for NSEC and "
 "NSEC3 is aborted for this nameserver."
 msgstr ""
-"Namnservern {ns} för zonen {domain} svarade med statuskod (RCODE) 'NOERROR' på "
-"en förfrågan som förväntades ge statuskoden (RCODE) 'NXDOMAIN'. Test av NSEC "
-"och NSEC3 avbröts för denna namnserver."
+"Namnservern {ns} för zonen {domain} svarade med statuskod (RCODE) 'NOERROR' "
+"på en förfrågan som förväntades ge statuskoden (RCODE) 'NXDOMAIN'. Test av "
+"NSEC och NSEC3 avbröts för denna namnserver."
 
 #. DNSSEC:TOO_MANY_ITERATIONS
 #, perl-brace-format
@@ -1042,8 +1042,8 @@ msgid ""
 "Nameserver {ns} responded with an unexpected rcode ({rcode}) on a DS query "
 "for zone {domain}."
 msgstr ""
-"Namnserver {ns} besvarade en DS-fråga för zonen {domain} med den icke-väntade "
-"svarskoden \"{rcode}\"."
+"Namnserver {ns} besvarade en DS-fråga för zonen {domain} med den icke-"
+"väntade svarskoden \"{rcode}\"."
 
 #. DELEGATION:ARE_AUTHORITATIVE
 #, perl-brace-format
@@ -1453,7 +1453,8 @@ msgstr ""
 #, perl-brace-format
 msgid ""
 "Response without EDNS from {ns} on query with EDNS0 asking for {domain}."
-msgstr "Svar utan EDNS från {ns} på förfrågan med EDNS0 (fråga efter {domain})."
+msgstr ""
+"Svar utan EDNS från {ns} på förfrågan med EDNS0 (fråga efter {domain})."
 
 #. NAMESERVER:EDNS_VERSION_ERROR
 #, perl-brace-format
@@ -1588,8 +1589,8 @@ msgid ""
 "SOA MNAME ({domain}) has a label ({label}) with a double hyphen ('--') in "
 "position 3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"SOA MNAME '{domain}' har domändelen '{label}' med bindestreck i position 3 och "
-"4 utan att börja med IDN-prefixet 'xn--'."
+"SOA MNAME '{domain}' har domändelen '{label}' med bindestreck i position 3 "
+"och 4 utan att börja med IDN-prefixet 'xn--'."
 
 #. SYNTAX:MNAME_NON_ALLOWED_CHARS
 #, perl-brace-format
@@ -1665,8 +1666,8 @@ msgid ""
 "Domain name ({domain}) has no label with a double hyphen ('--') in position "
 "3 and 4 (with a prefix which is not 'xn--')."
 msgstr ""
-"Domändelarna i domännamnet '{domain}' har antingen inte bindestreck i position "
-"3 och 4 eller har IDN-prefixet 'xn--'."
+"Domändelarna i domännamnet '{domain}' har antingen inte bindestreck i "
+"position 3 och 4 eller har IDN-prefixet 'xn--'."
 
 #. SYNTAX:NO_ENDING_HYPHENS
 #, perl-brace-format
@@ -1724,7 +1725,8 @@ msgstr "Adressen i SOA RNAME ({rname}) är giltig enligt RFC822."
 msgid ""
 "Domain name ({domain}) has a label ({label}) ending with a hyphen ('-')."
 msgstr ""
-"Domännamnet '{domain}' har domändelen '{label}' som slutar med ett bindestreck."
+"Domännamnet '{domain}' har domändelen '{label}' som slutar med ett "
+"bindestreck."
 
 #. ZONE:RETRY_MINIMUM_VALUE_LOWER
 #, perl-brace-format


### PR DESCRIPTION
This is another step towards solving #60 and #713. The main focus is renaming domain name arguments to "domain".

An accidental omission from #853 is also included,
in a couple of places missing arguments were added,
a few unused messages are cleaned up, and
some refactoring is included in order to ease the renaming of the domain arguments.