### PR TITLE
Make root hints file configurable

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -51,11 +51,9 @@ Makefile.PL
 MANIFEST			This list of files
 META.yml
 README.md
+share/GNUmakefile
 share/iana-ipv4-special-registry.csv
 share/iana-ipv6-special-registry.csv
-share/modules.txt
-share/profile.json
-share/profile_additional_properties.json
 share/locale/da/LC_MESSAGES/Zonemaster-Engine.mo
 share/locale/es/LC_MESSAGES/Zonemaster-Engine.mo
 share/locale/fi/LC_MESSAGES/Zonemaster-Engine.mo
@@ -63,7 +61,10 @@ share/locale/fr/LC_MESSAGES/Zonemaster-Engine.mo
 share/locale/nb/LC_MESSAGES/Zonemaster-Engine.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-Engine.mo
 share/Makefile
-share/GNUmakefile
+share/modules.txt
+share/profile.json
+share/profile_additional_properties.json
+share/root-hints.json
 t/00-load.t
 t/asn.data
 t/asn.t

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -22,7 +22,7 @@ our %_fake_addresses_cache;
 
 sub get_default_path {
     state $path =
-        $ENV{ZONEMASTER_ENGINE_ROOT_HINTS_FILE}              ? $ENV{ZONEMASTER_ENGINE_ROOT_HINTS_FILE}
+        length( $ENV{ZONEMASTER_ENGINE_ROOT_HINTS_FILE} )    ? $ENV{ZONEMASTER_ENGINE_ROOT_HINTS_FILE}
       : -e '/etc/zonemaster/root-hints.json'                 ? '/etc/zonemaster/root-hints.json'
       : -e '/usr/local/etc/zonemaster/root-hints.json'       ? '/usr/local/etc/zonemaster/root-hints.json'
       :                                                        eval { dist_file( 'Zonemaster-Engine', 'root-hints.json' ) };
@@ -460,7 +460,7 @@ Class method to empty the cache of responses to recursive queries (but not the o
 =item root_servers()
 
 Returns a list of ns objects representing the root servers. The list of root servers is found in an external
-file..
+file.
 
 =back
 

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -362,13 +362,11 @@ Zonemaster::Engine::Recursor - recursive resolver for Zonemaster
 
 =head1 CLASS VARIABLES
 
-=over
-
-=item %recurse_cache
+=head2 %recurse_cache
 
 Will cache result of previous queries.
 
-=item %_fake_addresses_cache
+=head2 %_fake_addresses_cache
 
 A hash of hashrefs of arrayrefs.
 The keys of the top level hash are domain names.
@@ -378,8 +376,6 @@ The elements of the third level arrayrefs are IP addresses.
 
 The IP addresses are those of the nameservers which are used in case of fake
 delegations (pre-publication tests).
-
-=back
 
 =head1 METHODS
 
@@ -399,7 +395,7 @@ The following checks are made in order:
 
 =item $ZONEMASTER_ENGINE_ROOT_HINTS_FILE
 
-If this environment variable is set ot a truthy value, that path is returned.
+If this environment variable is set to a non-empty string, that path is returned.
 
 =item /etc/zonemaster/root-hints.json
 
@@ -407,7 +403,7 @@ If a file exists at this path, it is returned.
 
 =item /usr/local/etc/zonemaster/root-hints.json
 
-If a file exists at such a path, it is returned.
+If a file exists at this path, it is returned.
 
 =item DIST_DIR/root-hints.json
 
@@ -416,52 +412,46 @@ DIST_DIR is wherever File::ShareDir installs the Zonemaster-Engine dist.
 
 =back
 
-=head2 Other mothods
-
-=over
-
-=item recurse($name, $type, $class)
+=head2 recurse($name, $type, $class)
 
 Does a recursive resolution from the root servers down for the given triplet.
 
-=item parent($name)
+=head2 parent($name)
 
 Does a recursive resolution from the root down for the given name (using type C<SOA> and class C<IN>). If the resolution is successful, it returns
 the domain name of the second-to-last step. If the resolution is unsuccessful, it returns the domain name of the last step.
 
-=item get_ns_from($packet, $state)
+=head2 get_ns_from($packet, $state)
 
 Internal method. Takes a packet and a recursion state and returns a list of ns objects. Used to follow redirections.
 
-=item get_addresses_for($name[, $state])
+=head2 get_addresses_for($name[, $state])
 
 Takes a name and returns a (possibly empty) list of IP addresses for
 that name (in the form of L<Zonemaster::Engine::Net::IP> objects). When used
 internally by the recursor it's passed a recursion state as its second
 argument.
 
-=item add_fake_addresses($domain, $data)
+=head2 add_fake_addresses($domain, $data)
 
 Class method to create fake adresses for fake delegations for a specified domain from data provided.
 
-=item has_fake_addresses($domain)
+=head2 has_fake_addresses($domain)
 
 Check if there is at least one fake nameserver specified for the given domain.
 
-=item get_fake_addresses($domain, $nsname)
+=head2 get_fake_addresses($domain, $nsname)
 
 Returns a list of all cached fake addresses for the given domain and name server name.
 Returns an empty list if no data is cached for the given arguments.
 
-=item clear_cache()
+=head2 clear_cache()
 
 Class method to empty the cache of responses to recursive queries (but not the ones for fake delegations).
 
-=item root_servers()
+=head2 root_servers()
 
 Returns a list of ns objects representing the root servers. The list of root servers is found in an external
 file.
-
-=back
 
 =cut

--- a/share/root-hints.json
+++ b/share/root-hints.json
@@ -1,0 +1,108 @@
+{
+   "." : [
+      {
+         "name" : "a.root-servers.net",
+         "address" : "198.41.0.4"
+      },
+      {
+         "name" : "a.root-servers.net",
+         "address" : "2001:503:ba3e::2:30"
+      },
+      {
+         "name" : "b.root-servers.net",
+         "address" : "199.9.14.201"
+      },
+      {
+         "name" : "b.root-servers.net",
+         "address" : "2001:500:200::b"
+      },
+      {
+         "name" : "c.root-servers.net",
+         "address" : "192.33.4.12"
+      },
+      {
+         "name" : "c.root-servers.net",
+         "address" : "2001:500:2::c"
+      },
+      {
+         "name" : "d.root-servers.net",
+         "address" : "199.7.91.13"
+      },
+      {
+         "name" : "d.root-servers.net",
+         "address" : "2001:500:2d::d"
+      },
+      {
+         "name" : "e.root-servers.net",
+         "address" : "192.203.230.10"
+      },
+      {
+         "name" : "e.root-servers.net",
+         "address" : "2001:500:a8::e"
+      },
+      {
+         "name" : "f.root-servers.net",
+         "address" : "192.5.5.241"
+      },
+      {
+         "name" : "f.root-servers.net",
+         "address" : "2001:500:2f::f"
+      },
+      {
+         "name" : "g.root-servers.net",
+         "address" : "192.112.36.4"
+      },
+      {
+         "name" : "g.root-servers.net",
+         "address" : "2001:500:12::d0d"
+      },
+      {
+         "name" : "h.root-servers.net",
+         "address" : "198.97.190.53"
+      },
+      {
+         "name" : "h.root-servers.net",
+         "address" : "2001:500:1::53"
+      },
+      {
+         "name" : "i.root-servers.net",
+         "address" : "192.36.148.17"
+      },
+      {
+         "name" : "i.root-servers.net",
+         "address" : "2001:7fe::53"
+      },
+      {
+         "name" : "j.root-servers.net",
+         "address" : "192.58.128.30"
+      },
+      {
+         "name" : "j.root-servers.net",
+         "address" : "2001:503:c27::2:30"
+      },
+      {
+         "name" : "k.root-servers.net",
+         "address" : "193.0.14.129"
+      },
+      {
+         "name" : "k.root-servers.net",
+         "address" : "2001:7fd::1"
+      },
+      {
+         "name" : "l.root-servers.net",
+         "address" : "199.7.83.42"
+      },
+      {
+         "name" : "l.root-servers.net",
+         "address" : "2001:500:9f::42"
+      },
+      {
+         "name" : "m.root-servers.net",
+         "address" : "202.12.27.33"
+      },
+      {
+         "name" : "m.root-servers.net",
+         "address" : "2001:dc3::35"
+      }
+   ]
+}


### PR DESCRIPTION
## Purpose

In current code the root hints are hard coded. This PR opens for use cases where private root must be used, see #850. The driving use case for this PR is the possibility to use it for unit tests.

## Context

Fixes #850.

## Changes

Default root hints file is found in shared dist directory, and is used in the normal case. If a root hints file is found in /etc/zonemaster or /usr/local/etc/zonemaster that is used instead. The file name must be `root-hints.json`. Highest priority has the environment variable `ZONEMASTER_ENGINE_ROOT_HINTS_FILE` that can point at any file name, and that file will be used as the root hints file.

## How to test this PR

1. Run a default configuration and validate that nothing breaks.
2. Create a private root zone file and a zone file for some non-existent TLD, e.g. .xa
3. In the root zone, delegate to .xa and load the zones.
4. Create a root hints file in /etc/zonemaster or /usr/local/etc/zonemaster that points at the private root.
5. Run `zonemaster-cli xa --level INFO` and verify that .xa is reported as an existing domain.
6. Rename the root hints file and use `ZONEMASTER_ENGINE_ROOT_HINTS_FILE` and verify that you can still test the .xa domain.
