### PR TITLE
Update Nameserver11 to check for OPTION-CODE in EDNS response

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -1202,7 +1202,11 @@ sub nameserver11 {
             }
 
             elsif ( defined $p->edns_data ) {
-                push @unknown_opt_code, $ns->address->short;
+                my $p_opt_code = unpack("S>", $p->edns_data);
+
+                if ( $p_opt_code == $opt_code ){
+                    push @unknown_opt_code, $ns->address->short;
+                }
             }
         }
         else{

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -1177,7 +1177,7 @@ sub nameserver11 {
         #To be changed to '$ns->query( $zone->name, q{SOA}, { edns_details => { version => 0 } } );' when PR#1147 is merged.
         my $p = $ns->query( $zone->name, q{SOA}, { edns_details => { udp_size => 512 } } );
 
-        if ( not $p or not $p->has_edns or $p->rcode ne q{NOERROR} or not $p->aa or not $p->get_records_for_name(q{SOA}, $zone->name, q{answer}) ){
+        if ( not $p or not $p->has_edns or $p->rcode ne q{NOERROR} or not $p->aa or not $p->get_records_for_name(q{SOA}, $zone->name, q{answer}) ) {
             next;
         }
 
@@ -1185,19 +1185,19 @@ sub nameserver11 {
         $p = $ns->query( $zone->name, q{SOA}, { edns_details => { data => $rdata, udp_size => 512 } } );
 
         if ( $p ) {
-            if ( $p->rcode ne q{NOERROR} ){
+            if ( $p->rcode ne q{NOERROR} ) {
                 push @{ $unexpected_rcode{$p->rcode} }, $ns->address->short;
             }
 
-            elsif ( not $p->has_edns ){
+            elsif ( not $p->has_edns ) {
                 push @no_edns, $ns->address->short;
             }
 
-            elsif ( not $p->get_records_for_name(q{SOA}, $zone->name, q{answer}) ){
+            elsif ( not $p->get_records_for_name(q{SOA}, $zone->name, q{answer}) ) {
                 push @unexpected_answer, $ns->address->short;
             }
 
-            elsif ( not $p->aa ){
+            elsif ( not $p->aa ) {
                 push @unset_aa, $ns->address->short;
             }
 
@@ -1207,16 +1207,17 @@ sub nameserver11 {
                 # Unpack the bytes string:
                 # - OPTION-CODE as unsigned short (16-bit) in "network" (big-endian) order, and
                 # - OPTION-DATA as a sequence of bytes of length specified by a prefixed unsigned short (16-bit)
-                #   in "network" (big-endian) order (OPTION-LENGTH)
+                #   in "network" (big-endian) order (OPTION-LENGTH), and
                 # - Remaining data, if any (i.e., other OPTIONS)
 
-                my @unpacked_opt = unpack("(n n/a)*", $p_opt);
+                my @unpacked_opt = eval { unpack("(n n/a)*", $p_opt) };
                 
                 while ( my ( $p_opt_code, $p_opt_data, @next_data ) = @unpacked_opt ) {
-                    if ( $p_opt_code == $opt_code ){
+                    if ( $p_opt_code == $opt_code ) {
                         push @unknown_opt_code, $ns->address->short;
                         last;
                     }
+
                     @unpacked_opt = @next_data;
                 }
             }
@@ -1226,11 +1227,11 @@ sub nameserver11 {
         }
     }
 
-    if ( scalar @no_response ){
+    if ( scalar @no_response ) {
         push @results, info( N11_NO_RESPONSE => { ns_ip_list => join( q{;}, uniq sort @no_response ) } );
     }
 
-    if ( scalar keys %unexpected_rcode ){
+    if ( scalar keys %unexpected_rcode ) {
         push @results, map {
           info(
             N11_UNEXPECTED_RCODE => {
@@ -1241,19 +1242,19 @@ sub nameserver11 {
         } keys %unexpected_rcode;
     }
 
-    if ( scalar @no_edns ){
+    if ( scalar @no_edns ) {
         push @results, info( N11_NO_EDNS => { ns_ip_list => join( q{;}, uniq sort @no_edns ) } );
     }
 
-    if ( scalar @unexpected_answer ){
+    if ( scalar @unexpected_answer ) {
         push @results, info( N11_UNEXPECTED_ANSWER_SECTION => { ns_ip_list => join( q{;}, uniq sort @unexpected_answer ) } );
     }
 
-    if ( scalar @unset_aa ){
+    if ( scalar @unset_aa ) {
         push @results, info( N11_UNSET_AA => { ns_ip_list => join( q{;}, uniq sort @unset_aa ) } );
     }
 
-    if ( scalar @unknown_opt_code ){
+    if ( scalar @unknown_opt_code ) {
         push @results, info( N11_RETURNS_UNKNOWN_OPTION_CODE => { ns_ip_list => join( q{;}, uniq sort @unknown_opt_code ) } );
     }
 

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -1202,7 +1202,8 @@ sub nameserver11 {
             }
 
             elsif ( defined $p->edns_data ) {
-                my $p_opt_code = unpack("S>", $p->edns_data);
+                my $p_edns_rdata = $p->edns_data;
+                my $p_opt_code = unpack("S>", $p_edns_rdata);
 
                 if ( $p_opt_code == $opt_code ){
                     push @unknown_opt_code, $ns->address->short;


### PR DESCRIPTION
## Purpose

This PR proposes an update to Nameserver11 to check for all OPTION-CODE in an EDNS response.
This depends on https://github.com/zonemaster/zonemaster-ldns/pull/166 to work.

## Context

Fixes #1173 

## Changes

...

## How to test this PR

1) Checkout and install https://github.com/zonemaster/zonemaster-ldns/pull/166 in Zonemaster-LDNS.
2) Checkout this PR in Zonemaster-Engine. Then run (domain name from #1173):

```
$ zonemaster-cli --show-testcase --test nameserver/nameserver11 abundo.se --level info
Seconds Level     Testcase       Message
======= ========= ============== =======
   0.00 INFO      UNSPECIFIED    Using version v4.6.0 of the Zonemaster engine.
```

3) Change OPTION-CODE value in query from 137 to 3, in line 1168 of lib/Zonemaster/Engine/Test/Nameserver.pm :
`    my $opt_code = 3;`

4) Then run:
```
$ zonemaster-cli --show-testcase --test nameserver/nameserver11 zonemaster.fr --level info
Seconds Level     Testcase       Message
======= ========= ============== =======
   0.00 INFO      UNSPECIFIED    Using version v4.6.0 of the Zonemaster engine.
   5.59 WARNING   NAMESERVER11   The DNS response contains an unknown EDNS option-code. Returned from name servers "192.134.0.49;192.134.4.1".
```