### PR TITLE
Add logentry arguments for SOA SERIAL

### DIFF
--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -70,8 +70,8 @@ and updated messages (*msgids* and *msgstr*).
 | nsname_list    | List of domain names                     | A list of name servers, as specified by "nsname", separated by ";".     |
 | rcode          | An RCODE Name                            | An RCODE Name (not numeric code) from [DNS RCODEs].                     |
 | rrtype         | A Resource Record TYPE Name              | A Resource Record TYPE Name (not numeric code) from [DNS RR TYPEs].     |
-| soaserial      | Non-zero positive integer                | The numeric value for the SERIAL field in an SOA record.                |
-| soaserial_list | Non-zero positive integers               | A list of numeric values, as specified by "soaserial", separated by ";".|
+| soaserial      | Non-negative integer                     | The numeric value for the SERIAL field in an SOA record.                |
+| soaserial_list | Non-negative integers                    | A list of non-negative integers, as specified by "soaserial", separated by ";".|
 | testcase       | A Zonemaster test case, or `all`         | A test case identifier.                                                 |
 | unicode_name   | Unicode name of a code point             | The name is a string in ASCII only and in upper case, e.g. "LATIN SMALL LETTER A"|
 

--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -70,8 +70,8 @@ and updated messages (*msgids* and *msgstr*).
 | nsname_list    | List of domain names                     | A list of name servers, as specified by "nsname", separated by ";".     |
 | rcode          | An RCODE Name                            | An RCODE Name (not numeric code) from [DNS RCODEs].                     |
 | rrtype         | A Resource Record TYPE Name              | A Resource Record TYPE Name (not numeric code) from [DNS RR TYPEs].     |
-| soaserial      | Non-negative integer                     | The numeric value for the SERIAL field in an SOA record.                |
-| soaserial_list | Non-negative integers                    | A list of non-negative integers, as specified by "soaserial", separated by ";".|
+| soaserial      | Non-negative integer                     | The numeric value for the SERIAL field in an SOA record. Integer in range 0-4,294,967,295 |
+| soaserial_list | List of non-negative integers            | A list of non-negative integers, as specified by "soaserial", separated by ";". |
 | testcase       | A Zonemaster test case, or `all`         | A test case identifier.                                                 |
 | unicode_name   | Unicode name of a code point             | The name is a string in ASCII only and in upper case, e.g. "LATIN SMALL LETTER A"|
 

--- a/docs/logentry_args.md
+++ b/docs/logentry_args.md
@@ -70,6 +70,8 @@ and updated messages (*msgids* and *msgstr*).
 | nsname_list    | List of domain names                     | A list of name servers, as specified by "nsname", separated by ";".     |
 | rcode          | An RCODE Name                            | An RCODE Name (not numeric code) from [DNS RCODEs].                     |
 | rrtype         | A Resource Record TYPE Name              | A Resource Record TYPE Name (not numeric code) from [DNS RR TYPEs].     |
+| soaserial      | Non-zero positive integer                | The numeric value for the SERIAL field in an SOA record.                |
+| soaserial_list | Non-zero positive integers               | A list of numeric values, as specified by "soaserial", separated by ";".|
 | testcase       | A Zonemaster test case, or `all`         | A test case identifier.                                                 |
 | unicode_name   | Unicode name of a code point             | The name is a string in ASCII only and in upper case, e.g. "LATIN SMALL LETTER A"|
 


### PR DESCRIPTION
## Purpose

This PR defines logentry arguments for the values of the SERIAL field in an SOA record.

## Context

Needed for https://github.com/zonemaster/zonemaster/pull/1032. [Discussion ](https://github.com/zonemaster/zonemaster/pull/1032#discussion_r993218787) thread.

## Changes

The following arguments are defined in the [Arguments ](https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md)specification:

- soaserial
- soaserial_list

## How to test this PR

N/A. Documentation only.
