### PR TITLE
Restores including latest release of Zonemaster::LDNS in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         compatibility:
           - develop
-          #- latest
+          - latest
         perl:
           - '5.32'
           - '5.26'


### PR DESCRIPTION
## Purpose

Make Github actions include latest release of Zonemaster::LDNS in tests.

## Context

Reverts 88075c0c193fd9175727c7d1a558230d85869937 from #896.

## Changes

Removes commenting.

## How to test this PR

Verify that latest release of Zonemaster::LDNS is run in the relevant tests.