### PR TITLE
Define argument name "label" and "unicode_name"

### DIFF
--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -71,7 +71,7 @@ and updated messages (*msgids* and *msgstr*).
 | rcode          | An RCODE Name                            | An RCODE Name (not numeric code) from [DNS RCODEs].                     |
 | rrtype         | A Resource Record TYPE Name              | A Resource Record TYPE Name (not numeric code) from [DNS RR TYPEs].     |
 | testcase       | A Zonemaster test case, or `all`         | A test case identifier.                                                 |
-
+| unicode_name   | Unicode name of a code point             | The name is a string in ASCII only and in upper case, e.g. "LATIN SMALL LETTER A"|
 
 ## Preliminary or proposed arguments
 

--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -57,6 +57,7 @@ and updated messages (*msgids* and *msgstr*).
 | ds_algo_mnemo  | Text                                     | The mnemonic of a [DS Digest algorithm].                                |
 | ds_algo_num    | Non-negative integer                     | The numeric value for a [DS Digest algorithm].                          |
 | keytag         | Non-negative integer                     | A keytag for a DNSKEY record or a keytag used in a DS or RRSIG record.  |
+| label          | Domain name label                        | A single label, i.e. the string between the dots, from a domain name.   |
 | mailtarget     | Domain name                              | The domain name of the mailserver in an MX RDATA.                       |
 | mailtarget_list| List of domain names                     | A list of name servers, as specified by "mailtarget", separated by ";". |
 | module         | A Zonemaster test module, or `all`       | The name of a Zonemaster test module.                                   |
@@ -91,7 +92,6 @@ defined *arguments*.
 || DNS packet size| The size in octets of a DNS packets.|
 || DNSKEY key length| The key length for a DNSKEY. The interpretation of this value various quite a bit with the algorithm. Be careful when using it for algorithms that aren't RSA-based.|
 || DNSSEC delegation verification failure reason| A somewhat human-readable reason why the delegation step between the tested zone and its parent is not secure.|
-| dlabel (?) | Domain name label| A single label from a domain name.|
 | dlength (?) | Domain name label length| The length of a domain name label.|
 || Duration in seconds| An integer number of seconds.|
 | fqdn (?) | FQDN| A fully qualified domain name (with terminating dot).|

--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -206,7 +206,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DOMAIN_NAME_LABEL_TOO_LONG => sub {
         __x    # BASIC:DOMAIN_NAME_LABEL_TOO_LONG
-          'Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max}).', @_;
+          'Domain name ({domain}) has a label ({label}) too long ({dlength}/{max}).', @_;
     },
     DOMAIN_NAME_TOO_LONG => sub {
         __x    # BASIC:DOMAIN_NAME_TOO_LONG
@@ -356,7 +356,7 @@ sub basic00 {
               info(
                 q{DOMAIN_NAME_LABEL_TOO_LONG} => {
                     domain  => "$name",
-                    dlabel  => $local_label,
+                    label  => $local_label,
                     dlength => length( $local_label ),
                     max     => $LABEL_MAX_LENGTH,
                 }

--- a/share/da.po
+++ b/share/da.po
@@ -170,9 +170,9 @@ msgstr ""
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({label}) too long ({dlength}/{max})."
 msgstr ""
-"Domænenavnet ({domain}) indeholder en label ({dlabel}), der er for lang "
+"Domænenavnet ({domain}) indeholder en label ({label}), der er for lang "
 "({dlength}/{max})."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG

--- a/share/es.po
+++ b/share/es.po
@@ -181,9 +181,9 @@ msgstr ""
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({label}) too long ({dlength}/{max})."
 msgstr ""
-"El nombre de dominio ({domain}) tiene una etiqueta ({dlabel}) demasiado "
+"El nombre de dominio ({domain}) tiene una etiqueta ({label}) demasiado "
 "larga ({dlength}/{max})."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG

--- a/share/fi.po
+++ b/share/fi.po
@@ -171,9 +171,9 @@ msgstr ""
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({label}) too long ({dlength}/{max})."
 msgstr ""
-"Verkkotunnuksen ({domain}) osa ({dlabel}) on liian pitkä ({dlength}/{max})."
+"Verkkotunnuksen ({domain}) osa ({label}) on liian pitkä ({dlength}/{max})."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG
 #, perl-brace-format

--- a/share/fr.po
+++ b/share/fr.po
@@ -180,9 +180,9 @@ msgstr ""
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({label}) too long ({dlength}/{max})."
 msgstr ""
-"Le nom de domaine '{domain}' a un label ({dlabel}) trop long ({dlength}/"
+"Le nom de domaine '{domain}' a un label ({label}) trop long ({dlength}/"
 "{max})."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG

--- a/share/nb.po
+++ b/share/nb.po
@@ -166,9 +166,9 @@ msgstr ""
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({label}) too long ({dlength}/{max})."
 msgstr ""
-"Domenenavnet ({domain}) har et ledd ({dlabel}) som er for langt ({dlength}/"
+"Domenenavnet ({domain}) har et ledd ({label}) som er for langt ({dlength}/"
 "{max})."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG

--- a/share/sv.po
+++ b/share/sv.po
@@ -165,9 +165,9 @@ msgstr ""
 #. BASIC:DOMAIN_NAME_LABEL_TOO_LONG
 #, perl-brace-format
 msgid ""
-"Domain name ({domain}) has a label ({dlabel}) too long ({dlength}/{max})."
+"Domain name ({domain}) has a label ({label}) too long ({dlength}/{max})."
 msgstr ""
-"Domändelen '{dlabel}' i domännamnet {domain} är för lång ({dlength}). "
+"Domändelen '{label}' i domännamnet {domain} är för lång ({dlength}). "
 "Maximal längd är {max}."
 
 #. BASIC:DOMAIN_NAME_TOO_LONG


### PR DESCRIPTION
## Purpose

Both "dlabel" and "label" are used as argument names, but none of them are defined. The former is used only once, the latter is clearer and used several times. With this PR "label" is defined in the documentation and "dlabel" is not used any more.

To make implementation consistent, "dlabel" is replaced by "label" in the affected Perl module and in the PO files.

In addition, the argument name "unicode_name" is defined (not yet in use in any code).

## Context

In https://github.com/zonemaster/zonemaster/pull/942#discussion_r951081481 it was noted that undefined "dlabel" was used in that PR. Instead of defining that, it will be replaced by "label" that this PR defines.

## Changes

* docs/logentry_args.md
* lib/Zonemaster/Engine/Test/Basic.pm
* share/da.po
* share/es.po
* share/fi.po
* share/fr.po
* share/nb.po
* share/sv.po

## How to test this PR

The main change is documentation change only. Review the change and compare with the implementation.

The other change affects the PO files. That can be tested by following the "[Instructions for translators]":

1. Update the PO files by running `./update-po da.po` and for all other PO files.
2. Check the arguments by running `../util/check-msg-args da.po` and for all other PO files.

[Instructions for translators]: https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/maintenance/Instructions-for-translators.md
