### PR TITLE
Fix Basic04 when there are no reachable name servers

### DIFF
--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -514,6 +514,15 @@ sub basic04 {
     my @query_types = qw{SOA NS};
     my @ns = @{ Zonemaster::Engine::TestMethods->method4and5( $zone ) };
 
+    if ( not scalar @ns ){
+        push @results,
+            info(
+               B04_NO_RESPONSE => {
+                   ns => ''
+                }
+            );
+    }
+
     foreach my $ns ( @ns ) {
         if ( _ip_disabled_message( \@results, $ns, @query_types ) ) {
             next;


### PR DESCRIPTION
## Purpose

This PR proposes a fix for #1104, by checking that Method4&5 used in the test case does indeed return Engine::Nameserver objects.

If not, message tag `B04_NO_RESPONSE` is used as output. As it is not possible to get the name/IP of the name servers (those are provided by the above method, which is empty is our case), I chose to use an empty string as a placeholder to have a sense of generalization in the message ID (instead of the variable name `{ns}`). Let me know if you think something else would be better instead.

This means the message ID will look like this:

`21.04 WARNING   BASIC04        Nameserver  does not respond over neither UDP nor TCP.`

## Context

Fixes #1104.

## How to test this PR

```
zonemaster-cli lame.dufberg.se --show-testcase --test basic/basic04 --level INFO --raw
   0.00 INFO      UNSPECIFIED    GLOBAL_VERSION   version=v4.5.1
  20.93 WARNING   BASIC04        B04_NO_RESPONSE   ns=
```