### PR TITLE
Fix queries and response packets content for undelegated tests

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -247,12 +247,16 @@ sub query {
     # Fake a DS answer
     if ( $type eq 'DS' and $class eq 'IN' and $self->fake_ds->{ lc( $name ) } ) {
         my $p = Zonemaster::LDNS::Packet->new( $name, $type, $class );
+        
+        $p->qr( 1 );
         $p->aa( 1 );
         $p->do( $dnssec );
         $p->rd( $recurse );
+        
         foreach my $rr ( @{ $self->fake_ds->{ lc( $name ) } } ) {
             $p->unique_push( 'answer', $rr );
         }
+        
         my $res = Zonemaster::Engine::Packet->new( { packet => $p } );
         Zonemaster::Engine->logger->add( FAKE_DS_RETURNED => { name => "$name", from => "$self" } );
         return $res;
@@ -269,16 +273,21 @@ sub query {
                 $p->unique_push( 'answer',     $_ ) for @{$name};
                 $p->unique_push( 'additional', $_ ) for @{$addr};
             }
+            elsif ( $type eq 'DS' ) {
+                $p->aa( 1 );
+            }
             else {
                 while ( my ( $section, $aref ) = each %{ $self->fake_delegations->{$fname} } ) {
                     $p->unique_push( $section, $_ ) for @{$aref};
                 }
             }
-
-            $p->aa( 0 );
+            
+            $p->aa( 0 ) unless ( $type eq 'DS' );
+            $p->qr( 1 );
             $p->do( $dnssec );
             $p->rd( $recurse );
             $p->answerfrom( $self->address->ip );
+
             Zonemaster::Engine->logger->add(
                 'FAKE_DELEGATION',
                 {


### PR DESCRIPTION
## Purpose

For undelegated tests (fake delegation), this PR adds the QR flag in queries and AA flag depending if DS record is provided or not.

## Context

Fixes #1100 

## Changes

- Sets the QR flag for queries in undelegated tests
- Sets the AA flag for queries in undelegated tests with DS record
- Returns empty sections in response packet to a DS query in undelegated tests with no DS record

## How to test this PR

`
zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --raw --level debug3 --test dnssec/dnssec11  > debug-dnssec11`

Inspect debug file `debug-dnssec11`. Search for `type=DS`. Look at flags and packet content thereafter. You can change query type in dnssec11 and compare.