### PR TITLE
Translator tooling installation on CentOS

### DIFF
--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -22,7 +22,11 @@ but you will have to find instructions elsewhere.
 
 * CentOS
 
-  To be written.
+  Install the following:
+  ```
+  yum install git make perl-App-cpanminus perl-Try-Tiny
+  cpanm Locale::PO
+  ```
 
 * Debian
 


### PR DESCRIPTION
## Purpose

This PR spells out what packages to  install to get up and running as a translator on CentOS.

## Changes

"To be written" is replaced with actual commands for installation in the software preparation section of the translator documentation.

## How to test this PR

Verify that all steps in the translator documentation can be followed without any commands crashing because of lacking dependencies.