### PR TITLE
Corrects the license statement in Engine.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For participation, contact and bug reporting, please see
 [Zonemaster/README.md](https://github.com/zonemaster/zonemaster/blob/master/README.md).
 
 
+## License
+
+This is free software under a 2-clause BSD license. The full text of the license can
+be found in the [LICENSE](LICENSE) file included in this respository.
+
+
 [CPAN site]:                                      https://metacpan.org/pod/Zonemaster::Engine
 [Docker Hub]:                                     https://hub.docker.com/u/zonemaster
 [Docker Image Creation]:                          https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -418,12 +418,8 @@ Calle Dybedahl <calle at init.se>
 
 =head1 LICENSE
 
-This is free software, licensed under:
-
-The (three-clause) BSD License
-
-The full text of the license can be found in the
-F<LICENSE> file included with this distribution.
+This is free software. The full text of the license can
+be found in the F<LICENSE> file included with this distribution.
 
 =cut
 

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -418,7 +418,7 @@ Calle Dybedahl <calle at init.se>
 
 =head1 LICENSE
 
-This is free software. The full text of the license can
+This is free software under a 2-clause BSD license. The full text of the license can
 be found in the F<LICENSE> file included with this distribution.
 
 =cut


### PR DESCRIPTION
## Purpose

The statement about license in Engine.pm is not correct, as pointed out by @emollier in #1149

This PR updates statement. It also adds the statement to the README file.

## How to test this PR

This is documentation change only.
