### PR TITLE
Remove Basic04 completely

### DIFF
--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -144,10 +144,6 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # BASIC:BASIC03
           'The Broken but functional test', @_;
     },
-    BASIC04 => sub {
-        __x    # BASIC:BASIC04
-          'Test of basic nameserver and zone functionality', @_;
-    },
     A_QUERY_NO_RESPONSES => sub {
         __x    # BASIC:A_QUERY_NO_RESPONSES
           'Nameservers did not respond to A query.';


### PR DESCRIPTION
## Purpose

Test case Basic04 was removed by #1143, but the test case description remains. Removed by this test case.

## How to test this PR

1. Make all clean
2. Check out this PR.
3. `cd share`
4. Update some PO file, e.g. `sv.po`, `./update-po sv.po`
5. There should not be any entry for `BASIC:BASIC04`
