### PR TITLE
fix po test

### DIFF
--- a/t/po-files.t
+++ b/t/po-files.t
@@ -15,6 +15,8 @@ my $makebin = 'make';
 sub make {
     my @make_args = @_;
 
+    undef $ENV{MAKEFLAGS};
+
     my $command = join( ' ', $makebin, '--silent', '--no-print-directory', @make_args );
     my $output = `$command`;
 


### PR DESCRIPTION
## Purpose

Fix po-files test when MAKEFLAGS is set to verbose output.

## Context

Ported from https://gitlab.rd.nic.fr/zonemaster/packages/debian/-/blob/bullseye/libzonemaster-engine-perl/debian/patches/01-Fix-test-po-files 

## Changes

Unset MAKFEFLAGS.

## How to test this PR

Running `MAKEFLAGS='--no-silent' perl ./t/po-files.t` should be successful
