### PR TITLE
exclude debian files from manifest

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -73,3 +73,7 @@
 
 # For Github action
 ^\.github/
+
+# Debian packaging
+^debian/
+^.pc/


### PR DESCRIPTION
## Purpose

Fix `make distcheck` when run while building the deb package.

## Context

Port [patch](https://gitlab.rd.nic.fr/zonemaster/packages/debian/-/blob/0f2054700c7245d498370bee039f2c7538be5cd9/libzonemaster-engine-perl/debian/patches/01_fix-manifest.patch) in upstream

## Changes

exlucde `debian` and `.pc` directories

## How to test this PR

