### PR TITLE
Add missing short descr for Nameserver test cases

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -5,7 +5,7 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare("v1.0.26");
+use version; our $VERSION = version->declare( "v1.0.27" );
 
 use Zonemaster::Engine;
 
@@ -1279,19 +1279,19 @@ Check whether authoritative name servers return same results for equivalent name
 
 =item nameserver10($zone)
 
-WIP
+Check whether authoritative name servers respond correctly to queries with undefined EDNS version.
 
 =item nameserver11($zone)
 
-WIP
+Check whether authoritative name servers responses doe not include unknown EDNS OPTION-CODE used in query.
 
 =item nameserver12($zone)
 
-WIP
+Check whether authoritative name servers responses has "Z" bits cleared even if they are set in the query.
 
 =item nameserver13($zone)
 
-WIP
+This Test Case will try to verify that if the response to a query with an OPT record is truncated, then the response will contain an OPT record.
 
 =back
 


### PR DESCRIPTION
## Purpose

This add some missing descriptions of test cases

- Nameserver10
- Nameserver11
- Nameserver12
- Nameserver13

Nameserver14 is not yet implemented

## Context

Fixes zonemaster/zonemaster-engine#1001

## Changes

Complete POD in Zonemaster::Engine::Test::Nameserver

## How to test this PR

Run :

`zonemaster-cli --list-tests`
