### PR TITLE
#1089 - Fix default value for undelegated tests

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -105,7 +105,7 @@ sub recurse {
 
 sub add_fake_delegation {
     my ( $class, $domain, $href, %flags ) = @_;
-    my $fill_in_empty_oob_glue = delete $flags{fill_in_empty_oob_glue} ? 1 : 0;
+    my $fill_in_empty_oob_glue = exists $flags{fill_in_empty_oob_glue} ? delete $flags{fill_in_empty_oob_glue} : 1;
     croak 'Unrecognized flags: ' . join( ', ', keys %flags )
       if %flags;
     undef %flags;


### PR DESCRIPTION
## Purpose

This PR fixes the default value for when to fill in IPs for out-of-bailiwick nameservers in undelegated tests.

## Context

Fixes #1089 

## Changes

Default value of $fill_in_empty_oob_glue in Engine::add_fake_delegation() is now 1.

## How to test this PR

Tests should proceed without errors.

`zonemaster-cli --ns nsa.dnsnode.net --ns nsu.dnsnode.net --ns nsp.dnsnode.net iis.se --level=DEBUG --raw`
