### PR TITLE
Removes Locale::Msgfmt from dependency list. Is not a dependency.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,8 +14,6 @@ bugtracker 'https://github.com/zonemaster/zonemaster-engine/issues';
 
 all_from 'lib/Zonemaster/Engine.pm';
 
-configure_requires 'Locale::Msgfmt' => 0.15;
-
 # "2.1.0" could be declared as "2.001" but not as "2.1"
 # (see Zonemaster::LDNS below)
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -45,7 +45,7 @@ This instruction covers the following operating systems:
 4) Install packages from CPAN:
 
    ```sh
-   sudo cpanm Locale::Msgfmt Module::Install Module::Install::XSUtil MooseX::Singleton Test::More
+   sudo cpanm Module::Install Module::Install::XSUtil MooseX::Singleton Test::More
    ```
 
 5) Install Zonemaster::LDNS and Zonemaster::Engine:
@@ -77,7 +77,7 @@ This instruction covers the following operating systems:
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl libjson-pp-perl liblist-moreutils-perl liblocale-msgfmt-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-xs-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl libjson-pp-perl liblist-moreutils-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-xs-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
@@ -123,7 +123,7 @@ This instruction covers the following operating systems:
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Locale-Msgfmt p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
+   pkg install devel/gmake libidn p5-App-cpanminus p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
    ```
 
 6) Install Zonemaster::LDNS:


### PR DESCRIPTION
## Purpose

`Locale::Msgfmt` is listed as dependency, but it is not. The PR removes it from the dependency listing.

## Context

#996 also updates the installation document, and should be merged first. 

See https://github.com/zonemaster/zonemaster-backend/pull/891#discussion_r748314363 for discussion on the need of the library.

## Changes

The PR updates
* Makefile.PL
* docs/Installation.md 

## How to test this PR

1. Make sure that the library is not installed, e.g. 
```sh
perl -E 'use Locale::Msgfmt; say $Locale::Msgfmt::VERSION;'
```
2. Install Zonemaster::Engine.
3. Run the command again to verify that the library has not been installed in the background.


