### PR TITLE
Add check for undelegated test in DNSSEC11

### DIFF
--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -2883,8 +2883,17 @@ sub dnssec11 {
     my %nss        = map { $_->name->string . '/' . $_->address->short => $_ } @nss_parent;
     my %ip_already_processed;
 
+    my $is_undelegated = Zonemaster::Engine::Recursor->has_fake_addresses( $zone->name->string );
+
     for my $nss_key ( sort keys %nss ) {
         my $ns = $nss{$nss_key};
+
+        if ( $is_undelegated ){
+            if ( not scalar %{$ns->fake_ds} ){
+                return ( @results, info( TEST_CASE_END => { testcase => (split /::/, (caller(0))[3])[-1] } ) );
+            }
+            last;
+        }
 
         next if exists $ip_already_processed{$ns->address->short};
         $ip_already_processed{$ns->address->short} = 1;

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -2889,7 +2889,7 @@ sub dnssec11 {
         my $ns = $nss{$nss_key};
 
         if ( $is_undelegated ){
-            if ( not scalar %{$ns->fake_ds} ){
+            if ( not $ns->fake_ds->{$zone->name->string} ){
                 return ( @results, info( TEST_CASE_END => { testcase => (split /::/, (caller(0))[3])[-1] } ) );
             }
             last;


### PR DESCRIPTION
## Purpose

This PR solves the missing check for undelegated test in DNSSEC11.

## Context

Fixes #1099.

## Changes

Check for undelegated test and exit if no DS is found.

## How to test this PR

`zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --raw --level INFO --test dnssec/dnssec11` should exit the test case instantly without outputting any messages nor doing any testing - this can be seen with the `--level DEBUG` option instead)

`zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --ds 12345,3,1,123456789abcdef67890123456789abcdef67890 --raw --level INFO --test dnssec/dnssec11` should not output any messages (but silently proceeds to test the child zone - this can be seen with the `--level DEBUG` option instead)
