### PR TITLE
Fix test issue for Address01

### DIFF
--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -173,7 +173,7 @@ sub address01 {
                 NAMESERVER_IP_PRIVATE_NETWORK => {
                     nsname    => $local_ns->name->string,
                     ns_ip     => $local_ns->address->short,
-                    prefix    => ${$ip_details_ref}{ip}->print,
+                    prefix    => ${$ip_details_ref}{ip}->short . '/' . ${$ip_details_ref}{ip}->prefixlen,
                     name      => ${$ip_details_ref}{name},
                     reference => ${$ip_details_ref}{reference},
                 }


### PR DESCRIPTION
## Purpose

Fix test crashing.

## Context

In version 0.21 of Net::IP::XS there is a bug causing the function `Net::IP::XS::print` to make the process crash on Debian and Ubuntu and return some garbage on RHEL (which later make the test crash because it failed to encode the result in JSON to save it), eg:

* RHEL 8:
   ```sh
   % perl -MNet::IP::XS -e ' my $ip = new Net::IP::XS ("a:b:c::" ); print $ip->print . "\n";'
   0�O�▒Va:b:c::/128
   ```
* Ubuntu / Debian:
   ```sh
   % perl -MNet::IP::XS -e ' my $ip = new Net::IP::XS ("a:b:c::" ); print $ip->print . "\n";'
   *** stack smashing detected ***: terminated
   Aborted
   ```

While the issue has been reported and resolved in Net::IP::XS (release 0.22), we don't know how long it will be before the new version is available as binary packages in the various distribution we support. In the meantime I suggest we use a workaround to display the subnet in Address01.

## Changes

* Manually display the subnet using the `short` and `prefixlen` methods.

## How to test this PR
Running the following command should not output any garbage in the `ns_ip` value or crash. The [recorded data is available](https://github.com/zonemaster/zonemaster-engine/files/10488017/address01.txt) if the domain has fixed its issue.
```sh
% zonemaster-cli --test Address/address01 ispfontela.es --raw
   0.03 ERROR     NAMESERVER_IP_PRIVATE_NETWORK   name=IPv4-mapped Address; ns_ip=::ffff:5598:1888; nsname=dns1.ispfontela.es; prefix=::ffff:0:0/96; reference=[RFC4291]
   0.03 ERROR     NAMESERVER_IP_PRIVATE_NETWORK   name=IPv4-mapped Address; ns_ip=::ffff:5d9c:4c75; nsname=dns2.ispfontela.es; prefix=::ffff:0:0/96; reference=[RFC4291]
```
