### PR TITLE
fix ubuntu installation procedure

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -108,13 +108,13 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-ip-perl libpod-coverage-perl libreadonly-perl libssl-dev libldns3 libldns-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
 
    ```sh
-   sudo cpanm Zonemaster::LDNS Zonemaster::Engine
+   sudo cpanm --configure-args="--no-internal-ldns" Zonemaster::LDNS Zonemaster::Engine
    ```
 
 ### Installation on FreeBSD


### PR DESCRIPTION
## Purpose

Fix LDNS installation using CPAN on Ubuntu 22.04.

## Context

Ubuntu 22.04 comes with OpenSSL 3, LDNS uses OpenSSL 1.1.1, the changes in the API break the build step of Zonemaster LDNS.

The LDNS package in Ubuntu 22.04 and Debian 11 is the right version to use algorithm 15 and 16. This PR change the installation instruction to use the system LDNS and not the internal one.

## Changes

* Use system LDNS.
* Add libldns3 (1.7.1) and libldns-dev to the dependency list.

## How to test this PR

* Install Zonemaster Engine / LDNS on Ubuntu 22.04 and Debian 11. The installation should work.