### PR TITLE
Avoid unnecessary calls to Profile::get in logger

### DIFF
--- a/lib/Zonemaster/Engine/Logger.pm
+++ b/lib/Zonemaster/Engine/Logger.pm
@@ -228,4 +228,15 @@ Clear the test level cached configuration.
 
 =back
 
+=head1 SUBROUTINES
+
+=over
+
+=item _check_filter($entry)
+
+Apply the C<logfilter> defined rules to the entry. See
+L<Zonemaster::Engine::Profile/"logfilter">.
+
+=back
+
 =cut


### PR DESCRIPTION
## Purpose

Store logfilter property instead of querying it at every method's call. This will improve performance.

## Context

Taken from https://gitlab.rd.nic.fr/zonemaster/zonemaster-engine/-/commit/8b303b6c5d2e1a148c592325839256cc85f828b8

Credits to @blacksponge for the proposal

## Changes

Logger.pm

## How to test this PR

Tests should pass.

To assess the performance improvements, run:

```
perl -d:NYTProf -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_zone("zonemaster.net")'
nytprofhtml --open
```
And check that the time passed in the `_check_filter` routine has decreased.