### PR TITLE
Provide a rule `new-po` to create an empty PO file

### DIFF
--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -24,6 +24,10 @@ extract-pot:
 
 $(POTFILE): extract-pot
 
+# Create a new empty PO file with basename provided with the POLANG variable
+new-po: extract-pot
+	@[ -n "$(POLANG)" ] && cp $(POTFILE) $(POLANG).po || echo "Usage: make POLANG=xx new-po"
+
 .po.mo:
 	@msgfmt -o $@ $<
 	@mkdir -p locale/`basename $@ .mo`/LC_MESSAGES

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -1,6 +1,6 @@
 .POSIX:
 .SUFFIXES: .po .mo
-.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po
+.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po new-po
 
 POFILES := $(shell find . -maxdepth 1 -type f -name '*.po' -exec basename {} \;)
 MOFILES := $(POFILES:%.po=%.mo)

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -29,7 +29,7 @@ $(POTFILE): extract-pot
 new-po: extract-pot
 	@[ -n "$(POLANG)" ] || ( echo "Usage: make POLANG=xx new-po" && exit 1 )
 	@cp $(POTFILE) $(POLANG).po
-	@sed -i 's/^"Language: /&$(POLANG)/' $(POLANG).po
+	@perl -pi -e 's/^"Language: /$$&$(POLANG)/' $(POLANG).po
 
 .po.mo:
 	@msgfmt -o $@ $<

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -25,8 +25,11 @@ extract-pot:
 $(POTFILE): extract-pot
 
 # Create a new empty PO file with basename provided with the POLANG variable
+# Update the Language field in the header
 new-po: extract-pot
-	@[ -n "$(POLANG)" ] && cp $(POTFILE) $(POLANG).po || echo "Usage: make POLANG=xx new-po"
+	@[ -n "$(POLANG)" ] || ( echo "Usage: make POLANG=xx new-po" && exit 1 )
+	@cp $(POTFILE) $(POLANG).po
+	@sed -i 's/^"Language: /&$(POLANG)/' $(POLANG).po
 
 .po.mo:
 	@msgfmt -o $@ $<


### PR DESCRIPTION
## Purpose

New Makefile rule to create an empty PO file using the basename provided in the POLANG variable.

## Context

Addresses https://github.com/zonemaster/zonemaster/issues/1131

See https://github.com/zonemaster/zonemaster/pull/1135 for an example of documentation.

## Changes

share/GNUMakefile: add a `new-po` rule

## How to test this PR

Run `make POLANG=rs new-po` and make sure that the file `rs.po` has been created with empty _msgstr_.
