### PR TITLE
Adds missing entry in MANIFEST.SKIP

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -6,6 +6,7 @@
 ^\.perltidyrc$
 ^\.travis\.yml$
 ^util/
+^share/update-po$         # PO files are exluded from dist, which makes this script meaningless in dist
 ^share/Zonemaster-Engine.pot$
 ^t/po-files.t$            # PO files are excluded from dist, so we cannot test them
 


### PR DESCRIPTION
## Purpose

Make MANIFEST/MANIFEST.SKIP cover all files.

## Context

Resolves #966.

## Changes

Updates MANIFEST.SKIP.

## How to test this PR

When running "make distcheck" there should be no files in neither MANIFEST nor MANIFEST.SKIP.