### PR TITLE
Fix message to take equality into consideration

### DIFF
--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -180,7 +180,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     RETRY_MINIMUM_VALUE_OK => sub {
         __x    # ZONE:RETRY_MINIMUM_VALUE_OK
-          'SOA \'retry\' value ({retry}) is more than the minimum recommended value ({required_retry}).', @_;
+          'SOA \'retry\' value ({retry}) is more or equal than the minimum recommended value ({required_retry}).', @_;
     },
     MNAME_NO_RESPONSE => sub {
         __x    # ZONE:MNAME_NO_RESPONSE
@@ -200,7 +200,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     REFRESH_MINIMUM_VALUE_OK => sub {
         __x    # ZONE:REFRESH_MINIMUM_VALUE_OK
-          'SOA \'refresh\' value ({refresh}) is higher than the minimum recommended value ({required_refresh}).', @_;
+          'SOA \'refresh\' value ({refresh}) is higher or equal than the minimum recommended value ({required_refresh}).', @_;
     },
     EXPIRE_LOWER_THAN_REFRESH => sub {
         __x    # ZONE:EXPIRE_LOWER_THAN_REFRESH


### PR DESCRIPTION
## Purpose

In Zone02 (resp. Zone04), when the SOA 'refresh' (resp. 'retry') value equals the minimum recommended value, the message can be disconcerting:

```
SOA 'refresh' value (14400) is higher than the minimum recommended value (14400). 
SOA 'retry' value (3600) is more than the minimum recommended value (3600). 
```
This PR updates the msgid to include the equality case in the message.

## Context

Addresses https://github.com/zonemaster/zonemaster/issues/1092

## Changes

Update msgid in Zone.pm.

## How to test this PR

Running a test where the SOA 'refresh' (resp. 'retry') value equal the minimum recommended one and see look for the updated messages:
```
zonemaster-cli --test zone/zone02 --test zone/zone04 --level INFO elysee.fr
Seconds Level     Message
======= ========= =======
   0.00 INFO      Using version v4.5.1 of the Zonemaster engine.
   1.86 INFO      SOA 'refresh' value (14400) is higher than the minimum recommended value (14400).
   0.00 INFO      Using version v4.5.1 of the Zonemaster engine.
   0.52 INFO      SOA 'retry' value (3600) is more than the minimum recommended value (3600).
```
