### PR TITLE
ASNLookup: no need to remove double quotes

### DIFF
--- a/lib/Zonemaster/Engine/ASNLookup.pm
+++ b/lib/Zonemaster/Engine/ASNLookup.pm
@@ -102,7 +102,6 @@ sub _cymru_asn_lookup {
                 my $str;
                 foreach my $rr ( @rr ) {
                     my $_str = $rr->txtdata;
-                    $_str =~ s/"([^"]+)"/$1/x;
                     my @_fields = split( /[ ][|][ ]?/x, $_str );
                     my @_asns   = split( /\s+/x,        $_fields[0] );
                     my $_prefix_length = ($_fields[1] =~ m!^.*[/](.*)!x)[0];


### PR DESCRIPTION
## Purpose

This PR undoes a hack that used to be necessary because of an incorrect implementation of `Zonemaster::LDNS::RR::txtdata()`.

## Context

Follow-up to https://github.com/zonemaster/zonemaster-ldns/pull/157.

## Changes

Remove the removal of double-quotes from code using the data in TXT resource records.

## How to test this PR

Unit tests should pass.
