### PR TITLE
Remove some unintended network dependencies from the unit tests

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -104,7 +104,11 @@ sub recurse {
 }
 
 sub add_fake_delegation {
-    my ( $class, $domain, $href ) = @_;
+    my ( $class, $domain, $href, %flags ) = @_;
+    my $fill_in_empty_ib = delete $flags{fill_in_empty_ib} ? 1 : 0;
+    croak 'Unrecognized flags: ' . join( ', ', keys %flags )
+      if %flags;
+    undef %flags;
 
     # Validate arguments
     $domain =~ /[^.]$|^\.$/
@@ -118,40 +122,19 @@ sub add_fake_delegation {
 
     # Check fake delegation
     my $incomplete_delegation;
-    foreach my $name ( keys %{$href} ) {
-        if ( !@{ $href->{$name} } ) {
-            if ( !$class->zone( $domain )->is_in_zone( $name ) ) {
-                my @ips = Zonemaster::LDNS->new->name2addr($name);
-                push @{ $href->{$name} }, @ips;
-            }
+    if ( $fill_in_empty_ib ) {
+        foreach my $name ( keys %{$href} ) {
             if ( !@{ $href->{$name} } ) {
-                $incomplete_delegation = 1;
+                if ( !$class->zone( $domain )->is_in_zone( $name ) ) {
+                    my @ips = Zonemaster::LDNS->new->name2addr($name);
+                    push @{ $href->{$name} }, @ips;
+                }
+                if ( !@{ $href->{$name} } ) {
+                    $incomplete_delegation = 1;
+                }
             }
         }
     }
-
-    $class->add_fake_delegation_raw( $domain, $href );
-
-    if ( $incomplete_delegation ) {
-        return;
-    }
-    return 1;
-}
-
-sub add_fake_delegation_raw {
-    my ( $class, $domain, $href ) = @_;
-
-    # Validate arguments
-    $domain =~ /[^.]$|^\.$/
-      or croak 'Argument $domain must omit the trailing dot, or it must be a single dot';
-    foreach my $name ( keys %{$href} ) {
-        $name =~ /[^.]$|^\.$/
-          or croak 'Each key of argument $href must omit the trailing dot, or it must be a single dot';
-        ref $href->{$name} eq 'ARRAY'
-          or croak 'Each value of argument $href must be an arrayref';
-    }
-
-    # Check fake delegation
     foreach my $name ( keys %{$href} ) {
         if ( not @{ $href->{$name} } ) {
             if ( $class->zone( $domain )->is_in_zone( $name ) ) {
@@ -173,7 +156,10 @@ sub add_fake_delegation_raw {
         $ns->add_fake_delegation( $domain => $href );
     }
 
-    return;
+    if ( $incomplete_delegation ) {
+        return;
+    }
+    return 1;
 }
 
 sub add_fake_ds {
@@ -329,50 +315,7 @@ If called in scalar context, only the AS number.
 
 Returns a list of the loaded test modules. Exactly the same as L<Zonemaster::Engine::Test/modules>.
 
-=item add_fake_delegation($domain, $data)
-
-This method wraps L<add_fake_delegation_raw($domain, $data)> and adds some extra
-functionality.
-
-The arguments are a domain name, and a hashref with delegation information.
-The keys in the hash are nameserver names, and the values are arrayrefs of IP
-addresses for their corresponding nameserver.
-
-Before propagating the given C<$data> to L<add_fake_delegation_raw($domain, $data)>,
-this method updates it filling in some glue.
-Specifically glue addresses are looked up and filled in for any nameserver names
-that are out of bailiwick of the given C<$domain> and that comes with an empty
-list of addresses.
-
-This method returns `1` if all name servers in C<$data> have non-empty lists of
-glue (after they've been filled in).
-Otherwise it returns `undef`.
-
-Example:
-
-    Zonemaster::Engine->add_fake_delegation(
-        'lysator.liu.se' => {
-            'ns1.nic.fr' => [ ],
-            'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
-            'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
-            'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
-        }
-    );
-
-will return 1.
-
-    Zonemaster::Engine->add_fake_delegation(
-        'lysator.liu.se' => {
-            'ns1.lysator.liu.se' => [ ],
-            'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
-            'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
-            'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
-        }
-    );
-
-will return 'undef' (missing address for ns1.lysator.liu.se).
-
-=item add_fake_delegation_raw($domain, $data)
+=item add_fake_delegation($domain, $data, %flags)
 
 This method adds some fake delegation information to the system.
 
@@ -384,16 +327,55 @@ For each provided nameserver with an empty list of addresses, either a
 C<FAKE_DELEGATION_NO_IP> or a C<FAKE_DELEGATION_IN_ZONE_NO_IP> message is
 emitted.
 
-Example:
+The only recognized flag is C<fill_in_empty_ib>.
+This flag is boolean and defaults to true.
+If this flag is true, this method updates the given C<$data> by looking up and
+filling in some glue addresses.
+Specifically the glue addresses for any nameserver name that are out of
+bailiwick of the given C<$domain> and that comes with an empty list of
+addresses.
 
-    Zonemaster::Engine->add_fake_delegation_raw(
+Returns `1` if all name servers in C<$data> have non-empty lists of
+glue (after they've been filled in) or if `fill_in_empty_ib` is false.
+Otherwise it returns `undef`.
+
+Examples:
+
+    Zonemaster::Engine->add_fake_delegation(
         'lysator.liu.se' => {
             'ns1.nic.fr' => [ ],
             'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
             'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
             'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
+        },
+    );
+
+returns 1.
+
+    Zonemaster::Engine->add_fake_delegation(
+        'lysator.liu.se' => {
+            'ns1.lysator.liu.se' => [ ],
+            'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
+            'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
+            'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
         }
     );
+
+returns C<undef> (signalling that fake delegation with empty glue was added to
+the system).
+
+    Zonemaster::Engine->add_fake_delegation(
+        'lysator.liu.se' => {
+            'ns1.lysator.liu.se' => [ ],
+            'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
+            'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
+            'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
+        },
+        fill_in_empty_ib => 0,
+    );
+
+returns 1 (does not signal that incomplete glue was added to the system).
+Moreover it does not even attempt to fill in glue for ns1.lysator.liu.se.
 
 =item add_fake_ds($domain, $data)
 

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -105,7 +105,7 @@ sub recurse {
 
 sub add_fake_delegation {
     my ( $class, $domain, $href, %flags ) = @_;
-    my $fill_in_empty_ib = delete $flags{fill_in_empty_ib} ? 1 : 0;
+    my $fill_in_empty_oob_glue = delete $flags{fill_in_empty_oob_glue} ? 1 : 0;
     croak 'Unrecognized flags: ' . join( ', ', keys %flags )
       if %flags;
     undef %flags;
@@ -122,7 +122,7 @@ sub add_fake_delegation {
 
     # Check fake delegation
     my $incomplete_delegation;
-    if ( $fill_in_empty_ib ) {
+    if ( $fill_in_empty_oob_glue ) {
         foreach my $name ( keys %{$href} ) {
             if ( !@{ $href->{$name} } ) {
                 if ( !$class->zone( $domain )->is_in_zone( $name ) ) {
@@ -327,7 +327,7 @@ For each provided nameserver with an empty list of addresses, either a
 C<FAKE_DELEGATION_NO_IP> or a C<FAKE_DELEGATION_IN_ZONE_NO_IP> message is
 emitted.
 
-The only recognized flag is C<fill_in_empty_ib>.
+The only recognized flag is C<fill_in_empty_oob_glue>.
 This flag is boolean and defaults to true.
 If this flag is true, this method updates the given C<$data> by looking up and
 filling in some glue addresses.
@@ -336,7 +336,7 @@ bailiwick of the given C<$domain> and that comes with an empty list of
 addresses.
 
 Returns `1` if all name servers in C<$data> have non-empty lists of
-glue (after they've been filled in) or if `fill_in_empty_ib` is false.
+glue (after they've been filled in) or if `fill_in_empty_oob_glue` is false.
 Otherwise it returns `undef`.
 
 Examples:
@@ -366,16 +366,15 @@ the system).
 
     Zonemaster::Engine->add_fake_delegation(
         'lysator.liu.se' => {
-            'ns1.lysator.liu.se' => [ ],
+            'ns1.nic.fr' => [ ],
             'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
             'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
             'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
         },
-        fill_in_empty_ib => 0,
+        fill_in_empty_oob_glue => 0,
     );
 
-returns 1 (does not signal that incomplete glue was added to the system).
-Moreover it does not even attempt to fill in glue for ns1.lysator.liu.se.
+returns 1. It does not even attempt to fill in glue for ns1.nic.fr.
 
 =item add_fake_ds($domain, $data)
 

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -124,12 +124,12 @@ sub add_fake_delegation {
     my $incomplete_delegation;
     if ( $fill_in_empty_oob_glue ) {
         foreach my $name ( keys %{$href} ) {
-            if ( !@{ $href->{$name} } ) {
-                if ( !$class->zone( $domain )->is_in_zone( $name ) ) {
-                    my @ips = Zonemaster::LDNS->new->name2addr($name);
-                    push @{ $href->{$name} }, @ips;
-                }
-                if ( !@{ $href->{$name} } ) {
+            if (   !@{ $href->{$name} }
+                && !$class->zone( $domain )->is_in_zone( $name ) )
+            {
+                my @ips = Zonemaster::LDNS->new->name2addr( $name );
+                push @{ $href->{$name} }, @ips;
+                if ( !@ips ) {
                     $incomplete_delegation = 1;
                 }
             }

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -309,11 +309,25 @@ Returns a list of the loaded test modules. Exactly the same as L<Zonemaster::Eng
 
 =item add_fake_delegation($domain, $data)
 
-This method adds some fake delegation information to the system. The arguments are a domain name, and a reference to a hash with delegation
-information. The keys in the hash must be nameserver names, and the values references to lists of IP addresses (which can be left empty) for
-the corresponding nameserver. If IP addresses are not provided for nameservers, the engine will perform queries to find them, except for
-in-bailiwick nameservers. All IP addresses found/provided are then used to initialize %Zonemaster::Engine::Recursor::fake_addresses_cache
-for later usage. If all servers can be associated to IP addresses, add_fake_delegation method returns 1, 'undef' otherwise.
+This method adds some fake delegation information to the system.
+
+The arguments are a domain name, and a hashref with delegation information.
+The keys in the hash are nameserver names, and the values are arrayrefs of IP
+addresses for their corresponding nameserver.
+
+Before adding the given C<$data> to the system, this method updates it filling
+in some glue.
+Specifically glue addresses are looked up and filled in for any nameserver names
+that are out of bailiwick of the given C<$domain> and that comes with an empty
+list of addresses.
+
+For each given nameserver with an empty list of addresses (after it's been
+filled in), either a C<FAKE_DELEGATION_NO_IP> or a
+C<FAKE_DELEGATION_IN_ZONE_NO_IP> message is emitted.
+
+This method returns `1` if all name servers in C<$data> have non-empty lists of
+glue (after they've been filled in).
+Otherwise it returns `undef`.
 
 Example:
 

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -119,20 +119,13 @@ sub add_fake_delegation {
     # Check fake delegation
     my $incomplete_delegation;
     foreach my $name ( keys %{$href} ) {
-        if ( not scalar @{ $href->{$name} } ) {
-            if ( $class->zone( $domain )->is_in_zone( $name ) ) {
-                push @{ $href->{$name} }, ();
-                $incomplete_delegation = 1;
-            }
-            else {
+        if ( !@{ $href->{$name} } ) {
+            if ( !$class->zone( $domain )->is_in_zone( $name ) ) {
                 my @ips = Zonemaster::LDNS->new->name2addr($name);
-                if ( @ips ) {
-                    push @{ $href->{$name} }, @ips;
-                }
-                else {
-                    push @{ $href->{$name} }, ();
-                    $incomplete_delegation = 1;
-                }
+                push @{ $href->{$name} }, @ips;
+            }
+            if ( !@{ $href->{$name} } ) {
+                $incomplete_delegation = 1;
             }
         }
     }

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -331,8 +331,8 @@ The only recognized flag is C<fill_in_empty_oob_glue>.
 This flag is boolean and defaults to true.
 If this flag is true, this method updates the given C<$data> by looking up and
 filling in some glue addresses.
-Specifically the glue addresses for any nameserver name that are out of
-bailiwick of the given C<$domain> and that comes with an empty list of
+Specifically the glue addresses for any nameserver name that are
+out-of-bailiwick of the given C<$domain> and that comes with an empty list of
 addresses.
 
 Returns `1` if all name servers in C<$data> have non-empty lists of

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -112,12 +112,14 @@ sub add_fake_delegation {
     foreach my $name ( keys %{$href} ) {
         $name =~ /[^.]$|^\.$/
           or croak 'Each key of argument $href must omit the trailing dot, or it must be a single dot';
+        ref $href->{ $name } eq 'ARRAY'
+          or croak 'Each value of argument $href must be an arrayref';
     }
 
     # Check fake delegation
     my $incomplete_delegation;
     foreach my $name ( keys %{$href} ) {
-        if ( not defined $href->{$name} or not scalar @{ $href->{$name} } ) {
+        if ( not scalar @{ $href->{$name} } ) {
             if ( $class->zone( $domain )->is_in_zone( $name ) ) {
                 Zonemaster::Engine->logger->add(
                     FAKE_DELEGATION_IN_ZONE_NO_IP => { domain => $domain , nsname => $name }

--- a/t/Test-consistency05-A.t
+++ b/t/Test-consistency05-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.consistency05.exempelvis.se' => {
         'ns1.a.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-A.t
+++ b/t/Test-consistency05-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-A.t
+++ b/t/Test-consistency05-A.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.consistency05.exempelvis.se' => {
         'ns1.a.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency05-E.t
+++ b/t/Test-consistency05-E.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'e.consistency05.exempelvis.se' => {
         'ns1.e.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.e.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{e.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-E.t
+++ b/t/Test-consistency05-E.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.e.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.e.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{e.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-E.t
+++ b/t/Test-consistency05-E.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'e.consistency05.exempelvis.se' => {
         'ns1.e.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.e.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency05-F.t
+++ b/t/Test-consistency05-F.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'f.consistency05.exempelvis.se' => {
         'ns1.f.consistency05.exempelvis.se' => [ '192.0.2.1', '2001:db8::1' ],
         'ns2.f.consistency05.exempelvis.se' => [ '192.0.2.2', '2001:db8::2' ],

--- a/t/Test-consistency05-F.t
+++ b/t/Test-consistency05-F.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'f.consistency05.exempelvis.se' => {
         'ns1.f.consistency05.exempelvis.se' => [ '192.0.2.1', '2001:db8::1' ],
         'ns2.f.consistency05.exempelvis.se' => [ '192.0.2.2', '2001:db8::2' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{f.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-F.t
+++ b/t/Test-consistency05-F.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.f.consistency05.exempelvis.se' => [ '192.0.2.1', '2001:db8::1' ],
         'ns2.f.consistency05.exempelvis.se' => [ '192.0.2.2', '2001:db8::2' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{f.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-G.t
+++ b/t/Test-consistency05-G.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'g.consistency05.exempelvis.se' => {
         'ns1.g.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency05-G.t
+++ b/t/Test-consistency05-G.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.g.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{g.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-G.t
+++ b/t/Test-consistency05-G.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'g.consistency05.exempelvis.se' => {
         'ns1.g.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{g.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-H.t
+++ b/t/Test-consistency05-H.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'h.consistency05.exempelvis.se' => {
         'ns1.g.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency05-H.t
+++ b/t/Test-consistency05-H.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'h.consistency05.exempelvis.se' => {
         'ns1.g.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{h.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-H.t
+++ b/t/Test-consistency05-H.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.g.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{h.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-I.t
+++ b/t/Test-consistency05-I.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'i.consistency05.exempelvis.se' => {
         'ns1.i.consistency05.exempelvis.se' => ['46.21.97.97'],
         'ns2.i.consistency05.exempelvis.se' => ['2001:2040:2b:1c13::53'],

--- a/t/Test-consistency05-I.t
+++ b/t/Test-consistency05-I.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.i.consistency05.exempelvis.se' => ['46.21.97.97'],
         'ns2.i.consistency05.exempelvis.se' => ['2001:2040:2b:1c13::53'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{i.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-I.t
+++ b/t/Test-consistency05-I.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'i.consistency05.exempelvis.se' => {
         'ns1.i.consistency05.exempelvis.se' => ['46.21.97.97'],
         'ns2.i.consistency05.exempelvis.se' => ['2001:2040:2b:1c13::53'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{i.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-J.t
+++ b/t/Test-consistency05-J.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'j.consistency05.exempelvis.se' => {
         'ns1.a.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{j.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-J.t
+++ b/t/Test-consistency05-J.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'j.consistency05.exempelvis.se' => {
         'ns1.a.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency05-J.t
+++ b/t/Test-consistency05-J.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.consistency05.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency05.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{j.consistency05.exempelvis.se} );

--- a/t/Test-consistency05-K.t
+++ b/t/Test-consistency05-K.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
 }
 
 Zonemaster::Engine->profile->set( q{net.ipv6}, 0 );
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'fi' => {
         'a.fi' => [ '193.166.4.1', '2001:708:10:53::53' ],
         'b.fi' => [ '194.146.106.26', '2001:67c:1010:6::53' ],
@@ -26,6 +26,7 @@ Zonemaster::Engine->add_fake_delegation_raw(
         'h.fi' => [ '87.239.120.11', '2001:678:a0::aaaa' ],
         'i.fi' => [ '194.0.25.30', '2001:678:20::30' ],
     },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'fi' );

--- a/t/Test-consistency05-K.t
+++ b/t/Test-consistency05-K.t
@@ -26,7 +26,7 @@ Zonemaster::Engine->add_fake_delegation(
         'h.fi' => [ '87.239.120.11', '2001:678:a0::aaaa' ],
         'i.fi' => [ '194.0.25.30', '2001:678:20::30' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'fi' );

--- a/t/Test-consistency05-K.t
+++ b/t/Test-consistency05-K.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
 }
 
 Zonemaster::Engine->profile->set( q{net.ipv6}, 0 );
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'fi' => {
         'a.fi' => [ '193.166.4.1', '2001:708:10:53::53' ],
         'b.fi' => [ '194.146.106.26', '2001:67c:1010:6::53' ],

--- a/t/Test-consistency05-L.t
+++ b/t/Test-consistency05-L.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'a.nic.no' => [ '46.21.96.58',  '2a02:750:12::53' ],
         'b.nic.no' => [ '212.85.74.18', '2001:470:28:5a0::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'no' );

--- a/t/Test-consistency05-L.t
+++ b/t/Test-consistency05-L.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
 }
 
 Zonemaster::Engine->profile->set( q{net.ipv6}, 0 );
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'no' => {
         'a.nic.no' => [ '46.21.96.58',  '2a02:750:12::53' ],
         'b.nic.no' => [ '212.85.74.18', '2001:470:28:5a0::53' ],

--- a/t/Test-consistency05-L.t
+++ b/t/Test-consistency05-L.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
 }
 
 Zonemaster::Engine->profile->set( q{net.ipv6}, 0 );
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'no' => {
         'a.nic.no' => [ '46.21.96.58',  '2a02:750:12::53' ],
         'b.nic.no' => [ '212.85.74.18', '2001:470:28:5a0::53' ],
     },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'no' );

--- a/t/Test-consistency06-A.t
+++ b/t/Test-consistency06-A.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.consistency06.exempelvis.se' => {
         'ns1.a.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency06-A.t
+++ b/t/Test-consistency06-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.consistency06.exempelvis.se} );

--- a/t/Test-consistency06-A.t
+++ b/t/Test-consistency06-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.consistency06.exempelvis.se' => {
         'ns1.a.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.consistency06.exempelvis.se} );

--- a/t/Test-consistency06-B.t
+++ b/t/Test-consistency06-B.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'drip.ip.se' => ['192.0.2.1'],
         'drop.ip.se' => ['192.0.2.2'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.consistency06.exempelvis.se} );

--- a/t/Test-consistency06-B.t
+++ b/t/Test-consistency06-B.t
@@ -14,10 +14,10 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'b.consistency06.exempelvis.se' => {
-        'drip.ip.se' => [],
-        'drop.ip.se' => [],
+        'drip.ip.se' => ['192.0.2.1'],
+        'drop.ip.se' => ['192.0.2.2'],
     }
 );
 

--- a/t/Test-consistency06-B.t
+++ b/t/Test-consistency06-B.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'b.consistency06.exempelvis.se' => {
         'drip.ip.se' => ['192.0.2.1'],
         'drop.ip.se' => ['192.0.2.2'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.consistency06.exempelvis.se} );

--- a/t/Test-consistency06-C.t
+++ b/t/Test-consistency06-C.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'c.consistency06.exempelvis.se' => {
         'ns1.c.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.consistency06.exempelvis.se} );

--- a/t/Test-consistency06-C.t
+++ b/t/Test-consistency06-C.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.c.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.consistency06.exempelvis.se} );

--- a/t/Test-consistency06-C.t
+++ b/t/Test-consistency06-C.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'c.consistency06.exempelvis.se' => {
         'ns1.c.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency06-D.t
+++ b/t/Test-consistency06-D.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'd.consistency06.exempelvis.se' => {
         'ns1.d.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.d.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.consistency06.exempelvis.se} );

--- a/t/Test-consistency06-D.t
+++ b/t/Test-consistency06-D.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'd.consistency06.exempelvis.se' => {
         'ns1.d.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.d.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-consistency06-D.t
+++ b/t/Test-consistency06-D.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.d.consistency06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.d.consistency06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.consistency06.exempelvis.se} );

--- a/t/Test-delegation01-A.t
+++ b/t/Test-delegation01-A.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.delegation01.exempelvis.se' => {
         'ns1.a.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation01-A.t
+++ b/t/Test-delegation01-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.delegation01.exempelvis.se} );

--- a/t/Test-delegation01-A.t
+++ b/t/Test-delegation01-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.delegation01.exempelvis.se' => {
         'ns1.a.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.delegation01.exempelvis.se} );

--- a/t/Test-delegation01-B.t
+++ b/t/Test-delegation01-B.t
@@ -14,10 +14,11 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'b.delegation01.exempelvis.se' => {
         'ns1.b.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'b.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-B.t
+++ b/t/Test-delegation01-B.t
@@ -18,7 +18,7 @@ Zonemaster::Engine->add_fake_delegation(
     'b.delegation01.exempelvis.se' => {
         'ns1.b.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'b.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-B.t
+++ b/t/Test-delegation01-B.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'b.delegation01.exempelvis.se' => {
         'ns1.b.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
     }

--- a/t/Test-delegation01-C.t
+++ b/t/Test-delegation01-C.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'c.delegation01.exempelvis.se' => {
         'ns1.c.delegation01.exempelvis.se' => ['2a02:750:12:77::97'],
         'ns2.c.delegation01.exempelvis.se' => ['2001:2040:2b:1c13::53'],

--- a/t/Test-delegation01-C.t
+++ b/t/Test-delegation01-C.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'c.delegation01.exempelvis.se' => {
         'ns1.c.delegation01.exempelvis.se' => ['2a02:750:12:77::97'],
         'ns2.c.delegation01.exempelvis.se' => ['2001:2040:2b:1c13::53'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'c.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-C.t
+++ b/t/Test-delegation01-C.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.c.delegation01.exempelvis.se' => ['2a02:750:12:77::97'],
         'ns2.c.delegation01.exempelvis.se' => ['2001:2040:2b:1c13::53'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'c.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-D.t
+++ b/t/Test-delegation01-D.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'd.delegation01.exempelvis.se' => {
         'ns1.d.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.d.delegation01.exempelvis.se' => [ '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'd.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-D.t
+++ b/t/Test-delegation01-D.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.d.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.d.delegation01.exempelvis.se' => [ '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'd.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-D.t
+++ b/t/Test-delegation01-D.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'd.delegation01.exempelvis.se' => {
         'ns1.d.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.d.delegation01.exempelvis.se' => [ '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation01-E.t
+++ b/t/Test-delegation01-E.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'e.delegation01.exempelvis.se' => {
         'ns1.e.delegation01.exempelvis.se' => [ '46.21.97.97' ],
         'ns2.e.delegation01.exempelvis.se' => [ '194.18.226.122' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'e.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-E.t
+++ b/t/Test-delegation01-E.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.e.delegation01.exempelvis.se' => [ '46.21.97.97' ],
         'ns2.e.delegation01.exempelvis.se' => [ '194.18.226.122' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'e.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-E.t
+++ b/t/Test-delegation01-E.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'e.delegation01.exempelvis.se' => {
         'ns1.e.delegation01.exempelvis.se' => [ '46.21.97.97' ],
         'ns2.e.delegation01.exempelvis.se' => [ '194.18.226.122' ],

--- a/t/Test-delegation01-F.t
+++ b/t/Test-delegation01-F.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.f.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.f.delegation01.exempelvis.se' => [ '194.18.226.122' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'f.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-F.t
+++ b/t/Test-delegation01-F.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'f.delegation01.exempelvis.se' => {
         'ns1.f.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.f.delegation01.exempelvis.se' => [ '194.18.226.122' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'f.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-F.t
+++ b/t/Test-delegation01-F.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'f.delegation01.exempelvis.se' => {
         'ns1.f.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.f.delegation01.exempelvis.se' => [ '194.18.226.122' ],

--- a/t/Test-delegation01-G.t
+++ b/t/Test-delegation01-G.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'g.delegation01.exempelvis.se' => {
         'ns1.g.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation01-G.t
+++ b/t/Test-delegation01-G.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'g.delegation01.exempelvis.se' => {
         'ns1.g.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone(  'g.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-G.t
+++ b/t/Test-delegation01-G.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.g.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone(  'g.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-H.t
+++ b/t/Test-delegation01-H.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'h.delegation01.exempelvis.se' => {
         'ns1.h.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.h.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation01-H.t
+++ b/t/Test-delegation01-H.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'h.delegation01.exempelvis.se' => {
         'ns1.h.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.h.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'h.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-H.t
+++ b/t/Test-delegation01-H.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.h.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.h.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'h.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-I.t
+++ b/t/Test-delegation01-I.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.i.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.i.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'i.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-I.t
+++ b/t/Test-delegation01-I.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'i.delegation01.exempelvis.se' => {
         'ns1.i.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.i.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation01-I.t
+++ b/t/Test-delegation01-I.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'i.delegation01.exempelvis.se' => {
         'ns1.i.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.i.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'i.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-J.t
+++ b/t/Test-delegation01-J.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'j.delegation01.exempelvis.se' => {
         'ns1.j.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.j.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'j.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-J.t
+++ b/t/Test-delegation01-J.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.j.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.j.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'j.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-J.t
+++ b/t/Test-delegation01-J.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'j.delegation01.exempelvis.se' => {
         'ns1.j.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.j.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation01-K.t
+++ b/t/Test-delegation01-K.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.k.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.k.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'k.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-K.t
+++ b/t/Test-delegation01-K.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'k.delegation01.exempelvis.se' => {
         'ns1.k.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.k.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation01-K.t
+++ b/t/Test-delegation01-K.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'k.delegation01.exempelvis.se' => {
         'ns1.k.delegation01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.k.delegation01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( 'k.delegation01.exempelvis.se' );

--- a/t/Test-delegation01-L.t
+++ b/t/Test-delegation01-L.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.l.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.l.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{l.delegation01.exempelvis.se} );

--- a/t/Test-delegation01-L.t
+++ b/t/Test-delegation01-L.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'l.delegation01.exempelvis.se' => {
         'ns1.l.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.l.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],

--- a/t/Test-delegation01-L.t
+++ b/t/Test-delegation01-L.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'l.delegation01.exempelvis.se' => {
         'ns1.l.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.l.delegation01.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{l.delegation01.exempelvis.se} );

--- a/t/Test-delegation01-M.t
+++ b/t/Test-delegation01-M.t
@@ -18,7 +18,7 @@ Zonemaster::Engine->add_fake_delegation(
     'm.delegation01.exempelvis.se' => {
         'ns1.m.delegation01.exempelvis.se' => [ '46.21.97.97', '194.18.226.122' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{m.delegation01.exempelvis.se} );

--- a/t/Test-delegation01-M.t
+++ b/t/Test-delegation01-M.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'm.delegation01.exempelvis.se' => {
         'ns1.m.delegation01.exempelvis.se' => [ '46.21.97.97', '194.18.226.122' ],
     }

--- a/t/Test-delegation01-M.t
+++ b/t/Test-delegation01-M.t
@@ -14,10 +14,11 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'm.delegation01.exempelvis.se' => {
         'ns1.m.delegation01.exempelvis.se' => [ '46.21.97.97', '194.18.226.122' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{m.delegation01.exempelvis.se} );

--- a/t/Test-delegation02-A.t
+++ b/t/Test-delegation02-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.delegation02.exempelvis.se' => {
         'ns1.a.delegation02.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation02.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.delegation02.exempelvis.se} );

--- a/t/Test-delegation02-A.t
+++ b/t/Test-delegation02-A.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.delegation02.exempelvis.se' => {
         'ns1.a.delegation02.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation02.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation02-A.t
+++ b/t/Test-delegation02-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.delegation02.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation02.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.delegation02.exempelvis.se} );

--- a/t/Test-delegation02-B.t
+++ b/t/Test-delegation02-B.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'b.delegation02.exempelvis.se' => {
         'ns1.b.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.b.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],

--- a/t/Test-delegation02-B.t
+++ b/t/Test-delegation02-B.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.b.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.b.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.delegation02.exempelvis.se} );

--- a/t/Test-delegation02-B.t
+++ b/t/Test-delegation02-B.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'b.delegation02.exempelvis.se' => {
         'ns1.b.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.b.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.delegation02.exempelvis.se} );

--- a/t/Test-delegation02-C.t
+++ b/t/Test-delegation02-C.t
@@ -20,7 +20,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.c.delegation02.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.delegation02.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.delegation02.exempelvis.se} );

--- a/t/Test-delegation02-C.t
+++ b/t/Test-delegation02-C.t
@@ -15,7 +15,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'c.delegation02.exempelvis.se' => {
         'ns1.c.delegation02.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.delegation02.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation02-C.t
+++ b/t/Test-delegation02-C.t
@@ -15,11 +15,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'c.delegation02.exempelvis.se' => {
         'ns1.c.delegation02.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.delegation02.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.delegation02.exempelvis.se} );

--- a/t/Test-delegation02-D.t
+++ b/t/Test-delegation02-D.t
@@ -20,7 +20,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.d.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.d.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.delegation02.exempelvis.se} );

--- a/t/Test-delegation02-D.t
+++ b/t/Test-delegation02-D.t
@@ -15,7 +15,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'd.delegation02.exempelvis.se' => {
         'ns1.d.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.d.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],

--- a/t/Test-delegation02-D.t
+++ b/t/Test-delegation02-D.t
@@ -15,11 +15,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'd.delegation02.exempelvis.se' => {
         'ns1.d.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
         'ns2.d.delegation02.exempelvis.se' => [ '46.21.97.97', '2a02:750:12:77::97' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.delegation02.exempelvis.se} );

--- a/t/Test-delegation03-A.t
+++ b/t/Test-delegation03-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.delegation03.exempelvis.se' => {
         'ns1.a.delegation03.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation03.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.delegation03.exempelvis.se} );

--- a/t/Test-delegation03-A.t
+++ b/t/Test-delegation03-A.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.delegation03.exempelvis.se' => {
         'ns1.a.delegation03.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation03.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-delegation03-A.t
+++ b/t/Test-delegation03-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.delegation03.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.delegation03.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.delegation03.exempelvis.se} );

--- a/t/Test-delegation03-B.t
+++ b/t/Test-delegation03-B.t
@@ -14,13 +14,14 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'b.delegation03.exempelvis.se' => {
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns1.b.delegation03.exempelvis.se' => [ '46.21.97.97' ],
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns2.b.delegation03.exempelvis.se' => [ '194.18.226.122' ],
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns3.b.delegation03.exempelvis.se' => [ '2a02:750:12:77::97' ],
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns4.b.delegation03.exempelvis.se' => [ '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.delegation03.exempelvis.se} );

--- a/t/Test-delegation03-B.t
+++ b/t/Test-delegation03-B.t
@@ -21,7 +21,7 @@ Zonemaster::Engine->add_fake_delegation(
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns3.b.delegation03.exempelvis.se' => [ '2a02:750:12:77::97' ],
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns4.b.delegation03.exempelvis.se' => [ '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.delegation03.exempelvis.se} );

--- a/t/Test-delegation03-B.t
+++ b/t/Test-delegation03-B.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'b.delegation03.exempelvis.se' => {
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns1.b.delegation03.exempelvis.se' => [ '46.21.97.97' ],
         'abcdefgh.abcdefghijklmnopqrstuvwxyz.ns2.b.delegation03.exempelvis.se' => [ '194.18.226.122' ],

--- a/t/Test-delegation03-C.t
+++ b/t/Test-delegation03-C.t
@@ -25,7 +25,7 @@ Zonemaster::Engine->add_fake_delegation(
 'abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.ns4.exempelvis.se'
           => [],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.delegation03.exempelvis.se} );

--- a/t/Test-delegation03-C.t
+++ b/t/Test-delegation03-C.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'c.delegation03.exempelvis.se' => {
 'abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.ns1.exempelvis.se'
           => [],
@@ -24,7 +24,8 @@ Zonemaster::Engine->add_fake_delegation_raw(
           => [],
 'abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.ns4.exempelvis.se'
           => [],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.delegation03.exempelvis.se} );

--- a/t/Test-delegation03-C.t
+++ b/t/Test-delegation03-C.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'c.delegation03.exempelvis.se' => {
 'abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.ns1.exempelvis.se'
           => [],

--- a/t/Test-dnssec05-A.t
+++ b/t/Test-dnssec05-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.dnssec05.exempelvis.se' => {
         'drip.ip.se' => ['192.0.2.1'],
         'drop.ip.se' => ['192.0.2.2'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-A.t
+++ b/t/Test-dnssec05-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'drip.ip.se' => ['192.0.2.1'],
         'drop.ip.se' => ['192.0.2.2'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-A.t
+++ b/t/Test-dnssec05-A.t
@@ -14,10 +14,10 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.dnssec05.exempelvis.se' => {
-        'drip.ip.se' => [],
-        'drop.ip.se' => [],
+        'drip.ip.se' => ['192.0.2.1'],
+        'drop.ip.se' => ['192.0.2.2'],
     }
 );
 

--- a/t/Test-dnssec05-B.t
+++ b/t/Test-dnssec05-B.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'b.dnssec05.exempelvis.se' => {
         'ns1.b.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.b.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-B.t
+++ b/t/Test-dnssec05-B.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'b.dnssec05.exempelvis.se' => {
         'ns1.b.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.b.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-B.t
+++ b/t/Test-dnssec05-B.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.b.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.b.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-C.t
+++ b/t/Test-dnssec05-C.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'c.dnssec05.exempelvis.se' => {
         'ns1.c.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.c.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-C.t
+++ b/t/Test-dnssec05-C.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'c.dnssec05.exempelvis.se' => {
         'ns1.c.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.c.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-C.t
+++ b/t/Test-dnssec05-C.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.c.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.c.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-D.t
+++ b/t/Test-dnssec05-D.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.d.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.d.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-D.t
+++ b/t/Test-dnssec05-D.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'd.dnssec05.exempelvis.se' => {
         'ns1.d.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.d.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-D.t
+++ b/t/Test-dnssec05-D.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'd.dnssec05.exempelvis.se' => {
         'ns1.d.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.d.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-E.t
+++ b/t/Test-dnssec05-E.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.e.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.e.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{e.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-E.t
+++ b/t/Test-dnssec05-E.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'e.dnssec05.exempelvis.se' => {
         'ns1.e.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.e.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{e.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-E.t
+++ b/t/Test-dnssec05-E.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'e.dnssec05.exempelvis.se' => {
         'ns1.e.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.e.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-F.t
+++ b/t/Test-dnssec05-F.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'f.dnssec05.exempelvis.se' => {
         'ns1.f.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.f.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{f.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-F.t
+++ b/t/Test-dnssec05-F.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.f.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.f.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{f.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-F.t
+++ b/t/Test-dnssec05-F.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'f.dnssec05.exempelvis.se' => {
         'ns1.f.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.f.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-G.t
+++ b/t/Test-dnssec05-G.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'g.dnssec05.exempelvis.se' => {
         'ns1.g.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.g.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{g.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-G.t
+++ b/t/Test-dnssec05-G.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.g.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.g.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{g.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-G.t
+++ b/t/Test-dnssec05-G.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'g.dnssec05.exempelvis.se' => {
         'ns1.g.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.g.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-H.t
+++ b/t/Test-dnssec05-H.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'h.dnssec05.exempelvis.se' => {
         'ns1.h.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.h.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{h.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-H.t
+++ b/t/Test-dnssec05-H.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'h.dnssec05.exempelvis.se' => {
         'ns1.h.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.h.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-H.t
+++ b/t/Test-dnssec05-H.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.h.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.h.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{h.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-I.t
+++ b/t/Test-dnssec05-I.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.i.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.i.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{i.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-I.t
+++ b/t/Test-dnssec05-I.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'i.dnssec05.exempelvis.se' => {
         'ns1.i.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.i.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{i.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-I.t
+++ b/t/Test-dnssec05-I.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'i.dnssec05.exempelvis.se' => {
         'ns1.i.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.i.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-dnssec05-J.t
+++ b/t/Test-dnssec05-J.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.j.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.j.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{j.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-J.t
+++ b/t/Test-dnssec05-J.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'j.dnssec05.exempelvis.se' => {
         'ns1.j.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.j.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{j.dnssec05.exempelvis.se} );

--- a/t/Test-dnssec05-J.t
+++ b/t/Test-dnssec05-J.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'j.dnssec05.exempelvis.se' => {
         'ns1.j.dnssec05.exempelvis.se' => ['46.21.97.97'],
         'ns2.j.dnssec05.exempelvis.se' => ['2a02:750:12:77::97'],

--- a/t/Test-nameserver01-A.t
+++ b/t/Test-nameserver01-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.nameserver01.exempelvis.se' => {
         'ns1.a.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-A.t
+++ b/t/Test-nameserver01-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-A.t
+++ b/t/Test-nameserver01-A.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.nameserver01.exempelvis.se' => {
         'ns1.a.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-nameserver01-B.t
+++ b/t/Test-nameserver01-B.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.b.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.b.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-B.t
+++ b/t/Test-nameserver01-B.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'b.nameserver01.exempelvis.se' => {
         'ns1.b.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.b.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-nameserver01-B.t
+++ b/t/Test-nameserver01-B.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'b.nameserver01.exempelvis.se' => {
         'ns1.b.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.b.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-C.t
+++ b/t/Test-nameserver01-C.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'c.nameserver01.exempelvis.se' => {
         'ns1.c.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-nameserver01-C.t
+++ b/t/Test-nameserver01-C.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.c.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-C.t
+++ b/t/Test-nameserver01-C.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'c.nameserver01.exempelvis.se' => {
         'ns1.c.nameserver01.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.nameserver01.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-D.t
+++ b/t/Test-nameserver01-D.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'resolver1.exempelvis.se' => ['8.8.8.8'],
         'resolver2.exempelvis.se' => ['9.9.9.9'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-D.t
+++ b/t/Test-nameserver01-D.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'd.nameserver01.exempelvis.se' => {
         'resolver1.exempelvis.se' => ['8.8.8.8'],
         'resolver2.exempelvis.se' => ['9.9.9.9'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.nameserver01.exempelvis.se} );

--- a/t/Test-nameserver01-D.t
+++ b/t/Test-nameserver01-D.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'd.nameserver01.exempelvis.se' => {
         'resolver1.exempelvis.se' => ['8.8.8.8'],
         'resolver2.exempelvis.se' => ['9.9.9.9'],

--- a/t/Test-syntax06-A.t
+++ b/t/Test-syntax06-A.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'a.syntax06.exempelvis.se' => {
         'ns1.a.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-A.t
+++ b/t/Test-syntax06-A.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.a.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-A.t
+++ b/t/Test-syntax06-A.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'a.syntax06.exempelvis.se' => {
         'ns1.a.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.a.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{a.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-B.t
+++ b/t/Test-syntax06-B.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'b.syntax06.exempelvis.se' => {
         'drip.ip.se' => ['192.0.2.1'],
         'drop.ip.se' => ['192.0.2.2'],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-B.t
+++ b/t/Test-syntax06-B.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'drip.ip.se' => ['192.0.2.1'],
         'drop.ip.se' => ['192.0.2.2'],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{b.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-B.t
+++ b/t/Test-syntax06-B.t
@@ -14,10 +14,10 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'b.syntax06.exempelvis.se' => {
-        'drip.ip.se' => [],
-        'drop.ip.se' => [],
+        'drip.ip.se' => ['192.0.2.1'],
+        'drop.ip.se' => ['192.0.2.2'],
     }
 );
 

--- a/t/Test-syntax06-C.t
+++ b/t/Test-syntax06-C.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.c.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-C.t
+++ b/t/Test-syntax06-C.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'c.syntax06.exempelvis.se' => {
         'ns1.c.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-C.t
+++ b/t/Test-syntax06-C.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'c.syntax06.exempelvis.se' => {
         'ns1.c.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.c.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{c.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-D.t
+++ b/t/Test-syntax06-D.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'd.syntax06.exempelvis.se' => {
         'ns1.d.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.d.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-D.t
+++ b/t/Test-syntax06-D.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.d.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.d.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-D.t
+++ b/t/Test-syntax06-D.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'd.syntax06.exempelvis.se' => {
         'ns1.d.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.d.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{d.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-E.t
+++ b/t/Test-syntax06-E.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.e.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.e.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{e.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-E.t
+++ b/t/Test-syntax06-E.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'e.syntax06.exempelvis.se' => {
         'ns1.e.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.e.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{e.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-E.t
+++ b/t/Test-syntax06-E.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'e.syntax06.exempelvis.se' => {
         'ns1.e.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.e.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-F.t
+++ b/t/Test-syntax06-F.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'f.syntax06.exempelvis.se' => {
         'ns1.f.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.f.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-F.t
+++ b/t/Test-syntax06-F.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'f.syntax06.exempelvis.se' => {
         'ns1.f.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.f.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{f.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-F.t
+++ b/t/Test-syntax06-F.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.f.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.f.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{f.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-G.t
+++ b/t/Test-syntax06-G.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.g.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{g.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-G.t
+++ b/t/Test-syntax06-G.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'g.syntax06.exempelvis.se' => {
         'ns1.g.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{g.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-G.t
+++ b/t/Test-syntax06-G.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'g.syntax06.exempelvis.se' => {
         'ns1.g.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.g.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-I.t
+++ b/t/Test-syntax06-I.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'i.syntax06.exempelvis.se' => {
         'ns1.i.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.i.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{i.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-I.t
+++ b/t/Test-syntax06-I.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'i.syntax06.exempelvis.se' => {
         'ns1.i.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.i.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-I.t
+++ b/t/Test-syntax06-I.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.i.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.i.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{i.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-J.t
+++ b/t/Test-syntax06-J.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'j.syntax06.exempelvis.se' => {
         'ns1.j.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.j.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{j.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-J.t
+++ b/t/Test-syntax06-J.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'j.syntax06.exempelvis.se' => {
         'ns1.j.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.j.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-J.t
+++ b/t/Test-syntax06-J.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.j.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.j.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{j.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-K.t
+++ b/t/Test-syntax06-K.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'k.syntax06.exempelvis.se' => {
         'ns1.k.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.k.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/Test-syntax06-K.t
+++ b/t/Test-syntax06-K.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'k.syntax06.exempelvis.se' => {
         'ns1.k.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.k.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{k.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-K.t
+++ b/t/Test-syntax06-K.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.k.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.k.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{k.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-L.t
+++ b/t/Test-syntax06-L.t
@@ -14,11 +14,12 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'l.syntax06.exempelvis.se' => {
         'ns1.l.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.l.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{l.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-L.t
+++ b/t/Test-syntax06-L.t
@@ -19,7 +19,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns1.l.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.l.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $zone = Zonemaster::Engine->zone( q{l.syntax06.exempelvis.se} );

--- a/t/Test-syntax06-L.t
+++ b/t/Test-syntax06-L.t
@@ -14,7 +14,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'l.syntax06.exempelvis.se' => {
         'ns1.l.syntax06.exempelvis.se' => [ '46.21.97.97',    '2a02:750:12:77::97' ],
         'ns2.l.syntax06.exempelvis.se' => [ '194.18.226.122', '2001:2040:2b:1c13::53' ],

--- a/t/undelegated.t
+++ b/t/undelegated.t
@@ -19,7 +19,7 @@ my $plain_p = Zonemaster::Engine->recurse( 'www.lysator.liu.se', 'AAAA' );
 isa_ok( $plain_p, 'Zonemaster::Engine::Packet' );
 ok( $plain_p,        'Got answer' );
 
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'lysator.liu.se' => {
         'ns-slave.lysator.liu.se'  => [ '130.236.254.4',  '130.236.255.2' ],
         'ns-master.lysator.liu.se' => [ '130.236.254.2', '2001:6b0:17:f0a0::2' ],
@@ -54,7 +54,7 @@ isa_ok( $ds, 'Zonemaster::LDNS::RR::DS' );
 is( $ds->hexdigest, 'faceb00c', 'Correct digest' );
 
 Zonemaster::Engine->logger->clear_history;
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'nic.se' => {
         'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
         'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
@@ -65,7 +65,7 @@ ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_TO_SELF' } @{ Zonemaster::Engine->log
     'Refused adding circular fake delegation.' );
 
 Zonemaster::Engine->logger->clear_history;
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'lysator.liu.se' => {
         'frfr.sesefrfr'  => [ ],
         'i.ns.se'        => [ '194.146.106.22', '2001:67c:1010:5::53' ],
@@ -77,7 +77,7 @@ ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_NO_IP' } @{ Zonemaster::Engine->logge
     'Refused fake delegation without IP address for bad ns.' );
 
 Zonemaster::Engine->logger->clear_history;
-Zonemaster::Engine->add_fake_delegation(
+Zonemaster::Engine->add_fake_delegation_raw(
     'nic.se' => {
         'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
         'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],

--- a/t/undelegated.t
+++ b/t/undelegated.t
@@ -26,7 +26,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns-slave-1.ifm.liu.se'    => [ '130.236.160.2',  '2001:6b0:17:f180::1001' ],
         'ns-slave-2.ifm.liu.se'    => [ '130.236.160.3',  '2001:6b0:17:f180::1002' ]
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 my $fake_happened = 0;
@@ -61,7 +61,7 @@ Zonemaster::Engine->add_fake_delegation(
         'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_TO_SELF' } @{ Zonemaster::Engine->logger->entries } ),
     'Refused adding circular fake delegation.' );
@@ -73,7 +73,7 @@ Zonemaster::Engine->add_fake_delegation(
         'i.ns.se'        => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se'     => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_NO_IP' } @{ Zonemaster::Engine->logger->entries } ),
@@ -87,7 +87,7 @@ Zonemaster::Engine->add_fake_delegation(
         'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ],
         'ns4.nic.se' => [ ]
     },
-    fill_in_empty_ib => 0,
+    fill_in_empty_oob_glue => 0,
 );
 
 ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_IN_ZONE_NO_IP' } @{ Zonemaster::Engine->logger->entries } ),

--- a/t/undelegated.t
+++ b/t/undelegated.t
@@ -19,13 +19,14 @@ my $plain_p = Zonemaster::Engine->recurse( 'www.lysator.liu.se', 'AAAA' );
 isa_ok( $plain_p, 'Zonemaster::Engine::Packet' );
 ok( $plain_p,        'Got answer' );
 
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'lysator.liu.se' => {
         'ns-slave.lysator.liu.se'  => [ '130.236.254.4',  '130.236.255.2' ],
         'ns-master.lysator.liu.se' => [ '130.236.254.2', '2001:6b0:17:f0a0::2' ],
         'ns-slave-1.ifm.liu.se'    => [ '130.236.160.2',  '2001:6b0:17:f180::1001' ],
         'ns-slave-2.ifm.liu.se'    => [ '130.236.160.3',  '2001:6b0:17:f180::1002' ]
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 my $fake_happened = 0;
@@ -54,36 +55,39 @@ isa_ok( $ds, 'Zonemaster::LDNS::RR::DS' );
 is( $ds->hexdigest, 'faceb00c', 'Correct digest' );
 
 Zonemaster::Engine->logger->clear_history;
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'nic.se' => {
         'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
         'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_TO_SELF' } @{ Zonemaster::Engine->logger->entries } ),
     'Refused adding circular fake delegation.' );
 
 Zonemaster::Engine->logger->clear_history;
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'lysator.liu.se' => {
         'frfr.sesefrfr'  => [ ],
         'i.ns.se'        => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se'     => [ '212.247.8.152',  '2a00:801:f0:211::152' ]
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_NO_IP' } @{ Zonemaster::Engine->logger->entries } ),
     'Refused fake delegation without IP address for bad ns.' );
 
 Zonemaster::Engine->logger->clear_history;
-Zonemaster::Engine->add_fake_delegation_raw(
+Zonemaster::Engine->add_fake_delegation(
     'nic.se' => {
         'ns.nic.se'  => [ '212.247.7.228',  '2a00:801:f0:53::53' ],
         'i.ns.se'    => [ '194.146.106.22', '2001:67c:1010:5::53' ],
         'ns3.nic.se' => [ '212.247.8.152',  '2a00:801:f0:211::152' ],
         'ns4.nic.se' => [ ]
-    }
+    },
+    fill_in_empty_ib => 0,
 );
 
 ok( !!( grep { $_->tag eq 'FAKE_DELEGATION_IN_ZONE_NO_IP' } @{ Zonemaster::Engine->logger->entries } ),


### PR DESCRIPTION
## Purpose

This PR makes the unit tests don't autocomplete fake glue by sending out DNS requests.

## Context

Fixes #888.

## Changes

A new method Zonemaster::Engine->add_fake_delegation_raw() is factored out from Zonemaster::Engine->add_fake_delegation(). The new method performs the meat of things but without the bells and whistles like autocompleting fake glue and returning a boolean. (I don't think the return value is ever used and it's kind of nonsense anyway. Maybe I should have removed it altogether.)

## How to test this PR

1. In one terminal run `sudo tcpdump -nn port 53` and keep it open.
2. In another terminal run `make test` and wait for it to complete.
3. Make sure tcpdump didn't list any DNS requests from the tests.