### PR TITLE
Momentarily comment out "latest" from Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         compatibility:
           - develop
-          - latest
+          #- latest
         perl:
           - '5.32'
           - '5.26'


### PR DESCRIPTION
## Purpose

Momentarily drop the unit tests relying on fetching Zonemaster::LDNS from CPAN due to an incompatibility with the required version of libidn. The CPAN module requires libidn11-dev, but current develop migrated to libidn2-dev.

## Context

Github Action is failing since merging #1056.

## Changes

Github Action file.

## How to test this PR

Tests should pass.
