### PR TITLE
Caching: add global cache based on Redis (experimental)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -24,6 +24,7 @@ lib/Zonemaster/Engine/Logger.pm
 lib/Zonemaster/Engine/Logger/Entry.pm
 lib/Zonemaster/Engine/Nameserver.pm
 lib/Zonemaster/Engine/Nameserver/Cache.pm
+lib/Zonemaster/Engine/Nameserver/Cache/LocalCache.pm
 lib/Zonemaster/Engine/Normalization.pm
 lib/Zonemaster/Engine/Normalization/Error.pm
 lib/Zonemaster/Engine/Net/IP.pm

--- a/MANIFEST
+++ b/MANIFEST
@@ -25,6 +25,7 @@ lib/Zonemaster/Engine/Logger/Entry.pm
 lib/Zonemaster/Engine/Nameserver.pm
 lib/Zonemaster/Engine/Nameserver/Cache.pm
 lib/Zonemaster/Engine/Nameserver/Cache/LocalCache.pm
+lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
 lib/Zonemaster/Engine/Normalization.pm
 lib/Zonemaster/Engine/Normalization/Error.pm
 lib/Zonemaster/Engine/Net/IP.pm

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -361,12 +361,14 @@ sub query {
     else {
         $md5->add( q{EDNS_UDP_SIZE} , 0);
     }
-    
+
     my $idx = $md5->b64digest();
-    if ( not exists( $self->cache->data->{$idx} ) ) {
-        $self->cache->data->{$idx} = $self->_query( $name, $type, $href );
+
+    my ( $in_cache, $p) = $self->cache->get_key( $idx );
+    if ( not $in_cache ) {
+        $p = $self->_query( $name, $type, $href );
+        $self->cache->set_key( $idx, $p );
     }
-    $p = $self->cache->data->{$idx};
 
     Zonemaster::Engine->logger->add( CACHED_RETURN => { packet => ( $p ? $p->string : 'undef' ) } );
 

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -237,7 +237,10 @@ sub _build_dns {
 sub _build_cache {
     my ( $self ) = @_;
 
-    Zonemaster::Engine::Nameserver::Cache->new( { address => $self->address } );
+    my $cache_type = Zonemaster::Engine::Nameserver::Cache->get_cache_type( Zonemaster::Engine::Profile->effective );
+    my $cache_class = Zonemaster::Engine::Nameserver::Cache->get_cache_class( $cache_type );
+
+    $cache_class->new( { address => $self->address } );
 }
 
 ###
@@ -614,6 +617,9 @@ sub restore {
         }
       );
 
+    my $cache_type = Zonemaster::Engine::Nameserver::Cache->get_cache_type( Zonemaster::Engine::Profile->effective );
+    my $cache_class = Zonemaster::Engine::Nameserver::Cache->get_cache_class( $cache_type );
+
     open my $fh, '<', $filename or die "Failed to open restore data file: $!\n";
     while ( my $line = <$fh> ) {
         my ( $name, $addr, $data ) = split( / /, $line, 3 );
@@ -622,7 +628,7 @@ sub restore {
             {
                 name    => $name,
                 address => Net::IP::XS->new($addr),
-                cache   => Zonemaster::Engine::Nameserver::Cache->new( { data => $ref, address => Net::IP::XS->new( $addr ) } )
+                cache   => $cache_class->new( { data => $ref, address => Net::IP::XS->new( $addr ) } )
             }
         );
     }

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -12,15 +12,6 @@ our %object_cache;
 has 'data' => ( is => 'ro' );
 has 'address' => ( is => 'ro' );
 
-sub check_cache {
-    my ( $self, $cache ) = @_;
-
-    if ( $cache !~ /^LocalCache$/ ) {
-        warn "Unknown cache format '$cache', using default 'LocalCache'";
-    }
-    return "LocalCache";
-}
-
 sub get_cache_type {
     my ( $class, $profile ) = @_;
     my $cache_type = 'LocalCache';
@@ -76,11 +67,6 @@ A reference to a hash holding the cache of sent queries. Not meant for external 
 =head1 CLASS METHODS
 
 =over
-
-=item check_cache($cache)
-
-Returns a normalized string based on the supported cache format.
-Emits a warning and retun "LocalCache" if the value is not LocalCache.
 
 =item get_cache_type()
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -51,6 +51,21 @@ sub new {
     return $obj;
 }
 
+sub set_key {
+     my ($self, $idx, $packet) = @_;
+     $self->data->{$idx} = $packet;
+}
+
+sub get_key {
+    my ( $self, $idx ) = @_;
+
+    if ( exists $self->data->{$idx} ) {
+        # cache hit
+        return ( 1, $self->data->{$idx} );
+    }
+    return ( 0, undef );
+}
+
 sub empty_cache {
     %object_cache = ();
 
@@ -92,6 +107,14 @@ Construct a new Cache object.
 =item empty_cache()
 
 Clear the cache.
+
+=item set_key($idx, $packet)
+
+Store packet with index idx.
+
+=item get_key($idx)
+
+Retrieve packet (data) at key idx.
 
 =back
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -16,8 +16,12 @@ sub get_cache_type {
     my ( $class, $profile ) = @_;
     my $cache_type = 'LocalCache';
 
-    if ( $profile->get( 'cache.redis' ) ) {
-        $cache_type = 'RedisCache';
+    if ( $profile->get( 'cache' ) ) {
+        my %cache_config = %{ $profile->get( 'cache' ) };
+
+        if ( exists $cache_config{'redis'} ) {
+            $cache_type = 'RedisCache';
+        }
     }
 
     return $cache_type;

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -5,37 +5,57 @@ use version; our $VERSION = version->declare("v1.0.4");
 use 5.014002;
 use warnings;
 
-use Moose;
+use Class::Accessor "antlers";
+use Carp qw( confess );
+use Scalar::Util qw( blessed );
+
 use Zonemaster::Engine;
 
 our %object_cache;
 
-has 'data' => ( is => 'ro', isa => 'HashRef[Maybe[Zonemaster::Engine::Packet]]', default => sub { {} } );
-has 'address' => ( is => 'ro', isa => 'Net::IP::XS', required => 1 );
+has 'data' => ( is => 'ro' );
+has 'address' => ( is => 'ro' );
 
-around 'new' => sub {
-    my $orig = shift;
-    my $self = shift;
+sub new {
+    my $proto = shift;
+    my $class = ref $proto || $proto;
+    my $attrs = shift;
 
-    my $obj = $self->$orig( @_ );
+    confess "Attribute \(address\) is required"
+        if !exists $attrs->{address};
 
-    if ( not exists $object_cache{ $obj->address->ip } ) {
-        Zonemaster::Engine->logger->add( CACHE_CREATED => { ip => $obj->address->ip } );
-        $object_cache{ $obj->address->ip } = $obj;
+    # Type coercions
+    $attrs->{address} = Net::IP::XS->new( $attrs->{address} )
+        if !blessed $attrs->{address} || !$attrs->{address}->isa( 'Net::IP::XS' );
+
+    # Type constraint
+    confess "Argument must be coercible into a Net::IP::XS: address"
+        if !$attrs->{address}->isa( 'Net::IP::XS' );
+    confess "Argument must be a HASHREF: data"
+        if exists $attrs->{data} && ref $attrs->{data} ne 'HASH';
+
+    # Default value
+    $attrs->{data} //= {};
+
+    my $ip = $attrs->{address}->ip;
+    if ( exists $object_cache{ $ip } ) {
+        Zonemaster::Engine->logger->add( CACHE_FETCHED => { ip => $ip } );
+        return $object_cache{ $ip };
     }
 
-    Zonemaster::Engine->logger->add( CACHE_FETCHED => { ip => $obj->address->ip } );
-    return $object_cache{ $obj->address->ip };
-};
+    my $obj = Class::Accessor::new( $class, $attrs );
+
+    Zonemaster::Engine->logger->add( CACHE_CREATED => { ip => $ip } );
+    $object_cache{ $ip } = $obj;
+
+    return $obj;
+}
 
 sub empty_cache {
     %object_cache = ();
 
     return;
 }
-
-no Moose;
-__PACKAGE__->meta->make_immutable( inline_constructor => 0 );
 
 1;
 
@@ -64,6 +84,10 @@ A reference to a hash holding the cache of sent queries. Not meant for external 
 =head1 CLASS METHODS
 
 =over
+
+=item new
+
+Construct a new Cache object.
 
 =item empty_cache()
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -16,7 +16,7 @@ sub get_cache_type {
     my ( $class, $profile ) = @_;
     my $cache_type = 'LocalCache';
 
-    if ( $profile->get( 'redis' ) ) {
+    if ( $profile->get( 'cache.redis' ) ) {
         $cache_type = 'RedisCache';
     }
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -70,13 +70,23 @@ A reference to a hash holding the cache of sent queries. Not meant for external 
 
 =item get_cache_type()
 
-Get the cache type value, i.e. the name of the cache module to use.
+    my $cache_type = get_cache_type( Zonemaster::Engine::Profile->effective );
+
+Get the cache type value from the profile, i.e. the name of the cache module to use.
+
+Takes a L<Zonemaster::Engine::Profile> object.
+
+Returns a string.
 
 =item get_cache_class()
 
+    my $cache_class = get_cache_class( 'LocalCache' );
+
 Get the cache adapter class for the given database type.
 
-Throws and exception if the cache adapter class cannot be loaded.
+Takes a string (cache database type).
+
+Returns a string, or throws an exception if the cache adapter class cannot be loaded.
 
 =item empty_cache()
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -23,7 +23,13 @@ sub check_cache {
 
 sub get_cache_type {
     my ( $class, $profile ) = @_;
-    return 'LocalCache';
+    my $cache_type = 'LocalCache';
+
+    if ( $profile->get( 'redis' ) ) {
+        $cache_type = 'RedisCache';
+    }
+
+    return $cache_type;
 }
 
 sub get_cache_class {

--- a/lib/Zonemaster/Engine/Nameserver/Cache/LocalCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/LocalCache.pm
@@ -27,7 +27,6 @@ sub new {
     $attrs->{address} = Net::IP::XS->new( $attrs->{address} )
         if !blessed $attrs->{address} || !$attrs->{address}->isa( 'Net::IP::XS' );
 
-    use Data::Dumper;
     # Type constraint
     confess "Argument must be coercible into a Net::IP::XS: address"
         if !$attrs->{address}->isa( 'Net::IP::XS' );
@@ -52,7 +51,7 @@ sub new {
 }
 
 sub set_key {
-     my ($self, $idx, $packet) = @_;
+     my ( $self, $idx, $packet ) = @_;
      $self->data->{$idx} = $packet;
 }
 
@@ -90,11 +89,11 @@ Construct a new Cache object.
 
 =item set_key($idx, $packet)
 
-Store packet with index idx.
+Store C<$packet> (data) with key C<$idx>.
 
 =item get_key($idx)
 
-Retrieve packet (data) at key idx.
+Retrieve C<$packet> (data) at key C<$idx>.
 
 =back
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache/LocalCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/LocalCache.pm
@@ -1,0 +1,101 @@
+package Zonemaster::Engine::Nameserver::Cache::LocalCache;
+
+use version; our $VERSION = version->declare("v1.0.4");
+
+use 5.014002;
+use warnings;
+
+use Carp qw( confess );
+use Scalar::Util qw( blessed );
+
+use Zonemaster::Engine;
+use Zonemaster::Engine::Nameserver::Cache;
+
+use base qw( Zonemaster::Engine::Nameserver::Cache );
+
+our $object_cache = \%Zonemaster::Engine::Nameserver::Cache::object_cache;
+
+sub new {
+    my $proto = shift;
+    my $class = ref $proto || $proto;
+    my $attrs = shift;
+
+    confess "Attribute \(address\) is required"
+        if !exists $attrs->{address};
+
+    # Type coercions
+    $attrs->{address} = Net::IP::XS->new( $attrs->{address} )
+        if !blessed $attrs->{address} || !$attrs->{address}->isa( 'Net::IP::XS' );
+
+    use Data::Dumper;
+    # Type constraint
+    confess "Argument must be coercible into a Net::IP::XS: address"
+        if !$attrs->{address}->isa( 'Net::IP::XS' );
+    confess "Argument must be a HASHREF: data"
+        if exists $attrs->{data} && ref $attrs->{data} ne 'HASH';
+
+    # Default value
+    $attrs->{data} //= {};
+
+    my $ip = $attrs->{address}->ip;
+    if ( exists $object_cache->{ $ip } ) {
+        Zonemaster::Engine->logger->add( CACHE_FETCHED => { ip => $ip } );
+        return $object_cache->{ $ip };
+    }
+
+    my $obj = Class::Accessor::new( $class, $attrs );
+
+    Zonemaster::Engine->logger->add( CACHE_CREATED => { ip => $ip } );
+    $object_cache->{ $ip } = $obj;
+
+    return $obj;
+}
+
+sub set_key {
+     my ($self, $idx, $packet) = @_;
+     $self->data->{$idx} = $packet;
+}
+
+sub get_key {
+    my ( $self, $idx ) = @_;
+
+    if ( exists $self->data->{$idx} ) {
+        # cache hit
+        return ( 1, $self->data->{$idx} );
+    }
+    return ( 0, undef );
+}
+
+1;
+
+=head1 NAME
+
+Zonemaster::Engine::Nameserver::LocalCache - local shared caches for nameserver objects
+
+=head1 SYNOPSIS
+
+    This class should not be used directly.
+
+=head1 ATTRIBUTES
+
+Subclass of L<Zonemaster::Engine::Nameserver::Cache>.
+
+=head1 CLASS METHODS
+
+=over
+
+=item new
+
+Construct a new Cache object.
+
+=item set_key($idx, $packet)
+
+Store packet with index idx.
+
+=item get_key($idx)
+
+Retrieve packet (data) at key idx.
+
+=back
+
+=cut

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -30,7 +30,7 @@ my $redis;
 my $config;
 our $object_cache = \%Zonemaster::Engine::Nameserver::Cache::object_cache;
 
-my $REDIS_EXPIRE_DEFAULT = 5; # seconds
+my $REDIS_EXPIRE_DEFAULT = 300; # seconds
 
 has 'redis' => ( is => 'ro' );
 has 'config' => ( is => 'ro' );

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -22,7 +22,6 @@ eval {
     use Redis;
 };
 
-
 if ( $@ ) {
     die "Can't use the Redis cache. Make sure the Data::MessagePack and Redis modules are installed.\n";
 }
@@ -106,9 +105,8 @@ sub get_key {
 
     if ( exists $self->data->{$hash} ) {
         #Zonemaster::Engine->logger->add( MEMORY_CACHE_HIT => { } );
-
-        return (1, $self->data->{$hash});
-    } elsif ($self->redis->exists($key)) {
+        return ( 1, $self->data->{$hash} );
+    } elsif ( $self->redis->exists($key) ) {
         my $fetch_start_time = [ gettimeofday ];
         my $data = $self->redis->get( $key );
         #Zonemaster::Engine->logger->add( REDIS_CACHE_HIT => { } );
@@ -153,11 +151,11 @@ Construct a new Cache object.
 
 =item set_key($idx, $packet)
 
-Store packet with index idx.
+Store C<$packet> with key C<$idx>.
 
 =item get_key($idx)
 
-Retrieve packet (data) at key idx.
+Retrieve C<$packet> (data) at key C<$idx>.
 
 =back
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -116,3 +116,35 @@ sub get_key {
 }
 
 1;
+
+=head1 NAME
+
+Zonemaster::Engine::Nameserver::Cache::RedisCache - global shared caches for nameserver objects
+
+=head1 SYNOPSIS
+
+    This is an EXPERIMENTAL caching layer and might change in the future.
+
+=head1 ATTRIBUTES
+
+Subclass of L<Zonemaster::Engine::Nameserver::Cache>.
+
+=head1 CLASS METHODS
+
+=over
+
+=item new
+
+Construct a new Cache object.
+
+=item set_key($idx, $packet)
+
+Store packet with index idx.
+
+=item get_key($idx)
+
+Retrieve packet (data) at key idx.
+
+=back
+
+=cut

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -17,22 +17,21 @@ use Zonemaster::Engine::Profile;
 
 use base qw( Zonemaster::Engine::Nameserver::Cache );
 
-eval( <<EOS
+eval {
     use Data::MessagePack;
     use Redis;
-EOS
-);
+};
 
 
 if ( $@ ) {
-    die "Cant' use the Redis cache. Make sure the Data::MessagePack and Redis module are installed.\n";
+    die "Can't use the Redis cache. Make sure the Data::MessagePack and Redis modules are installed.\n";
 }
 
 my $redis;
 my $config;
 our $object_cache = \%Zonemaster::Engine::Nameserver::Cache::object_cache;
 
-my $REDIS_EXPIRE = 5; # seconds
+my $REDIS_EXPIRE_DEFAULT = 5; # seconds
 
 has 'redis' => ( is => 'ro' );
 has 'config' => ( is => 'ro' );
@@ -55,7 +54,7 @@ sub new {
         $params->{redis} //= $redis;
         $params->{data} //= {};
         $params->{config} //= $config;
-        $config->{expire} //= $REDIS_EXPIRE;
+        $config->{expire} //= $REDIS_EXPIRE_DEFAULT;
         my $class = ref $proto || $proto;
         my $obj = Class::Accessor::new( $class, $params );
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -46,7 +46,7 @@ sub new {
         return $object_cache->{ $params->{address} };
     } else {
         if (! defined $redis) {
-            my $redis_config = Zonemaster::Engine::Profile->effective->get( q{cache.redis} );
+            my $redis_config = Zonemaster::Engine::Profile->effective->get( q{cache} )->{'redis'};
             $redis = Redis->new(server => $redis_config->{server});
             $config = $redis_config;
         }

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -81,12 +81,11 @@ sub set_key {
         }
         elsif ( $packet->authority ) {
             my @rr = $packet->authority;
-            my $rcode = $packet->rcode;
-            if ( $rcode eq 'NXDOMAIN' ) {
-                $ttl = min( map { $_->minimum } @rr );
-            }
-            elsif ( $rcode eq 'NOERROR' ) {
-                $ttl = min( map { $_->ttl } @rr );
+            foreach my $r (@rr) {
+                if ( $r->type eq 'SOA' ) {
+                    $ttl = $r->ttl;
+                    last;
+                }
             }
         }
         $ttl = $ttl < $REDIS_EXPIRE ? $ttl : $REDIS_EXPIRE;

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -46,7 +46,7 @@ sub new {
         return $object_cache->{ $params->{address} };
     } else {
         if (! defined $redis) {
-            my $redis_config = Zonemaster::Engine::Profile->effective->get( q{redis} );
+            my $redis_config = Zonemaster::Engine::Profile->effective->get( q{cache.redis} );
             $redis = Redis->new(server => $redis_config->{server});
             $config = $redis_config;
         }

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -1,0 +1,110 @@
+package Zonemaster::Engine::Nameserver::Cache::RedisCache;
+
+use version; our $VERSION = version->declare("v1.0.0");
+
+use 5.014002;
+
+use strict;
+use warnings;
+
+use Class::Accessor "antlers";
+use Time::HiRes qw[gettimeofday tv_interval];
+
+use Zonemaster::LDNS::Packet;
+use Zonemaster::Engine::Packet;
+use Zonemaster::Engine::Profile;
+
+use base qw( Zonemaster::Engine::Nameserver::Cache );
+
+eval( <<EOS
+    use Data::MessagePack;
+    use Redis;
+EOS
+);
+
+
+if ( $@ ) {
+    die "Cant' use the Redis cache. Make sure the Data::MessagePack and Redis module are installed.\n";
+}
+
+my $redis;
+our $object_cache = \%Zonemaster::Engine::Nameserver::Cache::object_cache;
+
+my $REDIS_EXPIRE = 3600; # seconds
+
+has 'redis' => ( is => 'ro' );
+
+my $mp = Data::MessagePack->new();
+
+sub new {
+    my $proto = shift;
+    my $params = shift;
+    $params->{address} = $params->{address}->ip;
+    if ( exists $object_cache->{ $params->{address} } ) {
+        Zonemaster::Engine->logger->add( CACHE_FETCHED => { ip => $params->{address} } );
+        return $object_cache->{ $params->{address} };
+    } else {
+        if (! defined $redis) {
+            my $redis_config = Zonemaster::Engine::Profile->effective->get( q{redis} );
+            $redis = Redis->new(%{$redis_config});
+        }
+        $params->{redis} //= $redis;
+        $params->{data} //= {};
+        my $class = ref $proto || $proto;
+        my $obj = Class::Accessor::new( $class, $params );
+
+        Zonemaster::Engine->logger->add( CACHE_CREATED => { ip => $params->{address} } );
+        $object_cache->{ $params->{address} } = $obj;
+
+        return $obj;
+    }
+}
+
+sub set_key {
+    my ( $self, $hash, $packet ) = @_;
+    my $key = "ns:" . $self->address . ":" . $hash;
+
+    $self->data->{$hash} = $packet;
+    if ( defined $packet ) {
+        my $msg = $mp->pack({
+            data       => $packet->data,
+            answerfrom => $packet->answerfrom,
+            timestamp  => $packet->timestamp,
+            querytime  => $packet->querytime,
+        });
+        $self->redis->set( $key, $msg, 'EX', $REDIS_EXPIRE );
+    } else {
+        $self->redis->set( $key, '', 'EX', $REDIS_EXPIRE );
+    }
+}
+
+sub get_key {
+    my ( $self, $hash ) = @_;
+    my $key = "ns:" . $self->address . ":" . $hash;
+
+    if ( exists $self->data->{$hash} ) {
+        #Zonemaster::Engine->logger->add( MEMORY_CACHE_HIT => { } );
+
+        return (1, $self->data->{$hash});
+    } elsif ($self->redis->exists($key)) {
+        my $fetch_start_time = [ gettimeofday ];
+        my $data = $self->redis->get( $key );
+        #Zonemaster::Engine->logger->add( REDIS_CACHE_HIT => { } );
+        if ( not length($data) ) {
+            $self->data->{$hash} = undef;
+        } else {
+            my $msg = $mp->unpack( $data );
+            my $packet = Zonemaster::Engine::Packet->new({ packet => Zonemaster::LDNS::Packet->new_from_wireformat($msg->{data}) });
+            $packet->answerfrom( $msg->{answerfrom} );
+            $packet->timestamp( $msg->{timestamp} );
+            $packet->querytime( $msg->{querytime} );
+
+            $self->data->{$hash} = $packet;
+        }
+        return ( 1, $self->data->{$hash} );
+    }
+    #Zonemaster::Engine->logger->add( CACHE_MISS => { } );
+    return ( 0, undef )
+}
+
+1;

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -104,12 +104,12 @@ sub get_key {
     my $key = "ns:" . $self->address . ":" . $hash;
 
     if ( exists $self->data->{$hash} ) {
-        #Zonemaster::Engine->logger->add( MEMORY_CACHE_HIT => { } );
+        Zonemaster::Engine->logger->add( MEMORY_CACHE_HIT => { hash => $hash } );
         return ( 1, $self->data->{$hash} );
     } elsif ( $self->redis->exists($key) ) {
         my $fetch_start_time = [ gettimeofday ];
         my $data = $self->redis->get( $key );
-        #Zonemaster::Engine->logger->add( REDIS_CACHE_HIT => { } );
+        Zonemaster::Engine->logger->add( REDIS_CACHE_HIT => { key => $key } );
         if ( not length($data) ) {
             $self->data->{$hash} = undef;
         } else {
@@ -123,7 +123,7 @@ sub get_key {
         }
         return ( 1, $self->data->{$hash} );
     }
-    #Zonemaster::Engine->logger->add( CACHE_MISS => { } );
+    Zonemaster::Engine->logger->add( CACHE_MISS => { key => $key } );
     return ( 0, undef )
 }
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -22,7 +22,7 @@ $YAML::XS::Boolean = "JSON::PP";
 use Zonemaster::Engine::Constants qw( $RESOLVER_SOURCE_OS_DEFAULT $DURATION_5_MINUTES_IN_SECONDS $DURATION_1_HOUR_IN_SECONDS $DURATION_4_HOURS_IN_SECONDS $DURATION_12_HOURS_IN_SECONDS $DURATION_1_DAY_IN_SECONDS $DURATION_1_WEEK_IN_SECONDS $DURATION_180_DAYS_IN_SECONDS );
 
 my %profile_properties_details = (
-    q{redis} => {
+    q{cache.redis} => {
         type    => q{HashRef},
     },
     q{resolver.defaults.debug} => {
@@ -765,6 +765,17 @@ servers when asn_db.style is set to C<"RIPE">. Normally only the first item
 in the list will be used, the rest are backups in case the earlier ones don't
 work.
 Default C<"asnlookup.zonemaster.net">.
+
+=head2 cache.redis (EXPERIMENTAL)
+
+A hashref. Undefined by default.
+
+Specifies the address of the Redis server used to perform
+global caching (C<cache.redis.server>) and an optional expire time which
+defaults to 5 seconds (C<cache.redis.expire>).
+
+C<cache.redis.server> is a string in the form C<host:port>.
+C<cache.redis.exire> is an integer and defines a time in second.
 
 =head2 logfilter
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -22,8 +22,26 @@ $YAML::XS::Boolean = "JSON::PP";
 use Zonemaster::Engine::Constants qw( $RESOLVER_SOURCE_OS_DEFAULT $DURATION_5_MINUTES_IN_SECONDS $DURATION_1_HOUR_IN_SECONDS $DURATION_4_HOURS_IN_SECONDS $DURATION_12_HOURS_IN_SECONDS $DURATION_1_DAY_IN_SECONDS $DURATION_1_WEEK_IN_SECONDS $DURATION_180_DAYS_IN_SECONDS );
 
 my %profile_properties_details = (
-    q{cache.redis} => {
+    q{cache} => {
         type    => q{HashRef},
+        test    => sub {
+            my @allowed_keys = ( 'redis' );
+            foreach my $cache_database ( keys %{$_[0]} ) {
+                if ( not grep( /^$cache_database$/, @allowed_keys ) ) {
+                    die "Property cache keys have " . scalar @allowed_keys . " possible values : " . join(", ", @allowed_keys);
+                }
+
+                if ( not scalar keys %{ $_[0]->{$cache_database} } ) {
+                    die "Property cache.$cache_database has no items";
+                }
+                else {
+                    foreach my $key ( keys %{ $_[0]->{$cache_database} } ) {
+                        die "Property cache.$cache_database.$key has a NULL or empty item" if not $_[0]->{$cache_database}->{$key};
+                        die "Property cache.$cache_database.$key has a negative value" if ( $key eq 'expire' and scalar $_[0]->{$cache_database}->{$key} < 0 ) ;
+                    }
+                }
+            }
+        }
     },
     q{resolver.defaults.debug} => {
         type    => q{Bool}
@@ -766,16 +784,23 @@ in the list will be used, the rest are backups in case the earlier ones don't
 work.
 Default C<"asnlookup.zonemaster.net">.
 
+=head2 cache (EXPERIMENTAL)
+
+A hash of hashes. The currently supported keys are C<"redis">.
+
+See more information in L<cache.redis>.
+
+Undefined by default.
+
 =head2 cache.redis (EXPERIMENTAL)
 
-A hashref. Undefined by default.
+A hashref. The currently supported keys are C<"server"> and C<"expire">.
 
-Specifies the address of the Redis server used to perform
-global caching (C<cache.redis.server>) and an optional expire time which
-defaults to 5 seconds (C<cache.redis.expire>).
+Specifies the address of the Redis server used to perform global caching
+(C<cache.redis.server>) and an optional expire time (C<cache.redis.expire>).
 
-C<cache.redis.server> is a string in the form C<host:port>.
-C<cache.redis.exire> is an integer and defines a time in second.
+C<cache.redis.server> must be a string in the form C<host:port>.
+C<cache.redis.expire> must be a non-negative integer and defines a time in seconds. Default 5 seconds.
 
 =head2 logfilter
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -22,6 +22,9 @@ $YAML::XS::Boolean = "JSON::PP";
 use Zonemaster::Engine::Constants qw( $RESOLVER_SOURCE_OS_DEFAULT $DURATION_5_MINUTES_IN_SECONDS $DURATION_1_HOUR_IN_SECONDS $DURATION_4_HOURS_IN_SECONDS $DURATION_12_HOURS_IN_SECONDS $DURATION_1_DAY_IN_SECONDS $DURATION_1_WEEK_IN_SECONDS $DURATION_180_DAYS_IN_SECONDS );
 
 my %profile_properties_details = (
+    q{redis} => {
+        type    => q{HashRef},
+    },
     q{resolver.defaults.debug} => {
         type    => q{Bool}
     },

--- a/share/profile_additional_properties.json
+++ b/share/profile_additional_properties.json
@@ -3,9 +3,11 @@
         "source4": "192.0.2.53",
         "source6": "2001:db8::42"
     },
-    "redis": {
-        "server": "127.0.0.1:6379",
-        "expire": 5
+    "cache": {
+        "redis": {
+            "server": "127.0.0.1:6379",
+            "expire": 5
+        }
     },
     "logfilter" : {
         "BASIC" : {

--- a/share/profile_additional_properties.json
+++ b/share/profile_additional_properties.json
@@ -6,7 +6,7 @@
     "cache": {
         "redis": {
             "server": "127.0.0.1:6379",
-            "expire": 5
+            "expire": 300
         }
     },
     "logfilter" : {

--- a/share/profile_additional_properties.json
+++ b/share/profile_additional_properties.json
@@ -4,7 +4,8 @@
         "source6": "2001:db8::42"
     },
     "redis": {
-        "server": "127.0.0.1:6379"
+        "server": "127.0.0.1:6379",
+        "expire": 5
     },
     "logfilter" : {
         "BASIC" : {

--- a/share/profile_additional_properties.json
+++ b/share/profile_additional_properties.json
@@ -3,6 +3,9 @@
         "source4": "192.0.2.53",
         "source6": "2001:db8::42"
     },
+    "redis": {
+        "server": "127.0.0.1:6379"
+    },
     "logfilter" : {
         "BASIC" : {
             "IPV6_ENABLED" : [

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -130,6 +130,12 @@ Readonly my $EXAMPLE_PROFILE_2 => q(
     "ipv6": true
   },
   "no_network": false,
+  "cache": {
+    "redis": {
+      "server": "127.0.0.2:6379",
+      "expire": 7200
+    }
+  },
   "asnroots": [
     "asn1.example.com", "asn2.example.com"
   ],
@@ -191,7 +197,7 @@ subtest 'new() returns a profile with all properties unset' => sub {
     is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
     is $profile->get( 'test_levels' ),                undef, 'test_levels is unset';
     is $profile->get( 'test_cases' ),                 undef, 'test_cases is unset';
-    is $profile->get( 'cache.redis' ),                undef, 'cache.redis is unset';
+    is $profile->get( 'cache' ),                      undef, 'cache is unset';
 };
 
 subtest 'default() returns a new profile every time' => sub {
@@ -251,7 +257,7 @@ subtest 'from_json("{}") returns a profile with all properties unset' => sub {
     is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
     is $profile->get( 'test_levels' ),                undef, 'test_levels is unset';
     is $profile->get( 'test_cases' ),                 undef, 'test_cases is unset';
-    is $profile->get( 'cache.redis' ),                undef, 'cache_redis is unset';
+    is $profile->get( 'cache' ),                      undef, 'cache is unset';
 };
 
 subtest 'from_json() parses values from a string' => sub {
@@ -275,7 +281,7 @@ subtest 'from_json() parses values from a string' => sub {
       'logfilter was parsed from JSON';
     eq_or_diff $profile->get( 'test_levels' ), { Zone => { TAG => 'INFO' } }, 'test_levels was parsed from JSON';
     eq_or_diff $profile->get( 'test_cases' ), ['Zone01'], 'test_cases was parsed from JSON';
-    eq_or_diff $profile->get( 'cache.redis' ), { server => '127.0.0.1:6379', expire => 3600 }, 'cache.redis was parsed from JSON';
+    eq_or_diff $profile->get( 'cache' ), { redis => { server => '127.0.0.1:6379', expire => 3600 } }, 'cache was parsed from JSON';
 };
 
 subtest 'from_json() parses sentinel values from a string' => sub {
@@ -318,6 +324,7 @@ subtest 'from_json() dies on illegal values' => sub {
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"logfilter":[]}' ); }                          "checks type of logfilter";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"test_levels":[]}' ); }                        "checks type of test_levels";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"test_cases":{}}' ); }                         "checks type of test_cases";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"cache":[]}' ); }                              "checks type of cache";
 };
 
 subtest 'from_json() emits warning on illegal values' => sub {
@@ -406,16 +413,19 @@ subtest 'get() returns deep copies of properties with complex types' => sub {
     $profile->set( 'logfilter',   {} );
     $profile->set( 'test_levels', {} );
     $profile->set( 'test_cases', [] );
+    $profile->set( 'cache',   {} );
 
     push @{ $profile->get( 'asnroots' ) },   'asn2.example.com';
     push @{ $profile->get( 'test_cases' ) }, 'Zone01';
     $profile->get( 'logfilter' )->{Zone} = {};
     $profile->get( 'test_levels' )->{Zone}{TAG} = 'INFO';
+    $profile->get( 'cache' )->{redis}{server} = '127.0.0.1:6379';
 
     eq_or_diff $profile->get( 'asnroots' ), ['asn1.example.com'], 'get(asnroots) returns a deep copy';
     eq_or_diff $profile->get( 'logfilter' ),   {}, 'get(logfilter) returns a deep copy';
     eq_or_diff $profile->get( 'test_levels' ), {}, 'get(test_levels) returns a deep copy';
     eq_or_diff $profile->get( 'test_cases' ), [], 'get(test_cases) returns a deep copy';
+    eq_or_diff $profile->get( 'cache' ),   {}, 'get(cache) returns a deep copy';
 };
 
 subtest 'get() dies if the given property name is invalid' => sub {
@@ -424,6 +434,7 @@ subtest 'get() dies if the given property name is invalid' => sub {
     $profile->set( 'logfilter', { Zone => {} } );
     $profile->set( 'test_levels', { Zone => { TAG => 'INFO' } } );
     $profile->set( 'test_cases', ['Zone01'] );
+    $profile->set( 'cache', { redis => { server => '127.0.0.1:6379' } } );
 
     throws_ok { $profile->get( 'net' ) }               qr/^.*Unknown property .*/, 'net';
     throws_ok { $profile->get( 'net.foobar' ) }        qr/^.*Unknown property .*/, 'net.foobar';
@@ -433,6 +444,7 @@ subtest 'get() dies if the given property name is invalid' => sub {
     throws_ok { $profile->get( 'logfilter.Zone' ) }    qr/^.*Unknown property .*/, 'logfilter.Zone';
     throws_ok { $profile->get( 'test_levels.Zone' ) }  qr/^.*Unknown property .*/, 'test_levels.Zone';
     throws_ok { $profile->get( 'test_cases.Zone01' ) } qr/^.*Unknown property .*/, 'test_cases.Zone01';
+    throws_ok { $profile->get( 'cache.redis' ) }       qr/^.*Unknown property .*/, 'cache.redis';
 };
 
 subtest 'set() inserts values for unset properties' => sub {
@@ -455,6 +467,7 @@ subtest 'set() inserts values for unset properties' => sub {
     $profile->set( 'logfilter', { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } } );
     $profile->set( 'test_levels', { Zone => { TAG => 'INFO' } } );
     $profile->set( 'test_cases', ['Zone01'] );
+    $profile->set( 'cache', { redis => { server => '127.0.0.1:6379', expire => 3600 } } );
 
     is $profile->get( 'resolver.defaults.usevc' ),    1,   'resolver.defaults.usevc can be given a value when unset';
     is $profile->get( 'resolver.defaults.dnssec' ),   0,   'resolver.defaults.dnssec can be given a value when unset';
@@ -475,6 +488,8 @@ subtest 'set() inserts values for unset properties' => sub {
     eq_or_diff $profile->get( 'test_levels' ), { Zone => { TAG => 'INFO' } },
       'test_levels can be given a value when unset';
     eq_or_diff $profile->get( 'test_cases' ), ['Zone01'], 'test_cases can be given a value when unset';
+    eq_or_diff $profile->get( 'cache' ), { redis => { server => '127.0.0.1:6379', expire => 3600 } },
+      'cache can be given a value when unset';
 };
 
 subtest 'set() updates values for set properties' => sub {
@@ -497,6 +512,7 @@ subtest 'set() updates values for set properties' => sub {
     $profile->set( 'logfilter', { Nameserver => { OTHER_TAG => [ { when => { apples => 1 }, set => 'INFO' } ] } } );
     $profile->set( 'test_levels', { Nameserver => { OTHER_TAG => 'ERROR' } } );
     $profile->set( 'test_cases', ['Zone02'] );
+    $profile->set( 'cache', { redis => { server => '127.0.0.2:6379', expire => 7200 } } );
 
     is $profile->get( 'resolver.defaults.usevc' ),   0,               'resolver.defaults.usevc was updated';
     is $profile->get( 'resolver.defaults.dnssec' ),  1,               'resolver.defaults.dnssec was updated';
@@ -515,6 +531,8 @@ subtest 'set() updates values for set properties' => sub {
       { Nameserver => { OTHER_TAG => [ { when => { apples => 1 }, set => 'INFO' } ] } }, 'logfilter was updated';
     eq_or_diff $profile->get( 'test_levels' ), { Nameserver => { OTHER_TAG => 'ERROR' } }, 'test_levels was updated';
     eq_or_diff $profile->get( 'test_cases' ), ['Zone02'], 'test_cases was updated';
+    eq_or_diff $profile->get( 'cache' ), { redis => { server => '127.0.0.2:6379', expire => 7200 } },
+    'cache was updated';
 };
 
 subtest 'set() dies on attempts to unset properties' => sub {
@@ -537,6 +555,7 @@ subtest 'set() dies on attempts to unset properties' => sub {
     throws_ok { $profile->set( 'logfilter',                  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset logfilter';
     throws_ok { $profile->set( 'test_levels',                undef ); } qr/^.* can not be undef/, 'dies on attempt to unset test_levels';
     throws_ok { $profile->set( 'test_cases',                 undef ); } qr/^.* can not be undef/, 'dies on attempt to unset test_cases';
+    throws_ok { $profile->set( 'cache',                      undef ); } qr/^.* can not be undef/, 'dies on attempt to unset cache';
 };
 
 subtest 'set() dies if the given property name is invalid' => sub {
@@ -545,6 +564,7 @@ subtest 'set() dies if the given property name is invalid' => sub {
     $profile->set( 'logfilter',   { Zone => {} } );
     $profile->set( 'test_levels', { Zone => {} } );
     $profile->set( 'test_cases', ['Zone01'] );
+    $profile->set( 'cache', { redis => { server => '127.0.0.1:6379' } } );
 
     throws_ok { $profile->set( 'net',               1 ) } qr/^.*Unknown property .*/, 'dies on attempt to set a value for net';
     throws_ok { $profile->set( 'net.foobar',        1 ) } qr/^.*Unknown property .*/, 'dies on attempt to set a value for net.foobar';
@@ -554,6 +574,7 @@ subtest 'set() dies if the given property name is invalid' => sub {
     throws_ok { $profile->set( 'logfilter.Zone',    1 ) } qr/^.*Unknown property .*/, 'dies on attempt to set a value for logfilter.Zone';
     throws_ok { $profile->set( 'test_levels.Zone',  1 ) } qr/^.*Unknown property .*/, 'dies on attempt to set a value for test_levels.Zone';
     throws_ok { $profile->set( 'test_cases.Zone01', 1 ) } qr/^.*Unknown property .*/, 'dies on attempt to set a value for test_cases.Zone01';
+    throws_ok { $profile->set( 'cache.redis',       1 ) } qr/^.*Unknown property .*/, 'dies on attempt to set a value for cache.redis';
 };
 
 subtest 'set() dies on illegal value' => sub {
@@ -571,7 +592,8 @@ subtest 'set() dies on illegal value' => sub {
     dies_ok { $profile->set( 'asnroots',        ['noreply@example.com'] ); } 'checks type of asnroots';
     dies_ok { $profile->set( 'logfilter',       [] ); } 'checks type of logfilter';
     dies_ok { $profile->set( 'test_levels',     [] ); } 'checks type of test_levels';
-    dies_ok { $profile->set( 'test_cases', {} ); } 'checks type of test_cases';
+    dies_ok { $profile->set( 'test_cases',      {} ); } 'checks type of test_cases';
+    dies_ok { $profile->set( 'cache',           [] ); } 'checks type of cache';
 };
 
 subtest 'set() accepts sentinel values' => sub {
@@ -644,8 +666,9 @@ subtest 'merge() with a profile with all properties unset' => sub {
     eq_or_diff $profile1->get( 'asnroots' ), ['example.com'], 'keeps value of asnroots';
     eq_or_diff $profile1->get( 'logfilter' ), { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } },
       'keeps value of logfilter';
-    eq_or_diff $profile1->get( 'test_levels' ), { Zone => { TAG => 'INFO' } }, 'test_levels';
+    eq_or_diff $profile1->get( 'test_levels' ), { Zone => { TAG => 'INFO' } }, 'keeps value of test_levels';
     eq_or_diff $profile1->get( 'test_cases' ), ['Zone01'], 'keeps value of test_cases';
+    eq_or_diff $profile1->get( 'cache' ), { redis => { server => '127.0.0.1:6379', expire => 3600 } }, 'keeps value of cache';
 };
 
 subtest 'merge() with a profile with all properties set' => sub {
@@ -672,6 +695,7 @@ subtest 'merge() with a profile with all properties set' => sub {
       { Nameserver => { OTHER_TAG => [ { when => { apples => 1 }, set => 'INFO' } ] } }, 'updates logfilter';
     eq_or_diff $profile1->get( 'test_levels' ), { Nameserver => { OTHER_TAG => 'ERROR' } }, 'updates test_levels';
     eq_or_diff $profile1->get( 'test_cases' ), ['Zone02'], 'updates test_cases';
+    eq_or_diff $profile1->get( 'cache' ), { redis => { server => '127.0.0.2:6379', expire => 7200 } }, 'updates cache';
 };
 
 subtest 'merge() does not update the other profile' => sub {
@@ -697,6 +721,7 @@ subtest 'merge() does not update the other profile' => sub {
     is $profile2->get( 'logfilter' ),                  undef, 'logfilter was untouched in other';
     is $profile2->get( 'test_levels' ),                undef, 'test_levels was untouched in other';
     is $profile2->get( 'test_cases' ),                 undef, 'test_cases was untouched in other';
+    is $profile2->get( 'cache' ),                      undef, 'cache was untouched in other';
 };
 
 subtest 'to_json() serializes each property' => sub {
@@ -880,6 +905,16 @@ subtest 'to_json() serializes each property' => sub {
 
         eq_or_diff decode_json( $json ),
           decode_json( '{"logfilter":{"Zone":{"TAG":[{"when":{"bananas":0},"set":"WARNING"}]}}}' );
+    };
+
+    subtest 'cache' => sub {
+        my $profile = Zonemaster::Engine::Profile->new;
+        $profile->set( 'cache', { redis => { server => '127.0.0.1:6379', expire => 3600 } } );
+
+        my $json = $profile->to_json;
+
+        eq_or_diff decode_json( $json ),
+          decode_json( '{"cache":{"redis":{"server":"127.0.0.1:6379","expire":3600}}}' );
     };
 };
 

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -34,6 +34,10 @@ net:
   ipv4: true
   ipv6: false
 no_network: true
+cache:
+  redis:
+    server: 127.0.0.1:6379
+    expire: 3600
 asnroots:
   - example.com
 logfilter:
@@ -71,6 +75,12 @@ Readonly my $EXAMPLE_PROFILE_1 => q(
     "ipv6": false
   },
   "no_network": true,
+  "cache": {
+    "redis": {
+      "server": "127.0.0.1:6379",
+      "expire": 3600
+    }
+  },
   "asnroots": [
     "example.com"
   ],
@@ -181,6 +191,7 @@ subtest 'new() returns a profile with all properties unset' => sub {
     is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
     is $profile->get( 'test_levels' ),                undef, 'test_levels is unset';
     is $profile->get( 'test_cases' ),                 undef, 'test_cases is unset';
+    is $profile->get( 'cache.redis' ),                undef, 'cache.redis is unset';
 };
 
 subtest 'default() returns a new profile every time' => sub {
@@ -240,6 +251,7 @@ subtest 'from_json("{}") returns a profile with all properties unset' => sub {
     is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
     is $profile->get( 'test_levels' ),                undef, 'test_levels is unset';
     is $profile->get( 'test_cases' ),                 undef, 'test_cases is unset';
+    is $profile->get( 'cache.redis' ),                undef, 'cache_redis is unset';
 };
 
 subtest 'from_json() parses values from a string' => sub {
@@ -263,6 +275,7 @@ subtest 'from_json() parses values from a string' => sub {
       'logfilter was parsed from JSON';
     eq_or_diff $profile->get( 'test_levels' ), { Zone => { TAG => 'INFO' } }, 'test_levels was parsed from JSON';
     eq_or_diff $profile->get( 'test_cases' ), ['Zone01'], 'test_cases was parsed from JSON';
+    eq_or_diff $profile->get( 'cache.redis' ), { server => '127.0.0.1:6379', expire => 3600 }, 'cache.redis was parsed from JSON';
 };
 
 subtest 'from_json() parses sentinel values from a string' => sub {


### PR DESCRIPTION
## Purpose

Improve our cache implementation to make room to integrate other caching solutions. Provide an optional and experimental global cache layer based on Redis. This can be handy when multiple Zonemaster instances run concurrently (when dealing with batches for instance).

## Context

https://gitlab.rd.nic.fr/zonemaster/zonemaster-engine/-/commit/b96181e460b5824dcd4ac913a3210c458970126a
and
https://gitlab.rd.nic.fr/zonemaster/zonemaster-engine/-/commit/0073398f8a4c47bb6f7f7d8dae8f8a2ddd2694a6

Credits to @blacksponge for the initial proposal

## Changes

* make Cache.pm an interface
* move old Cache.pm logic into a LocalCache module
* new RedisCache module (loaded only if configured in profile.json).

## How to test this PR

1. install Redis and the following perl modules: Redis and Data::MessagePack. For Debian, this can be done with:
     ```
     apt install redis libredis-perl libdata-messagepack-perl
     ```
2. start Redis service
3. modify the profile.json file to specify the Redis server (see `share/profile_additional_properties.json`) :
     ```
     ...
    "cache": {
       "redis": {
          "server": "127.0.0.1:6379",
          "expire": 60
        }
     },
    ...
    ```
4. run the tests or run Zonemaster on a zone to test
5. check that there is data stored in Redis
    ```
    redis-cli KEYS 'ns*'
    ```
