### PR TITLE
Make query timeout configurable in profile

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -429,6 +429,7 @@ sub _query {
     $flags{q{fallback}}  = $href->{q{fallback}}  // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.fallback} );
     $flags{q{recurse}}   = $href->{q{recurse}}   // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.recurse} );
     $flags{q{edns_size}} = $href->{q{edns_size}} // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.edns_size} );
+    $flags{q{timeout}}   = $href->{q{timeout}}   // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.timeout} );
     if ( defined $href->{edns_details} and $href->{edns_details}{udp_size} ) {
         $flags{q{edns_size}} = $href->{edns_details}{udp_size};
     }
@@ -811,13 +812,9 @@ Set the debug flag in the resolver, producing output on STDERR as the query proc
 
 Set the RD flag in the query.
 
-=item udp_timeout
+=item timeout
 
-Set the UDP timeout for the outgoing UDP socket. May or may not be observed by the underlying network stack.
-
-=item tcp_timeout
-
-Set the TCP timeout for the outgoing TCP socket. May or may not be observed by the underlying network stack.
+Set the timeout for the outgoing sockets. May or may not be observed by the underlying network stack.
 
 =item retry
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -49,6 +49,9 @@ my %profile_properties_details = (
     q{resolver.defaults.usevc} => {
         type    => q{Bool}
     },
+    q{resolver.defaults.timeout} => {
+        type    => q{Num}
+    },
     q{resolver.source} => {
         type    => q{Str},
         test    => sub {
@@ -225,7 +228,7 @@ sub _set_value_to_nested_hash {
     my ( $hash_ref, $value, @path ) = @_;
 
     my $key = shift @path;
-    
+
     if (  ! exists $hash_ref->{$key} ) {
         $hash_ref->{$key} = {};
     }
@@ -612,7 +615,7 @@ flag set will be automatically resent over TCP. Default false.
 =head2 resolver.defaults.fallback
 
 A boolean. If true, UDP queries that get responses with the C<TC>
-flag set will be automatically resent over TCP or using EDNS. Default 
+flag set will be automatically resent over TCP or using EDNS. Default
 true.
 
 In ldns-1.7.0 (NLnet Labs), in case of truncated answer when UDP is used,
@@ -663,7 +666,7 @@ Default C<"Cymru">.
 
 An arrayref of domain names when asn_db.style is set to C<"Cymru"> or whois
 servers when asn_db.style is set to C<"RIPE">. Normally only the first item
-in the list will be used, the rest are backups in case the earlier ones don't 
+in the list will be used, the rest are backups in case the earlier ones don't
 work.
 Default C<"asnlookup.zonemaster.net">.
 
@@ -689,10 +692,10 @@ The data under the C<logfilter> key should be structured like this:
              "set"
                 Severity level to set if all conditions match
 
-The hash with conditions should have keys matching the attributes of 
-the log entry that's being filtered (check the translation files to see 
-what they are). The values for the keys should be either a single value 
-that the attribute should be, or an array of values any one of which the 
+The hash with conditions should have keys matching the attributes of
+the log entry that's being filtered (check the translation files to see
+what they are). The values for the keys should be either a single value
+that the attribute should be, or an array of values any one of which the
 attribute should be.
 
 A complete logfilter structure might look like this:
@@ -780,8 +783,8 @@ L<test case specifications|
 https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests/ImplementedTestCases.md>.
 Default is an arrayref listing all the test cases.
 
-Specifies which test cases to consider when a test module is asked 
-to run of all of its test cases. 
+Specifies which test cases to consider when a test module is asked
+to run of all of its test cases.
 
 Test cases not included here can still be run individually.
 

--- a/share/profile.json
+++ b/share/profile.json
@@ -21,7 +21,8 @@
             "recurse" : false,
             "retrans" : 3,
             "retry" : 2,
-            "usevc" : false
+            "usevc" : false,
+            "timeout": 5
         },
         "source": "os_default"
     },


### PR DESCRIPTION
## Purpose

The timeout of queries is currently not configurable. This PR makes it configurable in the profile.

## Context

Asked on the mailing list.
>  I wanted to change this to just 1 query. Is it configurable?

## Changes

* Make the timeout configurable.
* The default is the current default (LDNS default)

## How to test this PR

* Query a NS that does not respond, check for the time taken to fail (two times the timeout as there is a retry)
   `../zonemaster-cli/script/zonemaster-cli --level debug --ns localhost/127.0.0.1 zonemaster.net`
* Lower the timeout, check that it fails faster.
