### PR TITLE
PoC: Send queries with EDNS option NSID set and retrieve the value if available

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -483,6 +483,8 @@ sub _query {
             }
         }
 
+        eval { $pkt->nsid; };
+
         $res = eval { $self->dns->query_with_pkt( $pkt ) };
 
         if ( $@ ) {

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -455,8 +455,8 @@ sub _query {
         );
     }
     else {
+        my $pkt = Zonemaster::LDNS::Packet->new("$name", $type, $href->{class} );
         if ( $edns_special_case ) {
-            my $pkt = Zonemaster::LDNS::Packet->new("$name", $type, $href->{class} );
             if ( defined $href->{edns_details} and defined $href->{edns_details}{version} and $href->{edns_details}{version} != 0 ) {
                 $pkt->set_edns_present();
                 $pkt->edns_version($href->{edns_details}{version});
@@ -481,11 +481,10 @@ sub _query {
                 $pkt->set_edns_present();
                 $pkt->edns_data($href->{edns_details}{data});
             }
-            $res = eval { $self->dns->query_with_pkt( $pkt ) };
         }
-        else {
-            $res = eval { $self->dns->query( "$name", $type, $href->{class} ) };
-        }
+
+        $res = eval { $self->dns->query_with_pkt( $pkt ) };
+
         if ( $@ ) {
             my $msg = "$@";
             my $trailing_info = " at ".__FILE__;

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -461,19 +461,19 @@ sub _query {
                 $pkt->set_edns_present();
                 $pkt->edns_version($href->{edns_details}{version});
             }
-	    if ( defined $href->{edns_details} and defined $href->{edns_details}{z} ) {
+            if ( defined $href->{edns_details} and defined $href->{edns_details}{z} ) {
                 $pkt->set_edns_present();
                 $pkt->edns_z($href->{edns_details}{z});
             }
-	    if ( defined $href->{edns_details} and defined $href->{edns_details}{do} ) {
+            if ( defined $href->{edns_details} and defined $href->{edns_details}{do} ) {
                 $pkt->set_edns_present();
                 $pkt->do($href->{edns_details}{do});
             }
-	    if ( defined $href->{edns_details} and defined $href->{edns_details}{udp_size} ) {
+            if ( defined $href->{edns_details} and defined $href->{edns_details}{udp_size} ) {
                 $pkt->set_edns_present();
                 $pkt->edns_size($href->{edns_details}{udp_size});
             }
-	    if ( defined $href->{edns_details} and defined $href->{edns_details}{extended_rcode} ) {
+            if ( defined $href->{edns_details} and defined $href->{edns_details}{extended_rcode} ) {
                 $pkt->set_edns_present();
                 $pkt->edns_rcode($href->{edns_details}{extended_rcode});
             }
@@ -481,7 +481,7 @@ sub _query {
                 $pkt->set_edns_present();
                 $pkt->edns_data($href->{edns_details}{data});
             }
-	    $res = eval { $self->dns->query_with_pkt( $pkt ) };
+            $res = eval { $self->dns->query_with_pkt( $pkt ) };
         }
         else {
             $res = eval { $self->dns->query( "$name", $type, $href->{class} ) };

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -341,7 +341,9 @@ sub query {
 
     Zonemaster::Engine->logger->add( CACHED_RETURN => { packet => ( $p ? $p->string : 'undef' ) } );
 
-    eval { $self->{nsid} = $p->get_nsid(); };
+    if ( Zonemaster::Engine::Profile->effective->get( q{nsid} ) ) {
+        eval { $self->{nsid} = $p->get_nsid(); };
+    }
 
     return $p;
 } ## end sub query
@@ -486,7 +488,9 @@ sub _query {
             }
         }
 
-        eval { $pkt->nsid; };
+        if ( Zonemaster::Engine::Profile->effective->get( q{nsid} ) ) {
+            eval { $pkt->nsid; };
+        }
 
         $res = eval { $self->dns->query_with_pkt( $pkt ) };
 

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -32,6 +32,7 @@ use overload
 
 has 'name'    => ( is => 'ro' );
 has 'address' => ( is => 'ro' );
+has 'nsid'    => ( is => 'rw' );
 
 has 'dns'   => ( is => 'ro' );
 has 'cache' => ( is => 'ro' );
@@ -340,6 +341,8 @@ sub query {
 
     Zonemaster::Engine->logger->add( CACHED_RETURN => { packet => ( $p ? $p->string : 'undef' ) } );
 
+    eval { $self->{nsid} = $p->get_nsid(); };
+
     return $p;
 } ## end sub query
 
@@ -531,6 +534,9 @@ sub _query {
 sub string {
     my ( $self ) = @_;
 
+    if ( defined $self->nsid ) {
+        return $self->name->string . q{/} . $self->address->short . q{/} . $self->nsid;
+    }
     return $self->name->string . q{/} . $self->address->short;
 }
 

--- a/lib/Zonemaster/Engine/Packet.pm
+++ b/lib/Zonemaster/Engine/Packet.pm
@@ -39,6 +39,7 @@ has 'packet' => (
           querytime
           do
           opcode
+          get_nsid
           )
     ]
 );

--- a/lib/Zonemaster/Engine/Packet.pm
+++ b/lib/Zonemaster/Engine/Packet.pm
@@ -18,7 +18,7 @@ has 'packet' => (
           rcode
           aa
           ra
-	  tc
+          tc
           question
           answer
           authority

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -72,6 +72,9 @@ my %profile_properties_details = (
     q{no_network} => {
         type    => q{Bool}
     },
+    q{nsid} => {
+        type    => q{Bool}
+    },
     q{asnroots} => {
         type    => q{ArrayRef},
         test    => sub {
@@ -646,6 +649,10 @@ A boolean. If true, network traffic is forbidden. Default false.
 
 Use when you want to be sure that any data is only taken from a preloaded
 cache.
+
+=head2 nsid
+
+A boolean. If true, sets the EDNS option NSID in queries. Default false.
 
 =head2 asnroots (DEPRECATED)
 

--- a/lib/Zonemaster/Engine/Test.pm
+++ b/lib/Zonemaster/Engine/Test.pm
@@ -42,6 +42,7 @@ BEGIN {
 sub _log_versions {
     info( GLOBAL_VERSION => { version => Zonemaster::Engine->VERSION } );
 
+    info( DEPENDENCY_VERSION => { name => 'libldns',               version => Zonemaster::LDNS::lib_version() } );
     info( DEPENDENCY_VERSION => { name => 'Zonemaster::LDNS',      version => $Zonemaster::LDNS::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'IO::Socket::INET6',     version => $IO::Socket::INET6::VERSION } );
     info( DEPENDENCY_VERSION => { name => 'Moose',                 version => $Moose::VERSION } );

--- a/share/profile.json
+++ b/share/profile.json
@@ -11,6 +11,7 @@
         "ipv6" : true
     },
     "no_network" : false,
+    "nsid": true,
     "resolver" : {
         "defaults" : {
             "debug" : false,


### PR DESCRIPTION
## Purpose

This PR is about validating that Zonemaster can retrieve and display NSID values from nameservers if available.

### Question

Currently this PR sets the EDNS option NSID to all queries. Should this option be sent only to nameservers that support EDNS (look for the results from Nameserver02)?

### Todo

- [ ] address the question asked above
- [ ] make sure that this EDNS option does not interfere with other tests.

## Context

Addresses #178 and follow-up on https://github.com/zonemaster/zonemaster-ldns/pull/151

## Changes

* some refactoring
* display libldns version as DEBUG
* always set the EDNS option NSID to all queries
* store the NSID (if available) whithin the Nameserver object
* append the NSID to the `ns/ip` tuple resulting in `ns/ip/nsid`

## How to test this PR

This requires libldns >= 1.8.2 and Zonemaster-LDNS from https://github.com/zonemaster/zonemaster-ldns/pull/151

```
$ zonemaster-cli --test basic --level INFO  zonemaster.net
Seconds Level     Message
======= ========= =======
   0.00 INFO      Using version v4.5.1 of the Zonemaster engine.
   0.27 INFO      Parent domain 'net' was found for the tested domain.
   1.39 INFO      Nameserver ns2.nic.fr/192.93.0.4/ns2.th2.nic.fr listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.40 INFO      Nameserver ns2.nic.fr/2001:660:3005:1::1:2/ns2.th2.nic.fr listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.40 INFO      Nameserver nsa.dnsnode.net/194.58.192.46/s4.bnx listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.40 INFO      Nameserver nsa.dnsnode.net/2a01:3f1:46::53/s4.bnx listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.41 INFO      Nameserver nsp.dnsnode.net/194.58.198.32/s4.bnx listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.41 INFO      Nameserver nsp.dnsnode.net/2a01:3f1:3032::53/s4.bnx listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.41 INFO      Nameserver nsu.dnsnode.net/185.42.137.98/u4.sub listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.41 INFO      Nameserver nsu.dnsnode.net/2a01:3f0:400::32/u4.stu listed these servers as glue: ns2.nic.fr.,nsa.dnsnode.net.,nsp.dnsnode.net.,nsu.dnsnode.net..
   1.41 INFO      Functional nameserver found. "A" query for www.zonemaster.net test skipped.
```

See the tuple `nsp.dnsnode.net/2a01:3f1:3032::53/s4.bnx` which is made of the nameserver name, the nameserver IP and the nameserver NSID.

If there is no NSID, the output would be unchanged:
```
$ zonemaster-cli --test basic --level INFO café.fr
Seconds Level     Message
======= ========= =======
   0.00 INFO      Using version v4.5.1 of the Zonemaster engine.
   0.48 INFO      Parent domain 'fr' was found for the tested domain.
   0.92 INFO      Nameserver ns1.parkingcrew.net/13.248.158.159 listed these servers as glue: ns1.parkingcrew.net.,ns2.parkingcrew.net..
   0.92 INFO      Nameserver ns2.parkingcrew.net/76.223.21.9 listed these servers as glue: ns1.parkingcrew.net.,ns2.parkingcrew.net..
   0.92 INFO      Functional nameserver found. "A" query for www.xn--caf-dma.fr test skipped.
```
