### PR TITLE
Dockerfile: add build dependencies for Net::IP::XS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM zonemaster/ldns:local as build
 
 RUN apk add --no-cache \
     # Only needed for CPAN deps
+    gcc \
     make \
+    musl-dev \
+    perl-dev \
     # Transitive deps included to improve build speed
     perl-mailtools \
     perl-module-build-tiny \


### PR DESCRIPTION
## Purpose

This PR fixes an issue preventing the Docker image from being built.

It turns out it was insufficient to just add Net::IP::XS to the list of packages to install in the Dockerfile. Because it’s the first XS package to be installed, it also requires GCC and the C header files for both Perl (for EXTERN.h) and musl libc (for sys/types.h).

## Context

Release testing for version 2022.2.

## Changes

Add missing dependencies in Dockerfile

## How to test this PR

Build the Docker image with `make docker-build`. That operation should complete successfully.
