### PR TITLE
Fixes bug in Net::IP with a work around. Issue #1107

### DIFF
--- a/lib/Zonemaster/Engine/Net/IP.pm
+++ b/lib/Zonemaster/Engine/Net/IP.pm
@@ -61,6 +61,12 @@ sub print {
 
 sub reverse_ip {
     my $self = shift;
+    my $addr = $self->{_inner}->short;
+    # Work around for IPv4 address due to a bug in Net::IP when the last octet is "0"
+    # https://github.com/zonemaster/zonemaster-engine/issues/1107
+    if ($addr =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.0$/) { # IPv4 x.x.x.0
+        return join ('.', reverse (split (/\./, $addr))) . '.in-addr.arpa.';
+    };
     return $self->{_inner}->reverse_ip();
 }
 


### PR DESCRIPTION
## Purpose

Net::IP does not make correct reverse name when last octet is a "0". This is a work-around the bug.

## Context

Resolves #1107


## How to test this PR

On a system where Net::IP::XS is not installed (e.g. CentOS 7) run the following command and verify that one of the last lines have a PTR query where the IP address ends with "0" and that the name is correct.
```
zonemaster-cli 15.248.151.in-addr.arpa --raw --show_testcase --test address/address02 --level DEBUG
```
