### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apk add --no-cache \
     perl-lwp-protocol-https \
     perl-module-install \
     perl-moose \
-    perl-net-ip \
     perl-pod-coverage \
     perl-test-differences \
     perl-test-exception \


### PR DESCRIPTION
## Purpose

This PR drops the Net::IP module from the docker installation.

## Context

Zonemaster::Engine specifies Net::IP::XS as a dependency, and it will be installed from CPAN.

## Changes

...

## How to test this PR

...
