### PR TITLE
- Fixes fatal error in output for basic04 test

### DIFF
--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -5,7 +5,7 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare("v1.0.17");
+use version; our $VERSION = version->declare("v1.0.18");
 
 use Zonemaster::Engine;
 

--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -668,8 +668,8 @@ sub basic04 {
                       );
                 }
                 else {
-                    my ( $ns ) = $p_ns_udp->get_records( q{NS}, q{answer} );
-                    if ( not $ns ) {
+                    my ( $ns_in_answer ) = $p_ns_udp->get_records( q{NS}, q{answer} );
+                    if ( not $ns_in_answer ) {
                         push @results,
                           info(
                             B04_MISSING_NS_RECORD => {
@@ -678,12 +678,12 @@ sub basic04 {
                           );
                     }
                     else {
-                        if ( lc($ns->owner) ne lc($name->fqdn) ) {
+                        if ( lc($ns_in_answer->owner) ne lc($name->fqdn) ) {
                             push @results,
                               info(
                                 B04_WRONG_NS_RECORD => {
                                     ns    => $ns->string,
-                                    owner => lc($ns->owner),
+                                    owner => lc($ns_in_answer->owner),
                                     name  => lc($name->fqdn)
                                 }
                               );


### PR DESCRIPTION
## Purpose

This PR fixes fatal error in output for basic.

## Context

Fixes  zonemaster/zonemaster-engine#948

## Changes

basic04 method has been updated

## How to test this PR

`zonemaster-cli --test basic kamglass.com.pl`
