### PR TITLE
Fix Nameserver10 EDNS query

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -1101,7 +1101,8 @@ sub nameserver10 {
 
         next if ( _ip_disabled_message( \@results, $ns, q{SOA} ) );
 
-        my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { version => 0 } } );
+        #To be changed to '$ns->query( $zone->name, q{SOA}, { edns_details => { version => 0 } } );' when PR#1147 is merged.
+        my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { udp_size => 512 } } );
 
         if ( $p and $p->rcode eq q{NOERROR} ){
             my $p2 = $ns->query( $zone->name, q{SOA}, { edns_details => { version => 1 } } );


### PR DESCRIPTION
## Purpose

This PR proposes a fix for a known bug on one query (i.e. it is not sent as an EDNS query right now) in nameserver10. It can be changed when https://github.com/zonemaster/zonemaster-engine/pull/1147 is merged (planned for 2023.1).

## Context

From https://github.com/zonemaster/zonemaster-engine/pull/1147#issuecomment-1337879630

## Changes

...

## How to test this PR

There are no unitary test for this test case yet (see #1146).

You can output DEBUG3 messages and inspect the content of DNS queries and responses to test in the output file, e.g.

`zonemaster-cli --test=nameserver/nameserver10 zonemaster.net --level=DEBUG3 --show-testcase --raw > test-nameserver10.txt`