### PR TITLE
Deprecate Zonemaster::Engine::Net::IP module

### DIFF
--- a/lib/Zonemaster/Engine/ASNLookup.pm
+++ b/lib/Zonemaster/Engine/ASNLookup.pm
@@ -7,12 +7,12 @@ use warnings;
 use version; our $VERSION = version->declare( "v1.0.10" );
 
 use Zonemaster::Engine;
-use Zonemaster::Engine::Net::IP;
 use Zonemaster::Engine::Nameserver;
 use Zonemaster::Engine::Profile;
 
 use IO::Socket;
 use IO::Socket::INET;
+use Net::IP::XS;
 
 our @db_sources;
 our $db_style;
@@ -40,8 +40,8 @@ sub get_with_prefix {
         }
     }
 
-    if ( not ref( $ip ) or not $ip->isa( 'Zonemaster::Engine::Net::IP' ) ) {
-        $ip = Zonemaster::Engine::Net::IP->new( $ip );
+    if ( not ref( $ip ) or not $ip->isa( 'Net::IP::XS' ) ) {
+        $ip = Net::IP::XS->new( $ip );
     }
 
     if ( not @db_sources ) {
@@ -113,7 +113,7 @@ sub _cymru_asn_lookup {
                     }
                 }
                 if ( scalar @rr ) {
-                    return \@asns, Zonemaster::Engine::Net::IP->new( $fields[1] ), $str, q{AS_FOUND};
+                    return \@asns, Net::IP::XS->new( $fields[1] ), $str, q{AS_FOUND};
                 }
                 else {
                     if ( $db_source_nb == scalar @db_sources ) {
@@ -173,7 +173,7 @@ sub _ripe_asn_lookup {
         elsif ( $str )  {
             my @fields = split( /\s+/x, $str );
             @asns = ( $fields[0] );
-            return \@asns, Zonemaster::Engine::Net::IP->new( $fields[1] ), $str, q{AS_FOUND};
+            return \@asns, Net::IP::XS->new( $fields[1] ), $str, q{AS_FOUND};
         }
         else {
             return \@asns, undef, q{}, q{EMPTY_ASN_SET};

--- a/lib/Zonemaster/Engine/Constants.pm
+++ b/lib/Zonemaster/Engine/Constants.pm
@@ -10,7 +10,7 @@ use Carp;
 use English qw( -no_match_vars ) ;
 
 use parent 'Exporter';
-use Zonemaster::Engine::Net::IP;
+use Net::IP::XS;
 use Text::CSV;
 use File::ShareDir qw[dist_dir dist_file];
 
@@ -129,7 +129,7 @@ sub _extract_iana_ip_blocks {
             $address_data =~ s/[ ]+//smx;
             foreach my $address_item ( split /,/smx, $address_data ) {
                 $address_item =~ s/(\A.+\/\d+).*\z/$1/smx;
-                push @list, { ip => Zonemaster::Engine::Net::IP->new( $address_item ), name => $fields->[1], reference => $fields->[2] };
+                push @list, { ip => Net::IP::XS->new( $address_item ), name => $fields->[1], reference => $fields->[2] };
             }
         }
         close $data or croak "Cannot close '${data_location}' : ${OS_ERROR}";

--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -11,7 +11,7 @@ use Zonemaster::Engine;
 our %object_cache;
 
 has 'data' => ( is => 'ro', isa => 'HashRef[Maybe[Zonemaster::Engine::Packet]]', default => sub { {} } );
-has 'address' => ( is => 'ro', isa => 'Zonemaster::Engine::Net::IP', required => 1 );
+has 'address' => ( is => 'ro', isa => 'Net::IP::XS', required => 1 );
 
 around 'new' => sub {
     my $orig = shift;
@@ -53,7 +53,7 @@ Zonemaster::Engine::Nameserver::Cache - shared caches for nameserver objects
 
 =item address
 
-A L<Zonemaster::Engine::Net::IP> object holding the nameserver's address.
+A L<Net::IP::XS> object holding the nameserver's address.
 
 =item data
 

--- a/lib/Zonemaster/Engine/Net/IP.pm
+++ b/lib/Zonemaster/Engine/Net/IP.pm
@@ -86,6 +86,9 @@ Zonemaster::Engine::Net::IP - Net::IP::XS Wrapper
 
 =head1 SYNOPSIS
 
+Deprecated module. This module will be removed in v2023.2. Use L<Net::IP::XS>
+instead.
+
     my $ip = Zonemaster::Engine::Net::IP->new( q{0.0.0.0/8} );
 
 =head1 PROCEDURAL INTERFACE

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -13,8 +13,8 @@ use Scalar::Util qw(reftype);
 use File::Slurp;
 use Clone qw(clone);
 use Data::Dumper;
+use Net::IP::XS;
 
-use Zonemaster::Engine::Net::IP;
 use Zonemaster::Engine::Constants qw( $RESOLVER_SOURCE_OS_DEFAULT $DURATION_5_MINUTES_IN_SECONDS $DURATION_1_HOUR_IN_SECONDS $DURATION_4_HOURS_IN_SECONDS $DURATION_12_HOURS_IN_SECONDS $DURATION_1_DAY_IN_SECONDS $DURATION_1_WEEK_IN_SECONDS $DURATION_180_DAYS_IN_SECONDS );
 
 my %profile_properties_details = (
@@ -56,10 +56,7 @@ my %profile_properties_details = (
         type    => q{Str},
         test    => sub {
             if ( $_[0] ne $RESOLVER_SOURCE_OS_DEFAULT ) {
-                eval { Zonemaster::Engine::Net::IP->new( $_[0] ) };
-                if ( $@ ) {
-                    die "Property resolver.source must be an IP address or the exact string $RESOLVER_SOURCE_OS_DEFAULT";
-                }
+                Net::IP::XS->new( $_[0] ) || die "Property resolver.source must be an IP address or the exact string $RESOLVER_SOURCE_OS_DEFAULT";
             }
         }
     },

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -10,10 +10,10 @@ use Class::Accessor "antlers";
 use File::ShareDir qw[dist_file];
 use File::Slurp qw( read_file );
 use JSON::PP;
+use Net::IP::XS;
 
 use Zonemaster::Engine;
 use Zonemaster::Engine::DNSName;
-use Zonemaster::Engine::Net::IP;
 use Zonemaster::Engine::Util qw( name ns parse_hints );
 
 our %recurse_cache;
@@ -327,7 +327,7 @@ sub get_addresses_for {
 
     foreach my $rr ( sort { $a->address cmp $b->address } @rrs ) {
         if ( name( $rr->name ) eq $name or $cname{ $rr->name } ) {
-            push @res, Zonemaster::Engine::Net::IP->new( $rr->address );
+            push @res, Net::IP::XS->new( $rr->address );
         }
     }
     return @res;
@@ -408,7 +408,7 @@ Internal method. Takes a packet and a recursion state and returns a list of ns o
 =head2 get_addresses_for($name[, $state])
 
 Takes a name and returns a (possibly empty) list of IP addresses for
-that name (in the form of L<Zonemaster::Engine::Net::IP> objects). When used
+that name (in the form of L<Net::IP::XS> objects). When used
 internally by the recursor it's passed a recursion state as its second
 argument.
 

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -14,7 +14,6 @@ use Readonly;
 use Zonemaster::Engine::Profile;
 use Zonemaster::Engine::Recursor;
 use Zonemaster::Engine::Constants ':all';
-use Zonemaster::Engine::Net::IP;
 use Zonemaster::Engine::Test::Address;
 use Zonemaster::Engine::Test::Syntax;
 use Zonemaster::Engine::TestMethods;

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -11,13 +11,13 @@ use List::MoreUtils qw[uniq none];
 use Locale::TextDomain qw[Zonemaster-Engine];
 use Readonly;
 use JSON::PP;
+use Net::IP::XS;
 
 use Zonemaster::Engine::Profile;
 use Zonemaster::Engine::Constants qw[:ip];
 use Zonemaster::Engine::Test::Address;
 use Zonemaster::Engine::Util;
 use Zonemaster::Engine::TestMethods;
-use Zonemaster::Engine::Net::IP;
 
 Readonly my @NONEXISTENT_NAMES => qw{
   xn--nameservertest.iis.se
@@ -703,7 +703,7 @@ sub nameserver04 {
 
         my $p = $local_ns->query( $zone->name, q{SOA} );
         if ( $p ) {
-            if ( $p->answerfrom and ( $local_ns->address->short ne Zonemaster::Engine::Net::IP->new( $p->answerfrom )->short ) ) {
+            if ( $p->answerfrom and ( $local_ns->address->short ne Net::IP::XS->new( $p->answerfrom )->short ) ) {
                 push @results,
                   info(
                     DIFFERENT_SOURCE_IP => {
@@ -1211,7 +1211,7 @@ sub nameserver11 {
                 # - Remaining data, if any (i.e., other OPTIONS)
 
                 my @unpacked_opt = eval { unpack("(n n/a)*", $p_opt) };
-                
+
                 while ( my ( $p_opt_code, $p_opt_data, @next_data ) = @unpacked_opt ) {
                     if ( $p_opt_code == $opt_code ) {
                         push @unknown_opt_code, $ns->address->short;

--- a/t/Test-address.t
+++ b/t/Test-address.t
@@ -1,7 +1,7 @@
 use Test::More;
 use File::Slurp;
 
-use Zonemaster::Engine::Net::IP;
+use Net::IP::XS;
 
 BEGIN {
     use_ok( q{Zonemaster::Engine} );
@@ -19,11 +19,10 @@ my $json          = read_file( "t/profiles/Test-address-all.json" );
 my $profile_test  = Zonemaster::Engine::Profile->from_json( $json );
 Zonemaster::Engine::Profile->effective->merge( $profile_test );
 
-
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{0.255.255.255} )
+            Net::IP::XS->new( q{0.255.255.255} )
         )
     ),
     q{bad address 0.255.255.255}
@@ -32,7 +31,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{10.255.255.255} )
+            Net::IP::XS->new( q{10.255.255.255} )
         )
     ),
     q{bad address 10.255.255.255}
@@ -41,7 +40,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.168.255.255} )
+            Net::IP::XS->new( q{192.168.255.255} )
         )
     ),
     q{bad address 192.168.255.255}
@@ -50,7 +49,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{172.17.255.255} )
+            Net::IP::XS->new( q{172.17.255.255} )
         )
     ),
     q{bad address 172.17.255.255}
@@ -59,7 +58,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{100.65.255.255} )
+            Net::IP::XS->new( q{100.65.255.255} )
         )
     ),
     q{bad address 100.65.255.255}
@@ -68,7 +67,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{127.255.255.255} )
+            Net::IP::XS->new( q{127.255.255.255} )
         )
     ),
     q{bad address 127.255.255.255}
@@ -77,7 +76,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{169.254.255.255} )
+            Net::IP::XS->new( q{169.254.255.255} )
         )
     ),
     q{bad address 169.254.255.255}
@@ -86,7 +85,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.0.0.255} )
+            Net::IP::XS->new( q{192.0.0.255} )
         )
     ),
     q{bad address 192.0.0.255}
@@ -95,7 +94,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.0.0.7} )
+            Net::IP::XS->new( q{192.0.0.7} )
         )
     ),
     q{bad address 192.0.0.7}
@@ -104,7 +103,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.0.0.170} )
+            Net::IP::XS->new( q{192.0.0.170} )
         )
     ),
     q{bad address 192.0.0.170}
@@ -113,7 +112,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.0.0.171} )
+            Net::IP::XS->new( q{192.0.0.171} )
         )
     ),
     q{bad address 192.0.0.171}
@@ -122,7 +121,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.0.2.255} )
+            Net::IP::XS->new( q{192.0.2.255} )
         )
     ),
     q{bad address 192.0.2.255}
@@ -131,7 +130,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{198.51.100.255} )
+            Net::IP::XS->new( q{198.51.100.255} )
         )
     ),
     q{bad address 198.51.100.255}
@@ -140,7 +139,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{203.0.113.255} )
+            Net::IP::XS->new( q{203.0.113.255} )
         )
     ),
     q{bad address 203.0.113.255}
@@ -149,7 +148,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.88.99.255} )
+            Net::IP::XS->new( q{192.88.99.255} )
         )
     ),
     q{bad address 192.88.99.255}
@@ -158,7 +157,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{198.19.255.255} )
+            Net::IP::XS->new( q{198.19.255.255} )
         )
     ),
     q{bad address 198.19.255.255}
@@ -167,7 +166,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{240.255.255.255} )
+            Net::IP::XS->new( q{240.255.255.255} )
         )
     ),
     q{bad address 240.255.255.255}
@@ -176,7 +175,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{255.255.255.255} )
+            Net::IP::XS->new( q{255.255.255.255} )
         )
     ),
     q{bad address 255.255.255.255}
@@ -185,7 +184,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{::1} )
+            Net::IP::XS->new( q{::1} )
         )
     ),
     q{bad address ::1}
@@ -194,7 +193,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{::} )
+            Net::IP::XS->new( q{::} )
         )
     ),
     q{bad address ::}
@@ -203,7 +202,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{::ffff:cafe:cafe} )
+            Net::IP::XS->new( q{::ffff:cafe:cafe} )
         )
     ),
     q{bad address ::ffff:cafe:cafe}
@@ -212,7 +211,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{64:ff9b::cafe:cafe} )
+            Net::IP::XS->new( q{64:ff9b::cafe:cafe} )
         )
     ),
     q{bad address 64:ff9b::cafe:cafe}
@@ -221,7 +220,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{100::cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{100::cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address 100::cafe:cafe:cafe:cafe}
@@ -230,7 +229,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address 2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe}
@@ -239,7 +238,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{2001::cafe:cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{2001::cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address 2001::cafe:cafe:cafe:cafe:cafe:cafe}
@@ -248,7 +247,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{2001:2::cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{2001:2::cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address 2001:2::cafe:cafe:cafe:cafe:cafe}
@@ -257,7 +256,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{2001:db8:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{2001:db8:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address 2001:db8:cafe:cafe:cafe:cafe:cafe:cafe}
@@ -266,7 +265,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{2001:1f::cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{2001:1f::cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address 2001:1f::cafe:cafe:cafe:cafe:cafe}
@@ -275,7 +274,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address 2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
@@ -284,7 +283,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
@@ -293,7 +292,7 @@ ok(
 ok(
     defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+            Net::IP::XS->new( q{febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
     q{bad address febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
@@ -304,7 +303,7 @@ SKIP: {
     ok(
         defined(
             Zonemaster::Engine::Test::Address->find_special_address(
-                Zonemaster::Engine::Net::IP->new( q{::cafe:cafe} )
+                Net::IP::XS->new( q{::cafe:cafe} )
             )
         ),
         q{bad address ::cafe:cafe}
@@ -316,7 +315,7 @@ SKIP: {
     ok(
         defined(
             Zonemaster::Engine::Test::Address->find_special_address(
-                Zonemaster::Engine::Net::IP->new( q{5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+                Net::IP::XS->new( q{5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
             )
         ),
         q{bad address 5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
@@ -328,7 +327,7 @@ SKIP: {
     ok(
         defined(
             Zonemaster::Engine::Test::Address->find_special_address(
-                Zonemaster::Engine::Net::IP->new( q{ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
+                Net::IP::XS->new( q{ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
             )
         ),
         q{bad address ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe}
@@ -338,7 +337,7 @@ SKIP: {
 ok(
     !defined(
         Zonemaster::Engine::Test::Address->find_special_address(
-            Zonemaster::Engine::Net::IP->new( q{192.134.4.45} )
+            Net::IP::XS->new( q{192.134.4.45} )
         )
     ),
     q{good address 192.134.4.45}

--- a/t/nameserver.t
+++ b/t/nameserver.t
@@ -17,7 +17,7 @@ my $nsv4 = new_ok( 'Zonemaster::Engine::Nameserver' => [ { name => 'ns.nic.se', 
 eval { Zonemaster::Engine::Nameserver->new( { name => 'dummy' } ); };
 like( $@, qr/Attribute \(address\) is required/, 'create fails without address.' );
 
-isa_ok( $nsv6->address, 'Zonemaster::Engine::Net::IP' );
+isa_ok( $nsv6->address, 'Net::IP::XS' );
 isa_ok( $nsv6->name,    'Zonemaster::Engine::DNSName' );
 is( $nsv6->dns->retry, 2 );
 

--- a/t/recursor.t
+++ b/t/recursor.t
@@ -51,7 +51,7 @@ is( $name, 'iis.se', 'name ok' );
 ok( $packet->no_such_record, 'expected packet content' );
 
 my @addr = Zonemaster::Engine::Recursor->get_addresses_for( 'ns.nic.se' );
-isa_ok( $_, 'Zonemaster::Engine::Net::IP' ) for @addr;
+isa_ok( $_, 'Net::IP::XS' ) for @addr;
 is( $addr[0]->short, '212.247.7.228',      'expected address' );
 is( $addr[1]->short, '2a00:801:f0:53::53', 'expected address' );
 


### PR DESCRIPTION
## Purpose

Replace internal use of Zonemaster::Engine::Net::IP with Net::IP::XS module. And mark Zonemaster::Engine::Net::IP as deprecated.

## Context

#1129 

## Changes

* Internal change
* update documentation with deprecation note

## How to test this PR

* Unit tests should pass.
* No more internal use of the Zonemaster::Engine::Net::IP module