### PR TITLE
replace moose with class accessor in Logger::Entry

### DIFF
--- a/lib/Zonemaster/Engine/Logger/Entry.pm
+++ b/lib/Zonemaster/Engine/Logger/Entry.pm
@@ -52,6 +52,11 @@ sub new {
     $attrs->{timestamp} = $time;
     $attrs->{trace} = _build_trace();
 
+    # lazy attributes
+    $attrs->{_module} = delete $attrs->{module} if exists $attrs->{module};
+    $attrs->{_level} = delete $attrs->{level} if exists $attrs->{level};
+    $attrs->{_testcase} = delete $attrs->{testcase} if exists $attrs->{testcase};
+
     my $class = ref $proto || $proto;
     return Class::Accessor::new( $class, $attrs );
 }
@@ -230,6 +235,10 @@ There should never be a need to create a log entry object in isolation. They sho
 
 =over
 
+=item new
+
+Construct a new object.
+
 =item levels
 
 Returns a hash where the keys are log levels as strings and the corresponding values their numeric value.
@@ -270,6 +279,10 @@ L<Time::HiRes>.
 =item trace
 
 A partial stack trace for the call that created the entry. Used to create the module tag. Almost certainly not useful for anything else.
+
+=item level
+
+The log level associated to this log entry.
 
 =back
 


### PR DESCRIPTION
## Purpose

Remove Moose from Logger::Entry for better performance. The logger entries are objects that are instantiated a large number of time and which properties are accessed a lot during tests execution. In large batches having too much overhead in the methods involved can lead to performance issue. (I don't have the exact numbers anymore, those are things I tested last September but didn't get the chance to backport in mainline Zonemaster).

## Context

* Continuation of a work started in https://github.com/zonemaster/zonemaster-engine/pull/566
* Partially ported from https://gitlab.rd.nic.fr/zonemaster/zonemaster-engine/-/blob/nightly-ronde/lib/Zonemaster/Engine/Logger/Entry.pm

## Changes

Replace Moose with Class::Accessor in Logger::Entry

## How to test this PR

* Tests can be executed as usual:  `zonemaster-cli --level info zonemaster.net --show-module --show-testcase`
* JSON generation is not impacted: `zonemaster-cli --level info zonemaster.net --json`
