### PR TITLE
Check manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           git clone --branch=develop --depth=1 https://github.com/zonemaster/zonemaster-ldns.git
           perl Makefile.PL  # Generate MYMETA.yml to appease cpanm .
           ( cd zonemaster-ldns ; cpanm --notest . )
+          rm -rf zonemaster-ldns
 
       - name: Install remaining dependencies
         run: |

--- a/MANIFEST
+++ b/MANIFEST
@@ -69,6 +69,7 @@ t/asn.data
 t/asn.t
 t/dnsname.t
 t/logger.t
+t/manifest.t
 t/nameserver-axfr.data
 t/nameserver-axfr.t
 t/nameserver.data

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,6 +40,7 @@ test_requires 'Pod::Coverage'     => 0;
 test_requires 'Test::Differences' => 0;
 test_requires 'Test::Exception'   => 0;
 test_requires 'Test::Fatal'       => 0;
+test_requires 'Test::NoWarnings'  => 0;
 test_requires 'Test::Pod'         => 1.22;
 
 # Make all platforms include inc/Module/Install/External.pm

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -39,7 +39,7 @@ This instruction covers the following operating systems:
 3) Install binary packages:
 
    ```sh
-   sudo yum --assumeyes install cpanminus gcc libidn-devel openssl-devel perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Module-Find perl-Moose perl-Net-IP perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-Pod perl-Text-CSV perl-YAML
+   sudo yum --assumeyes install cpanminus gcc libidn-devel openssl-devel perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Module-Find perl-Moose perl-Net-IP perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-YAML
    ```
 
 4) Install packages from CPAN:
@@ -77,7 +77,7 @@ This instruction covers the following operating systems:
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl libjson-pp-perl liblist-moreutils-perl liblocale-msgfmt-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-xs-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-pod-perl libtext-csv-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl libjson-pp-perl liblist-moreutils-perl liblocale-msgfmt-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-xs-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
@@ -123,8 +123,9 @@ This instruction covers the following operating systems:
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Locale-Msgfmt p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
+   pkg install devel/gmake libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Locale-Msgfmt p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
    ```
+
 6) Install Zonemaster::LDNS:
 
    ```sh

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -9,10 +9,6 @@ PMFILES := $(shell find ../lib -type f -name '*.pm' | sort)
 TESTMODULEFILES := $(shell find ../lib/Zonemaster/Engine/Test -type f -name '*.pm' | sort)
 
 all: $(MOFILES) modules.txt
-	@echo
-	@echo Remember to make sure all of the above names are in the
-	@echo MANIFEST file, or they will not be installed.
-	@echo
 
 # Tidy the formatting of all PO files
 tidy-po:

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -1,0 +1,35 @@
+#!perl
+use v5.14.2;
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 2;
+use Test::NoWarnings;
+
+use File::Basename qw( dirname );
+
+chdir dirname( dirname( __FILE__ ) ) or BAIL_OUT( "chdir: $!" );
+
+my $makebin = 'make';
+
+sub make {
+    my @make_args = @_;
+
+    my $command = join( ' ', $makebin, '-s', @make_args );
+    my $output = `$command 2>&1`;
+
+    if ( $? == -1 ) {
+        BAIL_OUT( "failed to execute: $!" );
+    }
+    elsif ( $? & 127 ) {
+        BAIL_OUT( "child died with signal %d, %s coredump\n", ( $? & 127 ), ( $? & 128 ) ? 'with' : 'without' );
+    }
+
+    return $output, $? >> 8;
+}
+
+subtest "distcheck" => sub {
+    my ( $output, $status ) = make "distcheck";
+    is $status, 0,  $makebin . ' distcheck exits with value 0';
+    is $output, "", $makebin . ' distcheck gives empty output';
+};


### PR DESCRIPTION
## Context

Fixes #902.

## Changes

This PR adds t/manifest.t which runs `make distcheck`.

## How to test this PR

Make sure we don't interfere with the release process:
```sh
git clean -dfx   # Start out with a clean repository
perl Makefile.PL # Generate the top-level Makefile
make all         # Generate MO files and modules.txt
make distcheck   # Verify that distcheck doesn't report any missing or unrecognized files
```

Run the unit tests in the source directory:
```sh
make distcheck     # Make sure distcheck doesn't report any missing or unrecognized files
prove t/manifest.t # Verify the new test passes
touch example.txt  # Create a file but don't add it to MANIFEST
prove t/manifest.t # Verify the new test fails
```

Run the unit tests in the dist file:
```sh
make distcheck                               # Make sure your repo is clean
make dist                                    # Create the dist file
cpanm --test-only Zonemaster-Engine-*.tar.gz # Run the tests included in the dist file
```