### PR TITLE
Correct msgid for MX_RECORD_EXISTS (Zone9)

### DIFF
--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -9,14 +9,16 @@
 | algo_num    | Non-negative integer | The numeric value for a [DNSSEC algorithm].                 |
 | domain      | Domain name          | A domain name. If nsname is also applicable, use that one instead. |
 | keytag      | Non-negative integer | A keytag for a DNSKEY record or a keytag used in a DS or RRSIG record. |
+| mailtarget  | Domain name          | The domain name of the mailserver in an MX RDATA.           |
+| mailtarget_list|List of domain names|A list of name servers, as specified by "mailtarget", separated by ";". |
 | module      | A Zonemaster test module, or `all` | The name of a Zonemaster test module.         |
 | module_list | List of Zonemaster test modules | A list of Zonemaster test modules, separated by ":". |
-| nsname      | Domain name          | The domain name of a name server.                           |
-| ns_ip       | IP address           | The IP address of a name server.                            |
 | ns          | Domain name and IP address pair | The name and IP address of a name server, separated by "/". |
-| nsname_list | List of domain names | A list of name servers, as specified by "nsname", separated by ";". |
+| ns_ip       | IP address           | The IP address of a name server.                            |
 | ns_ip_list  | List of IP addresses | A list of name servers, as specified by "ns_ip", separated by ";". |
 | ns_list     | List of domain name and IP address pairs | A list of name servers, as specified by "ns", separated by ";". |
+| nsname      | Domain name          | The domain name of a name server.                           |
+| nsname_list | List of domain names | A list of name servers, as specified by "nsname", separated by ";". |
 | testcase    | A Zonemaster test case, or `all` | A test case identifier.                         |
 || AS number| An Autonomous Space number for an IP address.|
 || Address record type (A or AAAA)| Used to tell the difference between IPv4 and IPv6.|

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -188,7 +188,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     MX_RECORD_EXISTS => sub {
         __x    # ZONE:MX_RECORD_EXISTS
-          'Target ({info}) found to deliver e-mail for the domain name.', @_;
+          'MX with mail target ({mailtarget_list}) exists for the domain name.', @_;
     },
     REFRESH_MINIMUM_VALUE_LOWER => sub {
         __x    # ZONE:REFRESH_MINIMUM_VALUE_LOWER
@@ -666,15 +666,15 @@ sub zone09 {
         else {
             my @mx = $p->get_records_for_name( q{MX}, $zone->name );
             for my $mx ( @mx ) {
-                my $tmp = q{MX=};
-                $tmp .= $mx->exchange;
+                my $tmp = $mx->exchange;
                 $tmp =~ s/[.]\z//smx;
-                $info .= $tmp . q{/};
+                $info .= $tmp . q{;};
             }
             chop $info;
         }
+
         if ( not grep { $_->tag ne q{TEST_CASE_START} } @results ) {
-            push @results, info( MX_RECORD_EXISTS => { info => $info } );
+            push @results, info( MX_RECORD_EXISTS => { mailtarget_list => $info } );
         }
     } ## end if ( $p )
     else {


### PR DESCRIPTION
## Purpose

Corrects msgid for MX_RECORD_EXISTS (Zone9). New log entry parameters are defined.

## Context

Resolves #967. Reported in zonemaster/zonemaster#990.

## Changes

The following files are changed:
*  docs/logentry_args.md 
* lib/Zonemaster/Engine/Test/Zone.pm 


## How to test this PR

When running a test of a domain with MX record, e.g. zonemaster.net, verify that the updated msgid is presented when language is English.