### PR TITLE
Remove installation instruction for FreeBSD 11

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -89,9 +89,9 @@ This instruction covers the following operating systems:
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
 
-     ```sh
-     sudo cpanm Zonemaster::LDNS Zonemaster::Engine
-     ```
+   ```sh
+   sudo cpanm Zonemaster::LDNS Zonemaster::Engine
+   ```
 
 ### Installation on FreeBSD
 
@@ -129,37 +129,14 @@ This instruction covers the following operating systems:
 
 5) Install dependencies from binary packages:
 
-   * On all versions of FreeBSD install:
-
-     ```sh
-     pkg install devel/gmake libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Locale-Msgfmt p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP
-     ```
-
-   * On FreeBSD 11.x (11.3 or newer) also install OpenSSL 1.1.1 or newer:
-
-     ```sh
-     pkg install security/openssl
-     ```
-
-   * On FreeBSD 12.x (12.1 or newer) also install:
-
-     ```sh
-     pkg install dns/ldns
-     ```
-
+   ```sh
+   pkg install devel/gmake libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Locale-Msgfmt p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
+   ```
 6) Install Zonemaster::LDNS:
 
-   * On FreeBSD 11.x (11.3 or newer):
-
-     ```sh
-     cpanm Zonemaster::LDNS
-     ```
-
-   * On FreeBSD 12.x (12.1 or newer):
-
-     ```sh
-     cpanm --configure-args="--no-internal-ldns" Zonemaster::LDNS
-     ```
+   ```sh
+   cpanm --configure-args="--no-internal-ldns" Zonemaster::LDNS
+   ```
 
 7) Install Zonemaster::Engine:
 


### PR DESCRIPTION
FreeBSD 11 is not supported anymore, and FreeBSD 13 follows the same instructions as FreeBSD 12.

--------------------
## How to test this PR

Successful installation testing will verify this PR.
