### PR TITLE
Zone01: Fix wrong test for localhost IPs

### DIFF
--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -490,7 +490,7 @@ sub zone01 {
 
         if ( $found_ip ){
             foreach my $ip ( keys %{ $mname_ns{$mname} } ){
-                if ( $ip eq ( '127.0.0.1' or '::1' ) ){
+                if ( $ip eq '127.0.0.1' or $ip eq '::1' ){
                     push @results, info( Z01_MNAME_HAS_LOCALHOST_ADDR => { nsname => $mname, ns_ip => $ip } );
                 }
                 else{


### PR DESCRIPTION
## Purpose

This PR fixes a small programming oversight in Zone01, where the message tag Z01_MNAME_HAS_LOCALHOST_ADDR would only be output if the SOA MNAME has an A record of 127.0.0.1, but not if it has a AAAA record of ::1.

## Context

Manually test of changes introduced by #1035.

## Changes

Change an `if ( $foo eq ("a" or "b") )` to `if ( $foo eq "a" or $foo eq "b" )`.

## How to test this PR

Set up an off-the-shelf name server and load the following zone file with origin `mname-resolves-to-localhost.zone01.xa` (any other name could work but I’m using the naming convention proposed in zonemaster/zonemaster#1113):

```zone
$TTL 3600
$ORIGIN mname-resolves-to-localhost.zone01.xa.

@                       IN  SOA  (
                                   ns0
                                   root.nic.xa.
                                   2022120700
                                   86400
                                   14400
                                   3600000
                                   3600
                                 )

                            NS   ns1

ns0                         A    127.0.0.1
                            AAAA ::1

;; Substitute with the address the nameserver actually listens on
ns1                         A    127.0.1.1
```

Then, run a test using `zonemaster-cli`, possibly using custom hints if necessary, and check that two warnings are emitted, one for 127.0.0.1 and another for ::1, as seen below:

```
$ zonemaster-cli --test zone/zone01 --hints fake_root.hints mname-resolves-to-localhost.zone01.xa
Seconds Level     Message
======= ========= =======
   0.03 WARNING   SOA MNAME name server "ns0.mname-resolves-to-localhost.zone01.xa" resolves to a localhost IP address (::1).
   0.03 WARNING   SOA MNAME name server "ns0.mname-resolves-to-localhost.zone01.xa" resolves to a localhost IP address (127.0.0.1).
```