### PR TITLE
expose the init methods

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -24,8 +24,19 @@ use Zonemaster::Engine::Test;
 use Zonemaster::Engine::Recursor;
 use Zonemaster::Engine::ASNLookup;
 
+INIT {
+    init_engine();
+}
+
 our $logger;
 our $recursor = Zonemaster::Engine::Recursor->new;
+
+my $init_done = 0;
+
+sub init_engine {
+    return if $init_done++;
+    Zonemaster::Engine::Recursor::init_recursor;
+}
 
 sub logger {
     return $logger //= Zonemaster::Engine::Logger->new;
@@ -236,6 +247,10 @@ This manual describes the main L<Zonemaster::Engine> module. If what you're afte
 =head1 METHODS
 
 =over
+
+=item init_engine()
+
+Run the inititalization tasks if they have not been run already. This method is called automatically in INIT block.
 
 =item test_zone($name)
 

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -19,7 +19,7 @@ use Zonemaster::Engine::Util qw( name ns parse_hints );
 our %recurse_cache;
 our %_fake_addresses_cache;
 
-INIT {
+sub init_recursor {
     my $hints_path = dist_file( 'Zonemaster-Engine', 'named.root' );
     my $hints_text = read_file( $hints_path );
     my $hints_data = parse_hints( $hints_text );
@@ -386,6 +386,11 @@ The IP addresses are those of the nameservers which are used in case of fake
 delegations (pre-publication tests).
 
 =head1 CLASS METHODS
+
+
+=head2 init_recursor()
+
+Initialize the recursor by loading the root hints.
 
 =head2 recurse($name, $type, $class)
 


### PR DESCRIPTION
## Purpose

In backend (RPCAPI) the INIT block is not run:

```
Too late to run INIT block at /home/../lib/Zonemaster/Engine/Recursor.pm line 28.
```

This PR expose the init methods to make it possible to call it in backend.

## Context

Following a change in https://github.com/zonemaster/zonemaster-engine/pull/1134

## Changes

* Move root hint initialization to a dedicated method
* Expose a global `init_engine` for environment where INIT is not run (when the module is imported at run time).

## How to test this PR

Automatic root hint loading should still work:

```
% perl -MZonemaster::Engine -MData::Dumper -e 'print Data::Dumper::Dumper( [ map { { ns => $_->name->string, ip => $_->address->short} } @{Zonemaster::Engine->zone( "afnic.fr" )->glue} ] )'
$VAR1 = [
          {
            'ns' => 'ns1.nic.fr',
            'ip' => '192.134.4.1'
          },
          {
            'ns' => 'ns1.nic.fr',
            'ip' => '2001:67c:2218:2::4:1'
          },
          {
            'ip' => '192.93.0.4',
            'ns' => 'ns2.nic.fr'
          },
          {
            'ip' => '2001:660:3005:1::1:2',
            'ns' => 'ns2.nic.fr'
          },
          {
            'ip' => '192.134.0.49',
            'ns' => 'ns3.nic.fr'
          },
          {
            'ns' => 'ns3.nic.fr',
            'ip' => '2001:660:3006:1::1:1'
          }
        ];
```

