### PR TITLE
Remove special SHA-1 treatment from DNSSEC01

### DIFF
--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -311,7 +311,6 @@ sub metadata {
               DS01_DS_ALGO_2_MISSING
               DS01_DS_ALGO_NOT_DS
               DS01_DS_ALGO_RESERVED
-              DS01_DS_ALGO_SHA1_DEPRECATED
               TEST_CASE_END
               TEST_CASE_START
               )
@@ -617,13 +616,6 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # DNSSEC:DS01_DS_ALGO_RESERVED
           'DS record for zone {domain} with keytag {keytag} was created with an unassigned digest algorithm '
           . '(algorithm number {ds_algo_num}). '
-          . 'Fetched from the nameservers with IP addresses "{ns_ip_list}".',
-          @_;
-    },
-    DS01_DS_ALGO_SHA1_DEPRECATED => sub {
-        __x    # DNSSEC:DS01_DS_ALGO_SHA1_DEPRECATED
-          'DS record for zone {domain} with keytag {keytag} was created by digest algorithm {ds_algo_num} '
-          . '({ds_algo_mnemo}). While still being widely in use, it is deprecated. '
           . 'Fetched from the nameservers with IP addresses "{ns_ip_list}".',
           @_;
     },
@@ -1323,19 +1315,7 @@ sub dnssec01 {
                             }
                           );
                     }
-                    elsif ( $ds_digtype == 1 ) {
-                        push @results,
-                          info(
-                            DS01_DS_ALGO_SHA1_DEPRECATED => {
-                                ns_ip_list    => join( q{;}, uniq sort @{ $ds_records{$ds_digtype}->{$ds_keytag} } ),
-                                domain        => q{} . $zone->name,
-                                keytag        => $ds_keytag,
-                                ds_algo_num   => $ds_digtype,
-                                ds_algo_mnemo => $mnemonic,
-                            }
-                          );
-                    }
-                    elsif ( $ds_digtype == 3 ) {
+                    elsif ( $ds_digtype == 1 or $ds_digtype == 3 ) {
                         push @results,
                           info(
                             DS01_DS_ALGO_DEPRECATED => {

--- a/share/profile.json
+++ b/share/profile.json
@@ -182,7 +182,6 @@
             "DS01_DS_ALGO_2_MISSING" : "NOTICE",
             "DS01_DS_ALGO_NOT_DS" : "ERROR",
             "DS01_DS_ALGO_RESERVED" : "ERROR",
-            "DS01_DS_ALGO_SHA1_DEPRECATED" : "WARNING",
             "DS02_ALGO_NOT_SUPPORTED_BY_ZM" : "NOTICE",
             "DS02_DNSKEY_NOT_FOR_ZONE_SIGNING" : "ERROR",
             "DS02_DNSKEY_NOT_SEP" : "NOTICE",

--- a/t/Test-dnssec.t
+++ b/t/Test-dnssec.t
@@ -94,26 +94,26 @@ zone_gives_not( 'dnssec07', $zone, [qw{NEITHER_DNSKEY_NOR_DS DNSKEY_BUT_NOT_DS D
 # dnssec01
 ###########
 $zone = Zonemaster::Engine->zone( 'dnssec01-ds-algorithm-ok.zut-root.rd.nic.fr' );
-zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_SHA1_DEPRECATED DS01_DS_ALGO_RESERVED DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_2_MISSING DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
+zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_RESERVED DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_2_MISSING DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
 
 $zone = Zonemaster::Engine->zone( 'dnssec01-nxdomain.zut-root.rd.nic.fr' );
-zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_SHA1_DEPRECATED DS01_DS_ALGO_RESERVED DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_2_MISSING DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
+zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_RESERVED DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_2_MISSING DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
 
 $zone = Zonemaster::Engine->zone( 'dnssec01-ds-algorithm-not-ds.zut-root.rd.nic.fr' );
 zone_gives( 'dnssec01', $zone, [qw{DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_2_MISSING DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
-zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_SHA1_DEPRECATED DS01_DS_ALGO_RESERVED}] );
+zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_RESERVED}] );
 
 $zone = Zonemaster::Engine->zone( 'dnssec01-ds-algorithm-deprecated1.zut-root.rd.nic.fr' );
-zone_gives( 'dnssec01', $zone, [qw{DS01_DS_ALGO_SHA1_DEPRECATED DS01_DS_ALGO_2_MISSING}] );
-zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_RESERVED DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
+zone_gives( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_2_MISSING}] );
+zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_RESERVED DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
 
 $zone = Zonemaster::Engine->zone( 'dnssec01-ds-algorithm-deprecated3.zut-root.rd.nic.fr' );
 zone_gives( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_2_MISSING DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
-zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_SHA1_DEPRECATED DS01_DS_ALGO_RESERVED}] );
+zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_NOT_DS DS01_DS_ALGO_RESERVED}] );
 
 $zone = Zonemaster::Engine->zone( 'dnssec01-ds-algorithm-reserved.zut-root.rd.nic.fr' );
 zone_gives( 'dnssec01', $zone, [qw{DS01_DS_ALGO_RESERVED DS01_DS_ALGO_2_MISSING DS01_DIGEST_NOT_SUPPORTED_BY_ZM}] );
-zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_SHA1_DEPRECATED DS01_DS_ALGO_NOT_DS}] );
+zone_gives_not( 'dnssec01', $zone, [qw{DS01_DS_ALGO_DEPRECATED DS01_DS_ALGO_NOT_DS}] );
 
 ###########
 # dnssec02


### PR DESCRIPTION
## Purpose

This PR removes the special treatment of SHA-1 from DNSSEC01, following the [update ](https://github.com/zonemaster/zonemaster/pull/1073) on the specification.

## Context

Fixes #1115 

## Changes

- Remove DS01_DS_ALGO_SHA1_DEPRECATED messages from test case and profile
- Output DS01_DS_ALGO_DEPRECATED for SHA-1 (Algo 1)
- Update DNSSEC01 unitary tests

## How to test this PR

Tests should pass.

```
zonemaster-cli --show-testcase --test dnssec/dnssec01 dnssec01-ds-algorithm-deprecated1.zut-root.rd.nic.fr --raw
   1.04 ERROR     DNSSEC01       DS01_DS_ALGO_DEPRECATED   domain=dnssec01-ds-algorithm-deprecated1.zut-root.rd.nic.fr; ds_algo_mnemo=SHA-1; ds_algo_num=1; keytag=8011; ns_ip_list=145.239.76.200;145.239.76.202
   1.04 NOTICE    DNSSEC01       DS01_DS_ALGO_2_MISSING   domain=dnssec01-ds-algorithm-deprecated1.zut-root.rd.nic.fr

```