### PR TITLE
Consistently output IPV4_DISABLED/IPV6_DISABLED message in DEBUG

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -450,14 +450,9 @@ sub nameserver01 {
         @nss = values %nss;
     }
 
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_6 } @nss;
-    }
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_4 } @nss;
-    }
-
     for my $ns ( @nss ) {
+
+        next if ( _ip_disabled_message( \@results, $ns, q{A} ) );
 
         my $response_count = 0;
         my $nxdomain_count = 0;
@@ -510,9 +505,7 @@ sub nameserver02 {
     foreach
       my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
     {
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $local_ns->address->version == $IP_VERSION_6 );
-
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $local_ns->address->version == $IP_VERSION_4 );
+        next if ( _ip_disabled_message( \@results, $local_ns, q{SOA} ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
 
@@ -593,9 +586,7 @@ sub nameserver03 {
       my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
     {
 
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $local_ns->address->version == $IP_VERSION_6 );
-
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $local_ns->address->version == $IP_VERSION_4 );
+        next if ( _ip_disabled_message( \@results, $local_ns, q{AXFR} ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
 
@@ -626,9 +617,7 @@ sub nameserver04 {
       my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
     {
 
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $local_ns->address->version == $IP_VERSION_6 );
-
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $local_ns->address->version == $IP_VERSION_4 );
+        next if ( _ip_disabled_message( \@results, $local_ns, q{SOA} ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
 
@@ -670,9 +659,7 @@ sub nameserver05 {
 
         next if $nsnames_and_ip{ $ns->name->string . q{/} . $ns->address->short };
 
-        if ( _ip_disabled_message( \@results, $ns, q{A} ) ) {
-            next;
-        }
+        next if ( _ip_disabled_message( \@results, $ns, q{A} ) );
 
         $nsnames_and_ip{ $ns->name->string . q{/} . $ns->address->short }++;
 
@@ -796,9 +783,7 @@ sub nameserver07 {
         foreach my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
             @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
         {
-            next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $local_ns->address->version == $IP_VERSION_6 );
-
-            next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $local_ns->address->version == $IP_VERSION_4 );
+            next if ( _ip_disabled_message( \@results, $local_ns, q{NS} ) );
 
             next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
 
@@ -843,9 +828,7 @@ sub nameserver08 {
     foreach
       my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
     {
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $local_ns->address->version == $IP_VERSION_6 );
-
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $local_ns->address->version == $IP_VERSION_4 );
+        next if ( _ip_disabled_message( \@results, $local_ns, q{SOA} ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
 
@@ -902,9 +885,7 @@ sub nameserver09 {
     foreach
       my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
     {
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) and $local_ns->address->version == $IP_VERSION_6 );
-
-        next if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) and $local_ns->address->version == $IP_VERSION_4 );
+        next if ( _ip_disabled_message( \@results, $local_ns, $record_type ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
 
@@ -1033,19 +1014,15 @@ sub nameserver10 {
         @nss = values %nss;
     }
 
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_6 } @nss;
-    }
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_4 } @nss;
-    }
-
     for my $ns ( @nss ) {
+
+        next if ( _ip_disabled_message( \@results, $ns, q{SOA} ) );
+
         my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { version => 0 } } );
-        
+
         if ( $p and $p->rcode eq q{NOERROR} ){
             my $p2 = $ns->query( $zone->name, q{SOA}, { edns_details => { version => 1 } } );
-            
+
             if ( $p2 ) {
                 if ( ($p2->rcode ne q{NOERROR} and $p2->edns_rcode != 1) ) {
                     push @{ $unexpected_rcode{$p->rcode} }, $ns->address->short;
@@ -1107,13 +1084,6 @@ sub nameserver11 {
         @nss = values %nss;
     }
 
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_6 } @nss;
-    }
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_4 } @nss;
-    }
-
     # Choose an unassigned EDNS0 Option Codes
     # values 15-26945 are Unassigned. Let's say we use 137 ???
     my $opt_code = 137;
@@ -1122,6 +1092,9 @@ sub nameserver11 {
     my $rdata = $opt_code*65536 + $opt_length;
 
     for my $ns ( @nss ) {
+
+        next if ( _ip_disabled_message( \@results, $ns, q{SOA} ) );
+
         my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { data => $rdata } } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->edns_rcode ) {
@@ -1164,14 +1137,10 @@ sub nameserver12 {
         @nss = values %nss;
     }
 
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_6 } @nss;
-    }
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_4 } @nss;
-    }
-
     for my $ns ( @nss ) {
+
+        next if ( _ip_disabled_message( \@results, $ns, q{SOA} ) );
+
         my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { z => 3 } } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->edns_rcode ) {
@@ -1213,14 +1182,10 @@ sub nameserver13 {
         @nss = values %nss;
     }
 
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv6}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_6 } @nss;
-    }
-    if ( not Zonemaster::Engine::Profile->effective->get(q{net.ipv4}) ) {
-        @nss = grep { $_->address->version != $IP_VERSION_4 } @nss;
-    }
-
     for my $ns ( @nss ) {
+
+        next if ( _ip_disabled_message( \@results, $ns, q{SOA} ) );
+
         my $p = $ns->query( $zone->name, q{SOA}, { usevc => 0, fallback => 0, edns_details => { do => 1, udp_size => 512  } } );
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->edns_rcode ) {

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -501,6 +501,7 @@ sub nameserver02 {
     my ( $class, $zone ) = @_;
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
     my %nsnames_and_ip;
+    my $n_error = 0;
 
     foreach
       my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
@@ -513,6 +514,7 @@ sub nameserver02 {
         if ( $p ) {
             if ( $p->rcode eq q{FORMERR} and not $p->has_edns) {
                 push @results, info( NO_EDNS_SUPPORT => { ns => $local_ns->string } );
+                $n_error++;
             }
             elsif ( $p->rcode eq q{NOERROR} and not $p->edns_rcode and $p->get_records( q{SOA}, q{answer} ) and $p->edns_version == 0 ) {
                 $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short }++;
@@ -526,6 +528,7 @@ sub nameserver02 {
                         domain => $zone->name,
                     }
                   );
+                $n_error++;
             }
             elsif ( $p->rcode eq q{NOERROR} and $p->has_edns and $p->edns_version != 0 ) {
                 push @results,
@@ -535,9 +538,11 @@ sub nameserver02 {
                         domain => $zone->name,
                     }
                   );
+                $n_error++;
             }
             else {
                 push @results, info( NS_ERROR => { ns => $local_ns->string } );
+                $n_error++;
             }
         }
         else {
@@ -550,6 +555,7 @@ sub nameserver02 {
                         domain => $zone->name,
                     }
                   );
+                $n_error++;
             }
             else {
                 push @results,
@@ -559,13 +565,14 @@ sub nameserver02 {
                         domain => $zone->name,
                     }
                   );
+                $n_error++;
             }
         }
 
         $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short }++;
     } ## end foreach my $local_ns ( @{ Zonemaster::Engine::TestMethods...})
 
-    if ( scalar keys %nsnames_and_ip and not grep { $_->tag ne q{TEST_CASE_START} } @results ) {
+    if ( scalar keys %nsnames_and_ip and not $n_error ) {
         push @results,
           info(
             EDNS0_SUPPORT => {
@@ -612,6 +619,7 @@ sub nameserver04 {
     my ( $class, $zone ) = @_;
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
     my %nsnames_and_ip;
+    my $n_error = 0;
 
     foreach
       my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
@@ -631,12 +639,13 @@ sub nameserver04 {
                         source => $p->answerfrom,
                     }
                   );
+                $n_error++;
             }
         }
         $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short }++;
     } ## end foreach my $local_ns ( @{ Zonemaster::Engine::TestMethods...})
 
-    if ( scalar keys %nsnames_and_ip and not grep { $_->tag ne q{TEST_CASE_START} } @results ) {
+    if ( scalar keys %nsnames_and_ip and not $n_error) {
         push @results,
           info(
             SAME_SOURCE_IP => {
@@ -775,6 +784,7 @@ sub nameserver07 {
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
     my %nsnames_and_ip;
     my %nsnames;
+    my $n_error = 0;
 
     if ( $zone->name eq q{.} ) {
         push @results, info( UPWARD_REFERRAL_IRRELEVANT => {} );
@@ -793,13 +803,14 @@ sub nameserver07 {
 
                 if ( @ns ) {
                     push @results, info( UPWARD_REFERRAL => { ns => $local_ns->string } );
+                    $n_error++;
                 }
             }
             $nsnames{ $local_ns->name }++;
             $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short }++;
         } ## end foreach my $local_ns ( @{ Zonemaster::Engine::TestMethods...})
 
-        if ( scalar keys %nsnames_and_ip and not grep { $_->tag ne q{TEST_CASE_START} } @results ) {
+        if ( scalar keys %nsnames_and_ip and not $n_error ) {
             push @results,
               info(
                 NO_UPWARD_REFERRAL => {

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -442,13 +442,7 @@ sub nameserver01 {
     my ( $class, $zone ) = @_;
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
 
-    my @nss;
-    {
-        my %nss = map { $_->string => $_ }
-          @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
-          @{ Zonemaster::Engine::TestMethods->method5( $zone ) };
-        @nss = values %nss;
-    }
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
 
     for my $ns ( @nss ) {
 
@@ -503,9 +497,9 @@ sub nameserver02 {
     my %nsnames_and_ip;
     my $n_error = 0;
 
-    foreach
-      my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
-    {
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
+
+    foreach my $local_ns ( @nss ) {
         next if ( _ip_disabled_message( \@results, $local_ns, q{SOA} ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
@@ -589,9 +583,9 @@ sub nameserver03 {
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
     my %nsnames_and_ip;
 
-    foreach
-      my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
-    {
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
+
+    foreach my $local_ns ( @nss ) {
 
         next if ( _ip_disabled_message( \@results, $local_ns, q{AXFR} ) );
 
@@ -621,9 +615,9 @@ sub nameserver04 {
     my %nsnames_and_ip;
     my $n_error = 0;
 
-    foreach
-      my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
-    {
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
+
+    foreach my $local_ns ( @nss ) {
 
         next if ( _ip_disabled_message( \@results, $local_ns, q{SOA} ) );
 
@@ -664,11 +658,13 @@ sub nameserver05 {
     my $aaaa_issue = 0;
     my @aaaa_ok;
 
-    foreach my $ns ( @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) } ) {
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
 
-        next if $nsnames_and_ip{ $ns->name->string . q{/} . $ns->address->short };
+    foreach my $ns ( @nss ) {
 
         next if ( _ip_disabled_message( \@results, $ns, q{A} ) );
+
+        next if $nsnames_and_ip{ $ns->name->string . q{/} . $ns->address->short };
 
         $nsnames_and_ip{ $ns->name->string . q{/} . $ns->address->short }++;
 
@@ -747,8 +743,7 @@ sub nameserver06 {
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
     my @all_nsnames = uniq map { lc( $_->string ) } @{ Zonemaster::Engine::TestMethods->method2( $zone ) },
       @{ Zonemaster::Engine::TestMethods->method3( $zone ) };
-    my @all_nsnames_with_ip = uniq map { lc( $_->name->string ) } @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
-      @{ Zonemaster::Engine::TestMethods->method5( $zone ) };
+    my @all_nsnames_with_ip = uniq map { lc( $_->name->string ) } @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
     my @all_nsnames_without_ip;
     my %diff;
 
@@ -790,9 +785,8 @@ sub nameserver07 {
         push @results, info( UPWARD_REFERRAL_IRRELEVANT => {} );
     }
     else {
-        foreach my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
-            @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
-        {
+        my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
+        foreach my $local_ns ( @nss ) {
             next if ( _ip_disabled_message( \@results, $local_ns, q{NS} ) );
 
             next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
@@ -836,9 +830,10 @@ sub nameserver08 {
         $randomized_uc_name = scramble_case $original_name;
     } while ( $randomized_uc_name eq $original_name );
 
-    foreach
-      my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
-    {
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
+
+    foreach my $local_ns ( @nss ) {
+
         next if ( _ip_disabled_message( \@results, $local_ns, q{SOA} ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
@@ -893,9 +888,10 @@ sub nameserver09 {
         $randomized_uc_name2 = scramble_case $original_name;
     } while ( $randomized_uc_name2 eq $original_name or $randomized_uc_name2 eq $randomized_uc_name1 );
 
-    foreach
-      my $local_ns ( @{ Zonemaster::Engine::TestMethods->method4( $zone ) }, @{ Zonemaster::Engine::TestMethods->method5( $zone ) } )
-    {
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
+
+    foreach my $local_ns ( @nss ) {
+
         next if ( _ip_disabled_message( \@results, $local_ns, $record_type ) );
 
         next if $nsnames_and_ip{ $local_ns->name->string . q{/} . $local_ns->address->short };
@@ -1017,13 +1013,7 @@ sub nameserver10 {
     my %unexpected_rcode;
     my @edns_response_error;
 
-    my @nss;
-    {
-        my %nss = map { $_->string => $_ }
-          @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
-          @{ Zonemaster::Engine::TestMethods->method5( $zone ) };
-        @nss = values %nss;
-    }
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
 
     for my $ns ( @nss ) {
 
@@ -1087,20 +1077,14 @@ sub nameserver11 {
     my ( $class, $zone ) = @_;
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
 
-    my @nss;
-    {
-        my %nss = map { $_->string => $_ }
-          @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
-          @{ Zonemaster::Engine::TestMethods->method5( $zone ) };
-        @nss = values %nss;
-    }
-
     # Choose an unassigned EDNS0 Option Codes
     # values 15-26945 are Unassigned. Let's say we use 137 ???
     my $opt_code = 137;
     my $opt_data = q{};
     my $opt_length = length($opt_data);
     my $rdata = $opt_code*65536 + $opt_length;
+
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
 
     for my $ns ( @nss ) {
 
@@ -1140,13 +1124,7 @@ sub nameserver12 {
     my ( $class, $zone ) = @_;
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
 
-    my @nss;
-    {
-        my %nss = map { $_->string => $_ }
-          @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
-          @{ Zonemaster::Engine::TestMethods->method5( $zone ) };
-        @nss = values %nss;
-    }
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
 
     for my $ns ( @nss ) {
 
@@ -1185,13 +1163,7 @@ sub nameserver13 {
     my ( $class, $zone ) = @_;
     push my @results, info( TEST_CASE_START => { testcase => (split /::/, (caller(0))[3])[-1] } );
 
-    my @nss;
-    {
-        my %nss = map { $_->string => $_ }
-          @{ Zonemaster::Engine::TestMethods->method4( $zone ) },
-          @{ Zonemaster::Engine::TestMethods->method5( $zone ) };
-        @nss = values %nss;
-    }
+    my @nss =  @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
 
     for my $ns ( @nss ) {
 


### PR DESCRIPTION
## Purpose

Such messages have a DEBUG level and were not always displayed. This
significantly increases the number of DEBUG messages.

## Context

Follow up from #1098, see https://github.com/zonemaster/zonemaster-engine/pull/1098#issuecomment-1190342319

## Changes

* Test/Nameserver.pm

## How to test this PR

Playing with `--no-ipv4` and `--no-ipv6` should give more DEBUG messages:
```
zonemaster-cli --no-ipv4 --test nameserver --level DEBUG --show-module --show-testcase --show-testcase --locale en_US.UTF-8 nic.fr | grep IP
```