### PR TITLE
Clean up dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN apk add --no-cache \
  && cpanm --no-wget --from=https://cpan.metacpan.org/ \
     Email::Valid \
     Locale::TextDomain \
-    JSON::PP \
     Module::Find \
     MooseX::Singleton \
     Readonly::XS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM zonemaster/ldns:local as build
 
 RUN apk add --no-cache \
-    # Only needed for Readonly::XS
-    build-base \
+    # Only needed for CPAN deps
     make \
-    perl-dev \
+    # Transitive deps included to improve build speed
+    perl-mailtools \
+    perl-module-build-tiny \
     # Compile-time dependencies
     perl-app-cpanminus \
     perl-clone \
@@ -27,8 +28,7 @@ RUN apk add --no-cache \
     Email::Valid \
     Locale::TextDomain \
     Module::Find \
-    MooseX::Singleton \
-    Readonly::XS
+    MooseX::Singleton
 
 ARG version
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,6 @@ requires 'Email::Valid'       => 0;
 requires 'File::ShareDir'     => 1.00;
 requires 'File::Slurp'        => 0;
 requires 'IO::Socket::INET6'  => 2.69;
-requires 'JSON::PP'           => 0;
 requires 'List::MoreUtils'    => 0;
 requires 'Locale::TextDomain' => 1.20;
 requires 'Module::Find'       => 0.10;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -46,7 +46,6 @@ if ($^O eq "freebsd") {
     requires_external_bin 'gmake';
 };
 
-recommends 'Readonly::XS' => 0;
 recommends 'Net::IP::XS'  => 0;
 
 sub MY::postamble {

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -59,7 +59,7 @@ Zonemaster::Engine, see the [declaration of prerequisites].
 3) Install binary packages:
 
    ```sh
-   sudo dnf --assumeyes install cpanminus gcc libidn-devel openssl-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-JSON-PP perl-List-MoreUtils perl-Module-Find perl-Module-Install perl-Moose perl-Net-IP perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple perl-YAML
+   sudo dnf --assumeyes install cpanminus gcc libidn-devel openssl-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Module-Find perl-Module-Install perl-Moose perl-Net-IP perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple perl-YAML
    ```
 
 4) Install packages from CPAN:
@@ -107,7 +107,7 @@ install from CPAN instead, follow the steps for Ubuntu.
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl libjson-pp-perl liblist-moreutils-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-xs-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn11-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
@@ -153,7 +153,7 @@ install from CPAN instead, follow the steps for Ubuntu.
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake libidn p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
+   pkg install devel/gmake libidn p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-MoreUtils p5-Locale-libintl p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
    ```
 
 6) Install Zonemaster::LDNS:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -153,7 +153,7 @@ install from CPAN instead, follow the steps for Ubuntu.
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake libidn p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Readonly-XS p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
+   pkg install devel/gmake libidn p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-JSON-PP p5-List-MoreUtils p5-Locale-libintl p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-IP-XS p5-Pod-Coverage p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV net-mgmt/p5-Net-IP dns/ldns
    ```
 
 6) Install Zonemaster::LDNS:


### PR DESCRIPTION
## Purpose

This PR cleans up dependencies a bit.

## Context

N/A

## Changes

Readonly::XS (obsoleted by Readonly, see [here](https://metacpan.org/pod/Readonly#Cons) and [here](https://metacpan.org/pod/Readonly#Internals)) and JSON::PP (included in core) are removed from Makefile.PL, Dockerfile and the installation instruction.

## How to test this PR

* The changes to the Dockerfile and Makefile.PL can be tested by [building a docker image](https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md#3-create-docker-images) and running the [sanity check](https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md#5-image-sanity-checks).
* The change to the installation instruction will be tested as part of the release testing.