### PR TITLE
Installation instructions for CentOS 7

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -171,6 +171,13 @@ install from CPAN instead, follow the steps for Ubuntu.
 
 ### Installation on CentOS 7
 
+> **Please note!** CentOS 7 will only be supported until the release of
+> v2023.1, which is expected to happen during the spring of 2023. Consider
+> [Rocky Linux][Installation on Rocky Linux] for an alternative Red Hat Linux
+> derivative.
+> If you like you could [reach out to let us know to which OS you
+> migrated][Mailing list zonemaster-users].
+
 1) Install the [EPEL] repository:
 
    ```sh
@@ -189,7 +196,7 @@ install from CPAN instead, follow the steps for Ubuntu.
    sudo cpanm Module::Install::XSUtil MooseX::Singleton
    ```
 
-4) Install Zonemaster::LDNS with DNSSEC 15 and 16 support:
+4) Install Zonemaster::LDNS with support for DNSSEC algorithms 15 and 16:
 
      ```sh
      sudo cpanm --configure-args="--openssl-lib=/usr/lib64/openssl11 --openssl-inc=/usr/include/openssl11" Zonemaster::LDNS
@@ -231,6 +238,7 @@ The command is expected to take a few seconds and print some results about the d
 [Installation on Rocky Linux]:                       #installation-on-rocky-linux
 [Installation on CentOS 7]:                          #installation-on-centos-7
 [JSON-RPC API]:                                      https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md
+[Mailing list zonemaster-users]:                     https://github.com/zonemaster/zonemaster/blob/master/docs/contact-and-mailing-lists.md#zonemaster-users
 [Main Zonemaster Repository]:                        https://github.com/zonemaster/zonemaster
 [USING]:                                             https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md
 [Zonemaster::Backend installation]:                  https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -10,6 +10,7 @@
   * [Installation on Debian]
   * [Installation on Ubuntu]
   * [Installation on FreeBSD]
+  * [Installation on CentOS 7]
 * [Post-installation sanity check](#Post-installation-sanity-check)
 * [What to do next](#What-to-do-next)
 
@@ -168,6 +169,38 @@ install from CPAN instead, follow the steps for Ubuntu.
    cpanm Zonemaster::Engine
    ```
 
+### Installation on CentOS 7
+
+1) Install the [EPEL] repository:
+
+   ```sh
+   sudo yum --assumeyes --enablerepo=extras install epel-release
+   ```
+
+2) Install binary packages:
+
+   ```sh
+   sudo yum --assumeyes install cpanminus gcc libidn2-devel openssl-devel openssl11-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Module-Find perl-Module-Install perl-Moose perl-Net-IP perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple perl-YAML
+   ```
+
+3) Install packages from CPAN:
+
+   ```sh
+   sudo cpanm Module::Install::XSUtil MooseX::Singleton
+   ```
+
+4) Install Zonemaster::LDNS with DNSSEC 15 and 16 support:
+
+     ```sh
+     sudo cpanm --configure-args="--openssl-lib=/usr/lib64/openssl11 --openssl-inc=/usr/include/openssl11" Zonemaster::LDNS
+     ```
+
+5) Finally install Zonemaster::Engine
+
+     ```sh
+     sudo cpanm Zonemaster::Engine
+     ```
+
 
 ## Post-installation sanity check
 
@@ -196,6 +229,7 @@ The command is expected to take a few seconds and print some results about the d
 [Installation on Ubuntu]:                            #installation-on-ubuntu
 [Installation on FreeBSD]:                           #installation-on-freebsd
 [Installation on Rocky Linux]:                       #installation-on-rocky-linux
+[Installation on CentOS 7]:                          #installation-on-centos-7
 [JSON-RPC API]:                                      https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md
 [Main Zonemaster Repository]:                        https://github.com/zonemaster/zonemaster
 [USING]:                                             https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md


### PR DESCRIPTION
## Purpose

This reinstates installation instructions for CentOS 7 but with support for DNSSEC algos 15 and 16.

## Context

based on [zonemaster/zonemaster-ldns#134](https://github.com/zonemaster/zonemaster-ldns/pull/134)

## Changes

New section for CentOS 7 in installation document with specific instruction to install Zonemaster::LDNS.

## How to test this PR

Following the installation instruction should result in a properly working Zonemaster instance with support for DNSSEC algo 15 and 16.
