### PR TITLE
Reinstate DEBUG2 QUERY message tag

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -229,7 +229,7 @@ sub query {
     }
 
     Zonemaster::Engine->logger->add(
-        'query',
+        'QUERY',
         {
             name  => "$name",
             type  => $type,
@@ -247,16 +247,16 @@ sub query {
     # Fake a DS answer
     if ( $type eq 'DS' and $class eq 'IN' and $self->fake_ds->{ lc( $name ) } ) {
         my $p = Zonemaster::LDNS::Packet->new( $name, $type, $class );
-        
+
         $p->qr( 1 );
         $p->aa( 1 );
         $p->do( $dnssec );
         $p->rd( $recurse );
-        
+
         foreach my $rr ( @{ $self->fake_ds->{ lc( $name ) } } ) {
             $p->unique_push( 'answer', $rr );
         }
-        
+
         my $res = Zonemaster::Engine::Packet->new( { packet => $p } );
         Zonemaster::Engine->logger->add( FAKE_DS_RETURNED => { name => "$name", from => "$self" } );
         return $res;
@@ -281,7 +281,7 @@ sub query {
                     $p->unique_push( $section, $_ ) for @{$aref};
                 }
             }
-            
+
             $p->aa( 0 ) unless ( $type eq 'DS' );
             $p->qr( 1 );
             $p->do( $dnssec );

--- a/share/profile.json
+++ b/share/profile.json
@@ -422,6 +422,7 @@
             "NO_SUCH_RECORD" : "DEBUG2",
             "NS_CREATED" : "DEBUG2",
             "PACKET_BIG" : "DEBUG",
+            "QUERY" : "DEBUG2",
             "RECURSE" : "DEBUG2",
             "RECURSE_QUERY" : "DEBUG2",
             "RESTORED_NS_CACHE" : "DEBUG2",

--- a/t/profiles/Test-all-levels.json
+++ b/t/profiles/Test-all-levels.json
@@ -199,6 +199,7 @@
             "NO_SUCH_NAME" : "DEBUG2",
             "NO_SUCH_RECORD" : "DEBUG2",
             "NS_CREATED" : "DEBUG2",
+            "QUERY" : "DEBUG2",
             "RECURSE" : "DEBUG2",
             "RECURSE_QUERY" : "DEBUG2",
             "RESTORED_NS_CACHE" : "DEBUG2",


### PR DESCRIPTION
## Purpose

PR #1142 removes a DEBUG2 message `QUERY`. While testing #1101 with the `--level DEBUG` option a lot of messages appear that were previously at DEBUG2 level.

PR #1142, says "_Unused messages removed from various places._", It appears that such `QUERY` messages were used (written in lowercase). I suggest reinstating them.

## Context

Reinstate a removed message in #1142 

## Changes

profile.json and Nameserver.pm

## How to test this PR

```
zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --raw --level DEBUG --test dnssec/dnssec11
```

This command should not output much messages between TEST_CASE_START and TEST_CASE_END.

## Note

To reproduce the behavior encountered while testing:
1. checkout to commit `d50ad0f` (PR #1101)
2. run the following test with DEBUG level, see that there are no messages between TEST_CASE_START and TEST_CASE_END
    ```
    zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --raw --level DEBUG --test dnssec/dnssec11
    ```
4. run the same test with DEBUG2 level
    ```
    zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --raw --level DEBUG2 --test dnssec/dnssec11
    ```
5. checkout to commit `6111d00` (PR #1142)
6. run the same test as 2. with DEBUG level, see the number of `QUERY` messages
    ```
    zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --raw --level DEBUG --test dnssec/dnssec11
    ```
7. same as 5. but with DEBUG2 level
    ```
    zonemaster-cli 190.187.193.in-addr.arpa --ns ns1.oxilion.nl --ns ns2.oxilion.nl --ns ns3.oxilion.net --raw --level DEBUG2 --test dnssec/dnssec11
    ```

