### PR TITLE
Missing update of ns args in SYSTEM messages

### DIFF
--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -771,8 +771,8 @@ sub _is_ip_version_disabled {
     if ( not Zonemaster::Engine::Profile->effective->get( q{net.ipv4} ) and $ns->address->version == $IP_VERSION_4 ) {
         Zonemaster::Engine->logger->add(
             SKIP_IPV4_DISABLED => {
-                ns_list => $ns->string,
-                rrtype  => $type
+                ns     => $ns->string,
+                rrtype => $type
             }
         );
         return 1;
@@ -781,8 +781,8 @@ sub _is_ip_version_disabled {
     if ( not Zonemaster::Engine::Profile->effective->get( q{net.ipv6} ) and $ns->address->version == $IP_VERSION_6 ) {
         Zonemaster::Engine->logger->add(
             SKIP_IPV6_DISABLED => {
-                ns_list => $ns->string,
-                rrtype  => $type
+                ns     => $ns->string,
+                rrtype => $type
             }
         );
         return 1;

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -769,12 +769,12 @@ sub _is_ip_version_disabled {
     my $ns = shift;
 
     if ( not Zonemaster::Engine::Profile->effective->get( q{net.ipv4} ) and $ns->address->version == $IP_VERSION_4 ) {
-        Zonemaster::Engine->logger->add( SKIP_IPV4_DISABLED => { ns => "$ns" } );
+        Zonemaster::Engine->logger->add( SKIP_IPV4_DISABLED => { ns_list => "$ns" } );
         return 1;
     }
 
     if ( not Zonemaster::Engine::Profile->effective->get( q{net.ipv6} ) and $ns->address->version == $IP_VERSION_6 ) {
-        Zonemaster::Engine->logger->add( SKIP_IPV6_DISABLED => { ns => "$ns" } );
+        Zonemaster::Engine->logger->add( SKIP_IPV6_DISABLED => { ns_list => "$ns" } );
         return 1;
     }
 

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -323,7 +323,7 @@ sub zone01 {
 
                 my $ns = Zonemaster::Engine::Nameserver->new( { name => $soa_mname, address => $ip_address->short } );
 
-                if ( _is_ip_version_disabled( $ns ) ) {
+                if ( _is_ip_version_disabled( $ns, q{SOA} ) ) {
                     next;
                 }
 
@@ -700,7 +700,7 @@ sub zone10 {
 
     foreach my $ns ( @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) } ) {
 
-        if ( _is_ip_version_disabled( $ns ) ) {
+        if ( _is_ip_version_disabled( $ns, q{SOA} ) ) {
             next;
         }
 
@@ -751,7 +751,7 @@ sub _retrieve_record_from_zone {
     # Return response from the first authoritative server that gives one
     foreach my $ns ( @{ Zonemaster::Engine::TestMethods->method5( $zone ) } ) {
 
-        if ( _is_ip_version_disabled( $ns ) ) {
+        if ( _is_ip_version_disabled( $ns, $type ) ) {
             next;
         }
 
@@ -766,15 +766,25 @@ sub _retrieve_record_from_zone {
 }
 
 sub _is_ip_version_disabled {
-    my $ns = shift;
+    my ( $ns, $type ) = @_;
 
     if ( not Zonemaster::Engine::Profile->effective->get( q{net.ipv4} ) and $ns->address->version == $IP_VERSION_4 ) {
-        Zonemaster::Engine->logger->add( SKIP_IPV4_DISABLED => { ns_list => "$ns" } );
+        Zonemaster::Engine->logger->add(
+            SKIP_IPV4_DISABLED => {
+                ns_list => $ns->string,
+                rrtype  => $type
+            }
+        );
         return 1;
     }
 
     if ( not Zonemaster::Engine::Profile->effective->get( q{net.ipv6} ) and $ns->address->version == $IP_VERSION_6 ) {
-        Zonemaster::Engine->logger->add( SKIP_IPV6_DISABLED => { ns_list => "$ns" } );
+        Zonemaster::Engine->logger->add(
+            SKIP_IPV6_DISABLED => {
+                ns_list => $ns->string,
+                rrtype  => $type
+            }
+        );
         return 1;
     }
 

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -73,11 +73,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     SKIP_IPV4_DISABLED => sub {
         __x    # SYSTEM:SKIP_IPV4_DISABLED
-          "IPv4 is disabled, not sending \"{rrtype}\" query to {ns_list}.", @_;
+          "IPv4 is disabled, not sending \"{rrtype}\" query to {ns}.", @_;
     },
     SKIP_IPV6_DISABLED => sub {
         __x    # SYSTEM:SKIP_IPV6_DISABLED
-          "IPv6 is disabled, not sending \"{rrtype}\" query to {ns_list}.", @_;
+          "IPv6 is disabled, not sending \"{rrtype}\" query to {ns}.", @_;
     },
     FAKE_DELEGATION => sub {
         __x    # SYSTEM:FAKE_DELEGATION

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -73,11 +73,11 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     SKIP_IPV4_DISABLED => sub {
         __x    # SYSTEM:SKIP_IPV4_DISABLED
-          "IPv4 is disabled, not sending query to {ns_list}.", @_;
+          "IPv4 is disabled, not sending \"{rrtype}\" query to {ns_list}.", @_;
     },
     SKIP_IPV6_DISABLED => sub {
         __x    # SYSTEM:SKIP_IPV6_DISABLED
-          "IPv6 is disabled, not sending query to {ns_list}.", @_;
+          "IPv6 is disabled, not sending \"{rrtype}\" query to {ns_list}.", @_;
     },
     FAKE_DELEGATION => sub {
         __x    # SYSTEM:FAKE_DELEGATION

--- a/lib/Zonemaster/Engine/Zone.pm
+++ b/lib/Zonemaster/Engine/Zone.pm
@@ -13,6 +13,7 @@ use List::MoreUtils qw[uniq];
 use Zonemaster::Engine::DNSName;
 use Zonemaster::Engine::Recursor;
 use Zonemaster::Engine::NSArray;
+use Zonemaster::Engine::Constants qw[:ip];
 
 has 'name' => ( is => 'ro', isa => 'Zonemaster::Engine::DNSName', required => 1 );
 has 'parent' => ( is => 'ro', isa => 'Maybe[Zonemaster::Engine::Zone]', lazy_build => 1 );
@@ -126,7 +127,7 @@ sub _build_glue_addresses {
 sub _is_ip_version_disabled {
     my ( $ns, $type ) = @_;
 
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == 4 ) {
+    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == $IP_VERSION_4 ) {
         Zonemaster::Engine->logger->add(
             SKIP_IPV4_DISABLED => {
                 ns     => $ns->string,
@@ -136,7 +137,7 @@ sub _is_ip_version_disabled {
         return 1;
     }
 
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == 6 ) {
+    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == $IP_VERSION_6 ) {
         Zonemaster::Engine->logger->add(
             SKIP_IPV6_DISABLED => {
                 ns     => $ns->string,
@@ -179,8 +180,8 @@ sub query_all {
     my @servers = @{ $self->ns };
 
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
-        my @nope = grep { $_->address->version == 4 } @servers;
-        @servers = grep { $_->address->version == 6 } @servers;
+        my @nope = grep { $_->address->version == $IP_VERSION_4 } @servers;
+        @servers = grep { $_->address->version == $IP_VERSION_6 } @servers;
         map {
             Zonemaster::Engine->logger->add(
                SKIP_IPV4_DISABLED => {
@@ -192,8 +193,8 @@ sub query_all {
         }
 
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
-        my @nope = grep { $_->address->version == 6 } @servers;
-        @servers = grep { $_->address->version == 4 } @servers;
+        my @nope = grep { $_->address->version == $IP_VERSION_6 } @servers;
+        @servers = grep { $_->address->version == $IP_VERSION_4 } @servers;
         map {
             Zonemaster::Engine->logger->add(
                 SKIP_IPV6_DISABLED => {

--- a/lib/Zonemaster/Engine/Zone.pm
+++ b/lib/Zonemaster/Engine/Zone.pm
@@ -180,7 +180,7 @@ sub query_all {
 
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
         my @nope = grep { $_->address->version == 4 } @servers;
-        @servers = grep { $_->address->version != 4 } @servers;
+        @servers = grep { $_->address->version == 6 } @servers;
         map {
             Zonemaster::Engine->logger->add(
                SKIP_IPV4_DISABLED => {
@@ -193,7 +193,7 @@ sub query_all {
 
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
         my @nope = grep { $_->address->version == 6 } @servers;
-        @servers = grep { $_->address->version != 6 } @servers;
+        @servers = grep { $_->address->version == 4 } @servers;
         map {
             Zonemaster::Engine->logger->add(
                 SKIP_IPV6_DISABLED => {

--- a/lib/Zonemaster/Engine/Zone.pm
+++ b/lib/Zonemaster/Engine/Zone.pm
@@ -129,8 +129,8 @@ sub _is_ip_version_disabled {
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == 4 ) {
         Zonemaster::Engine->logger->add(
             SKIP_IPV4_DISABLED => {
-                ns_list => $ns->string,
-                rrtype  => $type
+                ns     => $ns->string,
+                rrtype => $type
             }
         );
         return 1;
@@ -139,8 +139,8 @@ sub _is_ip_version_disabled {
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == 6 ) {
         Zonemaster::Engine->logger->add(
             SKIP_IPV6_DISABLED => {
-                ns_list => $ns->string,
-                rrtype  => $type
+                ns     => $ns->string,
+                rrtype => $type
             }
         );
         return 1;
@@ -184,8 +184,8 @@ sub query_all {
         map {
             Zonemaster::Engine->logger->add(
                SKIP_IPV4_DISABLED => {
-                   ns_list => $_->string,
-                   rrtype  => $type
+                   ns     => $_->string,
+                   rrtype => $type
                }
             )
             } @nope;
@@ -197,8 +197,8 @@ sub query_all {
         map {
             Zonemaster::Engine->logger->add(
                 SKIP_IPV6_DISABLED => {
-                    ns_list => $_->string,
-                    rrtype  => $type
+                    ns     => $_->string,
+                    rrtype => $type
                 }
             )
         } @nope;

--- a/lib/Zonemaster/Engine/Zone.pm
+++ b/lib/Zonemaster/Engine/Zone.pm
@@ -161,13 +161,21 @@ sub query_all {
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
         my @nope = grep { $_->address->version == 4 } @servers;
         @servers = grep { $_->address->version != 4 } @servers;
-        Zonemaster::Engine->logger->add( SKIP_IPV4_DISABLED => { ns_list => ( join ';', map { "$_" } @nope ) } );
+        map {
+            Zonemaster::Engine->logger->add(
+               SKIP_IPV4_DISABLED => { ns_list => $_->string }
+            )
+        } @nope;
     }
 
     if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
         my @nope = grep { $_->address->version == 6 } @servers;
         @servers = grep { $_->address->version != 6 } @servers;
-        Zonemaster::Engine->logger->add( SKIP_IPV6_DISABLED => { ns_list => ( join ';', map { "$_" } @nope ) } );
+        map {
+            Zonemaster::Engine->logger->add(
+                SKIP_IPV6_DISABLED => { ns_list => $_->string }
+            )
+        } @nope;
     }
 
     return [ map { $_->query( $name, $type, $flags ) } @servers ];

--- a/lib/Zonemaster/Engine/Zone.pm
+++ b/lib/Zonemaster/Engine/Zone.pm
@@ -123,6 +123,26 @@ sub _build_glue_addresses {
     return [ $p->get_records( 'a' ), $p->get_records( 'aaaa' ) ];
 }
 
+sub _is_ip_version_disabled {
+    my ( $ns ) = @_;
+
+    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == 4 ) {
+        Zonemaster::Engine->logger->add(
+            SKIP_IPV4_DISABLED => { ns_list => $ns->string }
+        );
+        return 1;
+    }
+
+    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == 6 ) {
+        Zonemaster::Engine->logger->add(
+            SKIP_IPV6_DISABLED => { ns_list => $ns->string }
+        );
+        return 1;
+    }
+
+    return 0;
+}
+
 ###
 ### Public Methods
 ###
@@ -133,13 +153,7 @@ sub query_one {
     # Return response from the first server that gives one
     my $i = 0;
     while ( my $ns = $self->ns->[$i] ) {
-        if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == 4 ) {
-            Zonemaster::Engine->logger->add( SKIP_IPV4_DISABLED => { ns_list => "$ns" } );
-            next;
-        }
-
-        if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == 6 ) {
-            Zonemaster::Engine->logger->add( SKIP_IPV6_DISABLED => { ns_list => "$ns" } );
+        if ( _is_ip_version_disabled( $ns ) ) {
             next;
         }
 
@@ -187,13 +201,7 @@ sub query_auth {
     # Return response from the first server that replies with AA set
     my $i = 0;
     while ( my $ns = $self->ns->[$i] ) {
-        if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == 4 ) {
-            Zonemaster::Engine->logger->add( SKIP_IPV4_DISABLED => { ns_list => "$ns" } );
-            next;
-        }
-
-        if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == 6 ) {
-            Zonemaster::Engine->logger->add( SKIP_IPV6_DISABLED => { ns_list => "$ns" } );
+        if ( _is_ip_version_disabled( $ns ) ) {
             next;
         }
 
@@ -215,13 +223,7 @@ sub query_persistent {
     # Return response from the first server that has a record like the one asked for
     my $i = 0;
     while ( my $ns = $self->ns->[$i] ) {
-        if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $ns->address->version == 4 ) {
-            Zonemaster::Engine->logger->add( SKIP_IPV4_DISABLED => { ns_list => "$ns" } );
-            next;
-        }
-
-        if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $ns->address->version == 6 ) {
-            Zonemaster::Engine->logger->add( SKIP_IPV6_DISABLED => { ns_list => "$ns" } );
+        if ( _is_ip_version_disabled( $ns ) ) {
             next;
         }
 


### PR DESCRIPTION
## Purpose

Commit 766c1116 (PR #792) missed some messages. This fixes it (and reverted the argument based on the conversation here, from "ns_list" to "ns").
Also the query type is logged as well.

## Context

Follow-up on #792 

## Changes

* Test/Zone.pm
* Zone.pm
* Translator.pm: the msgid for SKIP_IPV[46]_DISABLED is updated
* Some refactoring as well

## How to test this PR

The following command should not display `{ns_list}` anymore:
```
zonemaster-cli --no-ipv4 --test zone nic.fr --level DEBUG --show-testcase --show-testcase --locale en_US.UTF-8 | grep "disabled"
```
And the query type should also be logged.