### PR TITLE
Replace "make xx.po" with a script

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -56,10 +56,10 @@ sub MY::postamble {
         # Make FreeBSD use gmake for share/Makefile
         $text = 'GMAKE ?= "gmake"' . "\n"
             . 'pure_all :: share/Makefile' . "\n"
-            . "\t" . 'cd share && $(GMAKE) touch-po all' . "\n";
+            . "\t" . 'cd share && $(GMAKE) all' . "\n";
     } else {
         $text = 'pure_all :: share/Makefile' . "\n"
-            . "\t" . 'cd share && $(MAKE) touch-po all' . "\n";
+            . "\t" . 'cd share && $(MAKE) all' . "\n";
     };
     return $text;
 };

--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -79,8 +79,8 @@ ids based on fuzzy matching of similar strings. This is not always desirable
 and you can disable fuzzy matching by executing one of the following
 commands instead:
 ```
-make update-po MSGMERGE_OPTS=--no-fuzzy-mathing POFILES=xx.po
-make update-po MSGMERGE_OPTS=--no-fuzzy-mathing
+make update-po MSGMERGE_OPTS=--no-fuzzy-matching POFILES=xx.po
+make update-po MSGMERGE_OPTS=--no-fuzzy-matching
 ```
 
 ## Github preparation

--- a/docs/Translation-translators.md
+++ b/docs/Translation-translators.md
@@ -63,7 +63,8 @@ Currently there are the following files (and languages):
 * nb.po (Norwegian)
 * sv.po (Swedish)
 
-Execute `make xx.po` to update the *PO* file for language "xx".
+Execute `./update-po xx.po` to update the *PO* file for language
+"xx".
 Choose the language code for the language that you want to update.
 The command will update the *PO* file with new message ids (*msgid*) from the
 source code.
@@ -78,7 +79,7 @@ ids based on fuzzy matching of similar strings. This is not always desirable
 and you can disable fuzzy matching by executing one of the following
 commands instead:
 ```
-make xx.po MSGMERGE_OPTS=--no-fuzzy-mathing
+make update-po MSGMERGE_OPTS=--no-fuzzy-mathing POFILES=xx.po
 make update-po MSGMERGE_OPTS=--no-fuzzy-mathing
 ```
 
@@ -167,7 +168,7 @@ welcome comments on these.
   language code in question. This should be done every time.
   ```
   cd share
-  make xx.po
+  ./update-po xx.po
   ```
 
 * The *PO* file is updated with new *msgids*, if any, and now you can start
@@ -272,7 +273,7 @@ steps before this step:
   >   to work with. Replace "xx" with the language code in question.
   > ```
   > cd share
-  > make xx.po
+  > ./update-po xx.po
   > ```
 
 The new language is not there and cannot be updated. Instead you have to
@@ -293,7 +294,7 @@ of an existing file.
   for Swedish.
   ```
   cd share
-  make sv.po
+  ./update-po sv.po
   cp sv.po xx.po
   git checkout sv.po
   ```

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -1,6 +1,6 @@
 .POSIX:
 .SUFFIXES: .po .mo
-.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy touch-po update-po
+.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po
 
 POFILES := $(shell find . -maxdepth 1 -type f -name '*.po' -exec basename {} \;)
 MOFILES := $(POFILES:%.po=%.mo)
@@ -19,9 +19,6 @@ tidy-po:
 	@tmpdir="`mktemp -d tidy-po.XXXXXXXX`" ;\
 	trap 'rm -rf "$$tmpdir"' EXIT ;\
 	for f in $(POFILES) ; do msgcat $$f -o $$tmpdir/$$f && mv -f $$tmpdir/$$f $$f  ; done
-
-touch-po:
-	@touch $(POFILES)
 
 update-po: extract-pot
 	@for f in $(POFILES) ; do msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $$f $(POTFILE) ; done

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -21,17 +21,15 @@ tidy-po:
 	for f in $(POFILES) ; do msgcat $$f -o $$tmpdir/$$f && mv -f $$tmpdir/$$f $$f  ; done
 
 touch-po:
-	@touch $(POTFILE) $(POFILES)
+	@touch $(POFILES)
 
-update-po: extract-pot $(POFILES)
+update-po: extract-pot
+	@for f in $(POFILES) ; do msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $$f $(POTFILE) ; done
 
 extract-pot:
 	@xgettext --output $(POTFILE) --sort-by-file --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)
 
 $(POTFILE): extract-pot
-
-$(POFILES): $(POTFILE)
-	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
 
 .po.mo:
 	@msgfmt -o $@ $<

--- a/share/update-po
+++ b/share/update-po
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "$1" ] ; then
+    echo "error: No PO file specified." >&2
+    exit 2
+fi
+po_file="$1" ; shift
+
+make update-po POFILES="$po_file"


### PR DESCRIPTION
## Purpose

This PR makes the updating of msgids in PO files more robust.

## Context

This PR fixes #930.
It also provides some ground work for fixing #902.

## Changes

This PR changes how translators update their PO files with fresh msgids.

This PR makes the PO files not be make targets anymore. The `share/update-po` script is provided as a replacement for updating PO files with fresh msgids.

The touch-po hack is cleaned up since it's no longer needed after the PO files are demoted from being make targets.

## How to test this PR

Verify that all translator use cases are still supported by verifying all steps in the updated Translation-translators.md.