### PR TITLE
- Fixes Output issue

### DIFF
--- a/lib/Zonemaster/Engine/Logger/Entry.pm
+++ b/lib/Zonemaster/Engine/Logger/Entry.pm
@@ -5,7 +5,7 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare("v1.1.7");
+use version; our $VERSION = version->declare("v1.1.8");
 
 use Time::HiRes qw[time];
 use JSON::PP;
@@ -72,10 +72,9 @@ sub _build_testcase {
     my ( $self ) = @_;
 
     foreach my $e ( @{ $self->trace } ) {
-        if (    $e->[0] =~ /^(Zonemaster::Engine::Test::)([^:]+)$/
-            and $e->[1] =~ /^$1$2::($2[0-9]+)$/i )
+        if ( $e->[1] =~ /^Zonemaster::Engine::Test::([^:]+)::(\1[0-9]+)$/i )
         {
-            return uc $1;
+            return uc $2;
         }
     }
 


### PR DESCRIPTION
## Purpose

This PR fixes unexpected output with --show_testcase and --test module/method_name

## Context

Fixes zonemaster/zonemaster-engine#970

## Changes

method-name is now well displayed

## How to test this PR

zonemaster-cli --level INFO --show_testcase --test dnssec/dnssec15 nic.fr
