### PR TITLE
cache test level config in logger::entry

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -171,7 +171,7 @@ sub can_continue {
     my ( $class ) = @_;
 
     return 1;
-    
+
 }
 
 sub save_cache {
@@ -203,6 +203,7 @@ sub start_time_now {
 
 sub reset {
     Zonemaster::Engine::Logger->start_time_now();
+    Zonemaster::Engine::Logger->reset_config();
     Zonemaster::Engine::Nameserver->empty_cache();
     $logger->clear_history() if $logger;
     Zonemaster::Engine::Recursor->clear_cache();

--- a/lib/Zonemaster/Engine/Logger.pm
+++ b/lib/Zonemaster/Engine/Logger.pm
@@ -90,6 +90,11 @@ sub start_time_now {
     return;
 }
 
+sub reset_config {
+    Zonemaster::Engine::Logger::Entry->reset_config();
+    return;
+}
+
 sub clear_history {
     my ( $self ) = @_;
 
@@ -210,6 +215,10 @@ Set the logger's start time to the current time.
 =item clear_history()
 
 Remove all known log entries.
+
+=item reset_config()
+
+Clear the test level cached configuration.
 
 =back
 

--- a/lib/Zonemaster/Engine/Logger/Entry.pm
+++ b/lib/Zonemaster/Engine/Logger/Entry.pm
@@ -32,6 +32,7 @@ our %numeric = (
 our $start_time = time();
 
 my $json = JSON::PP->new->allow_blessed->convert_blessed->canonical;
+my $test_levels_config;
 
 __PACKAGE__->mk_ro_accessors(qw(tag args timestamp trace));
 
@@ -140,8 +141,12 @@ sub _build_level {
     my ( $self ) = @_;
     my $string;
 
-    if ( Zonemaster::Engine::Profile->effective->get( q{test_levels} )->{ $self->module }{ $self->tag } ) {
-        $string = uc Zonemaster::Engine::Profile->effective->get( q{test_levels} )->{ $self->module }{ $self->tag };
+    if ( !defined $test_levels_config ) {
+        $test_levels_config = Zonemaster::Engine::Profile->effective->get( q{test_levels} );
+    }
+
+    if ( exists $test_levels_config->{ $self->module }{ $self->tag } ) {
+        $string = uc $test_levels_config->{ $self->module }{ $self->tag };
     }
     else {
         $string = 'DEBUG';
@@ -219,6 +224,11 @@ sub start_time_now {
     return;
 }
 
+sub reset_config {
+    undef $test_levels_config;
+    return;
+}
+
 1;
 
 =head1 NAME
@@ -246,6 +256,10 @@ Returns a hash where the keys are log levels as strings and the corresponding va
 =item start_time_now()
 
 Set the logger's start time to the current time.
+
+=item reset_config()
+
+Clear the test level cached configuration.
 
 =back
 

--- a/t/logger.t
+++ b/t/logger.t
@@ -69,6 +69,7 @@ isa_ok( $err, 'Zonemaster::Engine::Exception' );
 is( "$err", 'canary' );
 $log->clear_callback;
 
+Zonemaster::Engine::Logger->reset_config();
 $json = read_file( "t/profile.json" );
 $profile_test  = Zonemaster::Engine::Profile->from_json( $json );
 ok( Zonemaster::Engine::Profile->effective->merge( $profile_test ), 'profile loaded' );
@@ -98,6 +99,7 @@ qr[[{"args":{"exception":"in callback at t/logger.t line 47, <DATA> line 1.\n"},
     'JSON looks OK'
 );
 
+Zonemaster::Engine::Logger->reset_config();
 Zonemaster::Engine::Profile->effective->set( q{test_levels}, {"BASIC" => {"NS_FAILED" => "GURKSALLAD" }}); #->{BASIC}{NS_FAILED} = 'GURKSALLAD';
 my $fail = Zonemaster::Engine::Logger::Entry->new( { module => 'BASIC', tag => 'NS_FAILED' } );
 like( exception { $fail->level }, qr/Unknown level string: GURKSALLAD/, 'Dies on unknown level string' );


### PR DESCRIPTION
## Purpose

Reduce the amount of time used cloning the test levels config.  
Each call to `Zonemaster::Engine::Profile->effective->get` clone the result if it is not a scalar. For the test levels, this means that there will be a lot of calls to clone a fairly big hash. Here are the profiling info for a single test measured with `PERL5OPT=-d:NYTProf ./zonemaster-cli --level info zonemaster.net --show-module --show-testcase`.
<table>
    <thead>
        <tr>
            <th></th>
            <th>calls</th>
            <th>exclusive time</th>
            <th>inclusive time</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td></td>
            <td colspan="3">Zonemaster::Engine::Logger::Entry::level</td>
        </tr>
        <tr>
            <th>before</th>
            <td>5841</td>
            <td>411ms</td>
            <td>3390ms</td>
        </tr>
        <tr>
            <th>after</th>
            <td>5842</td>
            <td>102ms</td>
            <td>122ms</td>
        </tr>
        <tr>
            <td></td>
            <td colspan="3">Zonemaster::Engine::Profile::get</td>
        </tr>
        <tr>
            <th>before</th>
            <td>35873</td>
            <td>361ms</td>
            <td>3570ms</td>
        </tr>
        <tr>
            <th>after</th>
            <td>24838</td>
            <td>245ms</td>
            <td>726ms</td>
        </tr>
    </tbody>
</table>

## Context

Ported from https://gitlab.rd.nic.fr/zonemaster/zonemaster-engine/-/blob/nightly-ronde/lib/Zonemaster/Engine/Logger/Entry.pm

## Changes

* Cache the test levels for the time of the test

## How to test this PR

Testing a domain should work as usual:  `./zonemaster-cli --level info zonemaster.net --show-module --show-testcase`