### PR TITLE
Add test case description in Engine

### DIFF
--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -74,6 +74,18 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    ADDRESS01 => sub {
+        __x    # ADDRESS:ADDRESS01
+          'Name server address must be globally routable', @_;
+    },
+    ADDRESS02 => sub {
+        __x    # ADDRESS:ADDRESS02
+          'Name server address must be globally routable', @_;
+    },
+    ADDRESS03 => sub {
+        __x    # ADDRESS:ADDRESS03
+          'Reverse DNS entry matches name server name', @_;
+    },
     NAMESERVER_IP_WITHOUT_REVERSE => sub {
         __x    # ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE
           'Nameserver {nsname} has an IP address ({ns_ip}) without PTR configured.', @_;
@@ -360,4 +372,3 @@ Verify that an address (Net::IP::XS) given is a special (private, reserved, ...)
 =back
 
 =cut
-

--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -80,7 +80,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     ADDRESS02 => sub {
         __x    # ADDRESS:ADDRESS02
-          'Name server address must be globally routable', @_;
+          'Reverse DNS entry exists for name server IP address', @_;
     },
     ADDRESS03 => sub {
         __x    # ADDRESS:ADDRESS03

--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -128,6 +128,26 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    BASIC00 => sub {
+        __x    # BASIC:BASIC00
+          'Domain name must be valid', @_;
+    },
+    BASIC01 => sub {
+        __x    # BASIC:BASIC01
+          'The domain must have a parent domain', @_;
+    },
+    BASIC02 => sub {
+        __x    # BASIC:BASIC02
+          'The domain must have at least one working name server', @_;
+    },
+    BASIC03 => sub {
+        __x    # BASIC:BASIC03
+          'The Broken but functional test', @_;
+    },
+    BASIC04 => sub {
+        __x    # BASIC:BASIC04
+          'Test of basic nameserver and zone functionality', @_;
+    },
     A_QUERY_NO_RESPONSES => sub {
         __x    # BASIC:A_QUERY_NO_RESPONSES
           'Nameservers did not respond to A query.';

--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -110,6 +110,19 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    CONNECTIVITY01 => sub {
+        __x    # CONNECTIVITY:CONNECTIVITY01
+          'UDP connectivity', @_;
+    },
+    CONNECTIVITY02 => sub {
+        __x    # CONNECTIVITY:CONNECTIVITY02
+          'TCP connectivity', @_;
+    },
+    CONNECTIVITY03 => sub {
+        __x    # CONNECTIVITY:CONNECTIVITY03
+          'AS Diversity', @_;
+    },
+
     CN01_IPV4_DISABLED => sub {
         __x    # CONNECTIVITY:CN01_IPV4_DISABLED
           'IPv4 is disabled. No DNS queries are sent to these name servers: "{ns_list}".', @_;

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -136,6 +136,30 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    CONSISTENCY01 => sub {
+        __x    # CONSISTENCY:CONSISTENCY01
+          'SOA serial number consistency', @_;
+    },
+    CONSISTENCY02 => sub {
+        __x    # CONSISTENCY:CONSISTENCY02
+          'SOA RNAME consistency', @_;
+    },
+    CONSISTENCY03 => sub {
+        __x    # CONSISTENCY:CONSISTENCY03
+          'SOA timers consistency', @_;
+    },
+    CONSISTENCY04 => sub {
+        __x    # CONSISTENCY:CONSISTENCY04
+          'Name server NS consistency', @_;
+    },
+    CONSISTENCY05 => sub {
+        __x    # CONSISTENCY:CONSISTENCY05
+          'Consistency between glue and authoritative data', @_;
+    },
+    CONSISTENCY06 => sub {
+        __x    # CONSISTENCY:CONSISTENCY06
+          'SOA MNAME consistency', @_;
+    },
     ADDRESSES_MATCH => sub {
         __x    # CONSISTENCY:ADDRESSES_MATCH
           'Glue records are consistent between glue and authoritative data.', @_;

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -511,6 +511,78 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    DNSSEC01 => sub {
+        __x    # DNSSEC:DNSSEC01
+          "Legal values for the DS hash digest algorithm", @_;
+    },
+    DNSSEC02 => sub {
+        __x    # DNSSEC:DNSSEC02
+          "DS must match a valid DNSKEY in the child zone", @_;
+    },
+    DNSSEC03 => sub {
+        __x    # DNSSEC:DNSSEC03
+          "Check for too many NSEC3 iterations", @_;
+    },
+    DNSSEC04 => sub {
+        __x    # DNSSEC:DNSSEC04
+          "Check for too short or too long RRSIG lifetimes", @_;
+    },
+    DNSSEC05 => sub {
+        __x    # DNSSEC:DNSSEC05
+          "Check for invalid DNSKEY algorithms", @_;
+    },
+    DNSSEC06 => sub {
+        __x    # DNSSEC:DNSSEC06
+          "Verify DNSSEC additional processing", @_;
+    },
+    DNSSEC07 => sub {
+        __x    # DNSSEC:DNSSEC07
+          "If DNSKEY at child, parent should have DS", @_;
+    },
+    DNSSEC08 => sub {
+        __x    # DNSSEC:DNSSEC08
+          "Valid RRSIG for DNSKEY", @_;
+    },
+    DNSSEC09 => sub {
+        __x    # DNSSEC:DNSSEC09
+          "RRSIG(SOA) must be valid and created by a valid DNSKEY", @_;
+    },
+    DNSSEC10 => sub {
+        __x    # DNSSEC:DNSSEC10
+          "Zone contains NSEC or NSEC3 records", @_;
+    },
+    DNSSEC11 => sub {
+        __x    # DNSSEC:DNSSEC11
+          "DS in delegation requires signed zone", @_;
+    },
+    DNSSEC12 => sub {
+        __x    # DNSSEC:DNSSEC12
+          "Test for DNSSEC Algorithm Completeness", @_;
+    },
+    DNSSEC13 => sub {
+        __x    # DNSSEC:DNSSEC13
+          "All DNSKEY algorithms used to sign the zone", @_;
+    },
+    DNSSEC14 => sub {
+        __x    # DNSSEC:DNSSEC14
+          "Check for valid RSA DNSKEY key size", @_;
+    },
+    DNSSEC15 => sub {
+        __x    # DNSSEC:DNSSEC15
+          "Existence of CDS and CDNSKEY", @_;
+    },
+    DNSSEC16 => sub {
+        __x    # DNSSEC:DNSSEC16
+          "Validate CDS", @_;
+    },
+    DNSSEC17 => sub {
+        __x    # DNSSEC:DNSSEC17
+          "Validate CDNSKEY", @_;
+    },
+    DNSSEC18 => sub {
+        __x    # DNSSEC:DNSSEC18
+          "Validate trust from DS to CDS and CDNSKEY ", @_;
+    },
     ADDITIONAL_DNSKEY_SKIPPED => sub {
         __x    # DNSSEC:ADDITIONAL_DNSKEY_SKIPPED
           'No DNSKEYs found. Additional tests skipped.', @_;

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -104,7 +104,7 @@ sub metadata {
         delegation05 => [
             qw(
               NO_NS_CNAME
-              NO_RESPONSE    
+              NO_RESPONSE
               NS_IS_CNAME
               UNEXPECTED_RCODE
               TEST_CASE_END
@@ -135,6 +135,34 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    DELEGATION01 => sub {
+        __x    # DELEGATION:DELEGATION01
+          "Minimum number of name servers", @_;
+    },
+    DELEGATION02 => sub {
+        __x    # DELEGATION:DELEGATION02
+          "Name servers must have distinct IP addresses", @_;
+    },
+    DELEGATION03 => sub {
+        __x    # DELEGATION:DELEGATION03
+          "No truncation of referrals", @_;
+    },
+    DELEGATION04 => sub {
+        __x    # DELEGATION:DELEGATION04
+          "Name server is authoritative", @_;
+    },
+    DELEGATION05 => sub {
+        __x    # DELEGATION:DELEGATION05
+          "Name server must not point at CNAME alias", @_;
+    },
+    DELEGATION06 => sub {
+        __x    # DELEGATION:DELEGATION06
+          "Existence of SOA", @_;
+    },
+    DELEGATION07 => sub {
+        __x    # DELEGATION:DELEGATION07
+          "Parent glue name records present in child", @_;
+    },
     ARE_AUTHORITATIVE => sub {
         __x    # DELEGATION:ARE_AUTHORITATIVE
           "All these nameservers are confirmed to be authoritative : {nsname_list}.", @_;

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -218,6 +218,62 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    NAMESERVER01 => sub {
+        __x    # NAMESERVER:NAMESERVER01
+            'A name server should not be a recursor', @_;
+    },
+    NAMESERVER02 => sub {
+        __x    # NAMESERVER:NAMESERVER02
+            'Test of EDNS0 support', @_;
+    },
+    NAMESERVER03 => sub {
+        __x    # NAMESERVER:NAMESERVER03
+            'Test availability of zone transfer (AXFR)', @_;
+    },
+    NAMESERVER04 => sub {
+        __x    # NAMESERVER:NAMESERVER04
+            'Same source address', @_;
+    },
+    NAMESERVER05 => sub {
+        __x    # NAMESERVER:NAMESERVER05
+            'Behaviour against AAAA query', @_;
+    },
+    NAMESERVER06 => sub {
+        __x    # NAMESERVER:NAMESERVER06
+            'NS can be resolved', @_;
+    },
+    NAMESERVER07 => sub {
+        __x    # NAMESERVER:NAMESERVER07
+            'To check whether authoritative name servers return an upward referral', @_;
+    },
+    NAMESERVER08 => sub {
+        __x    # NAMESERVER:NAMESERVER08
+            'Testing QNAME case insensitivity', @_;
+    },
+    NAMESERVER09 => sub {
+        __x    # NAMESERVER:NAMESERVER09
+            'Testing QNAME case sensitivity', @_;
+    },
+    NAMESERVER10 => sub {
+        __x    # NAMESERVER:NAMESERVER10
+            'Test for undefined EDNS version', @_;
+    },
+    NAMESERVER11 => sub {
+        __x    # NAMESERVER:NAMESERVER11
+            'Test for unknown EDNS OPTION-CODE', @_;
+    },
+    NAMESERVER12 => sub {
+        __x    # NAMESERVER:NAMESERVER12
+            'Test for unknown EDNS flags', @_;
+    },
+    NAMESERVER13 => sub {
+        __x    # NAMESERVER:NAMESERVER13
+            'Test for truncated response on EDNS query', @_;
+    },
+    NAMESERVER14 => sub {
+        __x    # NAMESERVER:NAMESERVER14
+            'Test for unknown version with unknown OPTION-CODE', @_;
+    },
     AAAA_BAD_RDATA => sub {
         __x    # NAMESERVER:AAAA_BAD_RDATA
             'Nameserver {ns} answered AAAA query with an unexpected RDATA length ({length} instead of 16).', @_;
@@ -719,7 +775,7 @@ sub nameserver05 {
                         $aaaa_issue++;
                     }
                     else {
-                        push @aaaa_ok, $rr->address;    
+                        push @aaaa_ok, $rr->address;
                     }
                 }
             }

--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -149,6 +149,38 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    SYNTAX01 => sub {
+        __x    # SYNTAX:SYNTAX01
+          'No illegal characters in the domain name', @_;
+    },
+    SYNTAX02 => sub {
+        __x    # SYNTAX:SYNTAX02
+          'No hyphen (\'-\') at the start or end of the domain name', @_;
+    },
+    SYNTAX03 => sub {
+        __x    # SYNTAX:SYNTAX03
+          'There must be no double hyphen (\'--\') in position 3 and 4 of the domain name', @_;
+    },
+    SYNTAX04 => sub {
+        __x    # SYNTAX:SYNTAX04
+          'The NS name must have a valid domain/hostname', @_;
+    },
+    SYNTAX05 => sub {
+        __x    # SYNTAX:SYNTAX05
+          'Misuse of \'@\' character in the SOA RNAME field', @_;
+    },
+    SYNTAX06 => sub {
+        __x    # SYNTAX:SYNTAX06
+          'No illegal characters in the SOA RNAME field', @_;
+    },
+    SYNTAX07 => sub {
+        __x    # SYNTAX:SYNTAX07
+          'No illegal characters in the SOA MNAME field', @_;
+    },
+    SYNTAX08 => sub {
+        __x    # SYNTAX:SYNTAX08
+          'MX name must have a valid hostname', @_;
+    },
     DISCOURAGED_DOUBLE_DASH => sub {
         __x    # SYNTAX:DISCOURAGED_DOUBLE_DASH
           'Domain name ({domain}) has a label ({label}) with a double hyphen (\'--\') '

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -174,6 +174,46 @@ sub metadata {
 } ## end sub metadata
 
 Readonly my %TAG_DESCRIPTIONS => (
+    ZONE01 => sub {
+        __x    # ZONE:ZONE01
+          'Fully qualified master nameserver in SOA', @_;
+    },
+    ZONE02 => sub {
+        __x    # ZONE:ZONE02
+          'SOA \'refresh\' minimum value', @_;
+    },
+    ZONE03 => sub {
+        __x    # ZONE:ZONE03
+          'SOA \'retry\' lower than \'refresh\'', @_;
+    },
+    ZONE04 => sub {
+        __x    # ZONE:ZONE04
+          'SOA \'retry\' at least 1 hour', @_;
+    },
+    ZONE05 => sub {
+        __x    # ZONE:ZONE05
+          'SOA \'expire\' minimum value', @_;
+    },
+    ZONE06 => sub {
+        __x    # ZONE:ZONE06
+          'SOA \'minimum\' maximum value', @_;
+    },
+    ZONE07 => sub {
+        __x    # ZONE:ZONE07
+          'SOA master is not an alias', @_;
+    },
+    ZONE08 => sub {
+        __x    # ZONE:ZONE08
+          'MX is not an alias', @_;
+    },
+    ZONE09 => sub {
+        __x    # ZONE:ZONE09
+          'MX record present', @_;
+    },
+    ZONE10 => sub {
+        __x    # ZONE:ZONE10
+          'No multiple SOA records', @_;
+    },
     RETRY_MINIMUM_VALUE_LOWER => sub {
         __x    # ZONE:RETRY_MINIMUM_VALUE_LOWER
           'SOA \'retry\' value ({retry}) is less than the recommended one ({required_retry}).', @_;

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -234,6 +234,17 @@ sub translate_tag {
     return $self->_translate_tag( $entry->module, $entry->tag, $entry->printable_args ) // $entry->string;
 }
 
+
+sub test_case_description {
+    my ( $self, $test_name ) = @_;
+
+    $test_name = uc $test_name;
+    my $module = $test_name;
+    $module =~ s/\d+$//;
+
+    return $self->_translate_tag( $module, $test_name, {} ) // $test_name;
+}
+
 sub _translate_tag {
     my ( $self, $module, $tag, $args ) = @_;
 

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -363,6 +363,10 @@ entry.
 
 Takes a L<Zonemaster::Engine::Logger::Entry> object as its argument and returns a translation of its tag and arguments.
 
+=item test_case_description
+
+Returns the translated test case description for a given test case ID.
+
 =item BUILD
 
 Internal method that's only mentioned here to placate L<Pod::Coverage>.


### PR DESCRIPTION
## Purpose

Make test case descriptions available in Engine.

## Context

https://github.com/zonemaster/zonemaster-gui/pull/341
https://github.com/zonemaster/zonemaster-backend/pull/1055

## Changes

* Adds test case descriptions
* Add method in translator to fetch the translated description for a given test case id.
TODO: unit test

## How to test this PR

```
% perl -MZonemaster::Engine::Translator -e 'my $t = Zonemaster::Engine::Translator->new; print $t->test_case_description("BASIC00") . "\n";'
Domain name must be valid
```