### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ This repository does not need any specific configuration.
 
 ## Docker
 
-Zonemaster-CLI is available on [Docker Hub], and can be run without any
-installation. See [USING] Zonemaster-CLI for how to run it on Docker.
+Zonemaster-CLI is available on [Docker Hub], and can be conveniently downloaded
+and run without any installation. See [USING] Zonemaster-CLI for how to run
+Zonemaster-CLI on Docker.
 
-To build your own Docker image, see [Create Docker Image] documentation.
+To build your own Docker image, see the [Docker Image Creation] documentation.
 
 
 ## Documentation
@@ -48,8 +49,8 @@ For participation, contact and bug reporting, please see
 
 
 [CPAN site]:                                      https://metacpan.org/pod/Zonemaster::Engine
-[Create Docker Image]:                            https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
 [Docker Hub]:                                     https://hub.docker.com/u/zonemaster
+[Docker Image Creation]:                          https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
 [Docs]:                                           docs/
 [Installation]:                                   docs/Installation.md
 [USING]:                                          https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ To build your own Docker image, see the [Docker Image Creation] documentation.
 There is full POD coverage of the Perl code. The documentation can be
 read on the [CPAN site].
 
-More documentations regarding translating the output to another language,
-implementing a new test and the log entries are found under the [docs] directory.
+Documentation on Zonemaster-Engine is also found under the [docs] directory.
 
 
 ## Participation, Contact and Bug reporting

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Zonemaster Engine
-[![Build Status](https://travis-ci.org/zonemaster/zonemaster-engine.svg?branch=master)](https://travis-ci.org/zonemaster/zonemaster-engine)
-[![CPAN version](https://badge.fury.io/pl/Zonemaster-Engine.svg)](https://badge.fury.io/pl/Zonemaster-Engine)
 
 ## Purpose
 
 This repository holds one of the components of the Zonemaster product. For an
 overview of the Zonemaster software, please see the
-[Zonemaster main repository](https://github.com/zonemaster/zonemaster).
+[Zonemaster main repository].
 
 This Git repository contains the *Zonemaster Engine testing framework*,
 and contains all code needed to perform the full suite of Zonemaster
@@ -14,55 +12,34 @@ tests.
 
 ## Prerequisites
 
-For supported processor architectures, operating systems and Perl versions see 
-[Zonemaster/README.md](https://github.com/zonemaster/zonemaster/blob/master/README.md).
+For supported processor architectures, operating systems and Perl versions see
+[Zonemaster/README.md].
 
 ## Installation
 
 Installation instructions for the Engine is provided in the
-[installation](docs/Installation.md) document.
+[installation] document.
 
-## Configuration 
+## Configuration
 
 This repository does not need any specific configuration.
 
 ## Docker
 
-To build a local base image for Zonemaster Engine you need a [local Zonemaster
-LDNS base image].
+Zonemaster-CLI is available on [Docker Hub], and can be run without any
+installation. See [USING] Zonemaster-CLI for how to run it on Docker.
 
-Build a new local base image:
+To build your own Docker image, see [Create Docker Image] documentation.
 
-```sh
-make all dist docker-build
-```
-
-Tag the local base image with the current version number:
-
-```sh
-make docker-tag-version
-```
-
-Tag the local base image as the latest version:
-
-```sh
-make docker-tag-latest
-```
-
-Perform smoke test on the local base image:
-
-```sh
-docker run --rm zonemaster/engine:local perl -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("BASIC", "zonemaster.net")'
-```
 
 ## Documentation
 
 There is full POD coverage of the Perl code. The documentation can be
-read on the [CPAN site](https://metacpan.org/pod/Zonemaster::Engine).
+read on the [CPAN site].
 
-For a curious user, there are documentations regarding translating the output to
-a new language, implementing a new test and the log entries under the directory
-[docs](docs/). 
+More documentations regarding translating the output to another language,
+implementing a new test and the log entries under the directory are found under
+the [docs] directory.
 
 ## Participation, Contact and Bug reporting
 
@@ -70,10 +47,14 @@ For participation, contact and bug reporting, please see
 [Zonemaster/README.md](https://github.com/zonemaster/zonemaster/blob/master/README.md).
 
 
-## License
+[CPAN site]:                                      https://metacpan.org/pod/Zonemaster::Engine
+[Create Docker Image]:                            https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+[Docker Hub]:                                     https://hub.docker.com/u/zonemaster
+[Docs]:                                           docs/
+[Installation]:                                   docs/Installation.md
+[USING]:                                          https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
+[Zonemaster main repository]:                     https://github.com/zonemaster/zonemaster
+[Zonemaster/README.md]:                           https://github.com/zonemaster/zonemaster/blob/master/README.md
 
-The software is released under the 2-clause BSD license. See separate LICENSE file.
 
 
-
-[Local Zonemaster LDNS base image]: https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md#docker

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ There is full POD coverage of the Perl code. The documentation can be
 read on the [CPAN site].
 
 More documentations regarding translating the output to another language,
-implementing a new test and the log entries under the directory are found under
-the [docs] directory.
+implementing a new test and the log entries are found under the [docs] directory.
+
 
 ## Participation, Contact and Bug reporting
 


### PR DESCRIPTION
## Purpose

This PR:

* Removes detailed Docker build information and adds referral to other document.
* Adds referral to document how to run Zonemaster-CLI on Docker.
* Adds editorial updates.

The updated document has a referral to a document that does not yet exist in the master branch, only in the develop branch. The link is, and should be, to the master branch.
```
https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
```

## Comment

The plan was to update the Installation document too to include some information on Docker, but that document is currently "locked" by PR #996.

## Changes

Updates the README.md file.

## How to test this PR

Documentation only.
