### PR TITLE
Use lowercase fragments to refer to internal headings

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -2,16 +2,16 @@
 
 ## Table of contents
 
-* [Overview](#Overview)
-* [Docker](#Docker)
-* [Prerequisites](#Prerequisites)
-* [Local installation](#Local-installation)
+* [Overview](#overview)
+* [Docker](#docker)
+* [Prerequisites](#prerequisites)
+* [Local installation](#local-installation)
   * [Installation on Rocky Linux]
   * [Installation on Debian and Ubuntu]
   * [Installation on FreeBSD]
   * [Installation on CentOS 7]
-* [Post-installation sanity check](#Post-installation-sanity-check)
-* [What to do next](#What-to-do-next)
+* [Post-installation sanity check](#post-installation-sanity-check)
+* [What to do next](#what-to-do-next)
 
 
 ## Overview


### PR DESCRIPTION
## Purpose

When it comes to referring to internal anchors, we used a mix of upper and lower cases in our Markdown documents. It appears that Github handles this well, but other Markdown to HTML engines suffer to link to the related identifier on the page since they are looking for a perfect match (case sensitively).
This PR is about downcasing all fragments in our Markdown documents.

## Context

n/a

## Changes

Downcase all fragments that refer to internal anchors in our Markdown documents.

## How to test this PR

Documentation only. Links with the updated fragments should work properly once rendered.