### PR TITLE
use internal ldns for debian/ubuntu

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -108,13 +108,13 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libldns3 libldns-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libldns3 libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
 
    ```sh
-   sudo cpanm --configure-args="--no-internal-ldns" Zonemaster::LDNS Zonemaster::Engine
+   sudo cpanm Zonemaster::LDNS Zonemaster::Engine
    ```
 
 ### Installation on FreeBSD


### PR DESCRIPTION
## Purpose

Use internal LDNS for Debian and Ubuntu when installed from CPAN.

## Context

Last release we changed to use the shared library on ubuntu and debian because of compilation issue with the new OpenSSL. It seems to have been fixed and can now be compiled without issue on both platform.

## Changes

Use internal LDNS.

## How to test this PR

Try installing LDNS from the tarball using the installation instruction on Debian and Ubuntu.
