### PR TITLE
Update CentOS installation instruction

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -33,28 +33,22 @@ This instruction covers the following operating systems:
 2) Install the [EPEL] repository:
 
    ```sh
-   sudo yum --enablerepo=extras install epel-release
+   sudo yum --assumeyes --enablerepo=extras install epel-release
    ```
 
-3) Make sure the development environment is installed:
+3) Install binary packages:
 
    ```sh
-   sudo yum groupinstall "Development Tools"
+   sudo yum --assumeyes install cpanminus gcc libidn-devel openssl-devel perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Module-Find perl-Moose perl-Net-IP perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-Pod perl-Text-CSV perl-YAML
    ```
 
-4) Install binary packages:
-
-   ```sh
-   sudo yum install cpanminus libidn-devel openssl-devel perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Module-Find perl-Moose perl-Net-IP perl-Pod-Coverage perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-Pod perl-Text-CSV perl-YAML perl-MailTools
-   ```
-
-5) Install packages from CPAN:
+4) Install packages from CPAN:
 
    ```sh
    sudo cpanm Locale::Msgfmt Module::Install Module::Install::XSUtil MooseX::Singleton Test::More
    ```
 
-6) Install Zonemaster::LDNS and Zonemaster::Engine for *CentOS 7*:
+5) Install Zonemaster::LDNS and Zonemaster::Engine for *CentOS 7*:
 
    ```sh
    sudo cpanm --configure-args="--no-ed25519" Zonemaster::LDNS
@@ -67,7 +61,7 @@ This instruction covers the following operating systems:
 > **Note**: Support for DNSSEC algorithms 15 (Ed25519) and 16 (Ed448) is not
 > included in CentOS 7. OpenSSL version 1.1.1 or higher is required.
 
-7) Install Zonemaster::LDNS and Zonemaster::Engine for *CentOS 8*:
+6) Install Zonemaster::LDNS and Zonemaster::Engine for *CentOS 8*:
 
    ```sh
    sudo cpanm Zonemaster::LDNS Zonemaster::Engine

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -48,24 +48,23 @@ This instruction covers the following operating systems:
    sudo cpanm Locale::Msgfmt Module::Install Module::Install::XSUtil MooseX::Singleton Test::More
    ```
 
-5) Install Zonemaster::LDNS and Zonemaster::Engine for *CentOS 7*:
+5) Install Zonemaster::LDNS and Zonemaster::Engine:
 
-   ```sh
-   sudo cpanm --configure-args="--no-ed25519" Zonemaster::LDNS
-   ```
+   * CentOS 7:
 
-   ```sh
-   sudo cpanm Zonemaster::Engine
-   ```
+     ```sh
+     sudo cpanm --configure-args="--no-ed25519" Zonemaster::LDNS
+     sudo cpanm Zonemaster::Engine
+     ```
 
-> **Note**: Support for DNSSEC algorithms 15 (Ed25519) and 16 (Ed448) is not
-> included in CentOS 7. OpenSSL version 1.1.1 or higher is required.
+     > **Note**: Support for DNSSEC algorithms 15 (Ed25519) and 16 (Ed448) is not
+     > included in CentOS 7. OpenSSL version 1.1.1 or higher is required.
 
-6) Install Zonemaster::LDNS and Zonemaster::Engine for *CentOS 8*:
+   * CentOS 8:
 
-   ```sh
-   sudo cpanm Zonemaster::LDNS Zonemaster::Engine
-   ```
+     ```sh
+     sudo cpanm Zonemaster::LDNS Zonemaster::Engine
+     ```
 
 ### Installation on Debian
 


### PR DESCRIPTION
## Purpose

This PR provides some incremental improvements to the installation experience for CentOS. It also performs some clean-up.

## Changes

* On CentOS we're installing a pretty big group of dependencies named Development Tools. The only package we need from this group is actually gcc. This PR replaces Development Tools with gcc.
* The perl-MailTools package is removed from the installation instruction. It's not a direct dependency of ours so it doesn't belong there.
* All yum commands are made non-interactive to make the installation experience less staggered.
* Formatting is cleaned up in the CentOS section of the installation instruction.

## How to test this PR

This PR is implicitly tested as part of installation testing.