### PR TITLE
New "resolver.source4" and "resolver.source6" properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             build-essential \
             gettext \
             libidn2-dev \
+            liblog-any-perl \
             libssl-dev \
             libtool \
             m4 \

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,7 @@ requires 'File::Slurp'        => 0;
 requires 'IO::Socket::INET6'  => 2.69;
 requires 'List::MoreUtils'    => 0;
 requires 'Locale::TextDomain' => 1.20;
+requires 'Log::Any'           => 0,
 requires 'Module::Find'       => 0.10;
 requires 'Moose'              => 2.0401;
 requires 'MooseX::Singleton'  => 0.30;

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -59,7 +59,7 @@ Zonemaster::Engine, see the [declaration of prerequisites].
 3) Install binary packages:
 
    ```sh
-   sudo dnf --assumeyes install cpanminus gcc libidn2-devel openssl-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Locale-PO perl-Module-Find perl-Module-Install perl-Moose perl-Net-DNS perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple perl-YAML
+   sudo dnf --assumeyes install cpanminus gcc libidn2-devel openssl-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Locale-PO perl-Log-Any perl-Module-Find perl-Module-Install perl-Moose perl-Net-DNS perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple perl-YAML
    ```
 
 4) Install packages from CPAN:
@@ -108,7 +108,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install dependencies from binary packages:
 
    ```sh
-   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl liblocale-po-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
+   sudo apt install autoconf automake build-essential cpanminus libclass-accessor-perl libclone-perl libdevel-checklib-perl libemail-valid-perl libfile-sharedir-perl libfile-slurp-perl libidn2-dev libintl-perl libio-socket-inet6-perl liblist-moreutils-perl liblocale-po-perl liblog-any-perl libmodule-find-perl libmodule-install-perl libmodule-install-xsutil-perl libmoose-perl libmoosex-singleton-perl libnet-dns-perl libnet-ip-xs-perl libpod-coverage-perl libreadonly-perl libssl-dev libtest-differences-perl libtest-exception-perl libtest-fatal-perl libtest-nowarnings-perl libtest-pod-perl libtext-csv-perl libtool m4
    ```
 
 3) Install Zonemaster::LDNS and Zonemaster::Engine.
@@ -154,7 +154,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 5) Install dependencies from binary packages:
 
    ```sh
-   pkg install devel/gmake libidn2 p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-MoreUtils p5-Locale-libintl p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV dns/ldns
+   pkg install devel/gmake libidn2 p5-App-cpanminus p5-Class-Accessor p5-Clone p5-Devel-CheckLib p5-Email-Valid p5-File-ShareDir p5-File-Slurp p5-IO-Socket-INET6 p5-List-MoreUtils p5-Locale-libintl p5-Log-Any p5-Module-Find p5-Module-Install p5-Module-Install-XSUtil p5-Moose p5-MooseX-Singleton p5-Net-DNS p5-Net-IP-XS p5-Pod-Coverage p5-Readonly p5-Test-Differences p5-Test-Exception p5-Test-Fatal p5-Test-NoWarnings p5-Test-Pod p5-Text-CSV dns/ldns
    ```
 
 6) Install Zonemaster::LDNS:
@@ -187,7 +187,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install binary packages:
 
    ```sh
-   sudo yum --assumeyes install cpanminus gcc libidn2-devel openssl-devel openssl11-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Locale-PO perl-Module-Find perl-Module-Install perl-Moose perl-Net-DNS perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple perl-YAML
+   sudo yum --assumeyes install cpanminus gcc libidn2-devel openssl-devel openssl11-devel perl-Class-Accessor perl-Clone perl-core perl-Devel-CheckLib perl-Email-Valid perl-File-ShareDir perl-File-Slurp perl-libintl perl-IO-Socket-INET6 perl-List-MoreUtils perl-Locale-PO perl-Log-Any perl-Module-Find perl-Module-Install perl-Moose perl-Net-DNS perl-Pod-Coverage perl-Readonly perl-Test-Differences perl-Test-Exception perl-Test-Fatal perl-Test-NoWarnings perl-Test-Pod perl-Text-CSV perl-Test-Simple perl-YAML
    ```
 
 3) Install packages from CPAN:

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -14,6 +14,7 @@ use File::Slurp;
 use Clone qw(clone);
 use Data::Dumper;
 use Net::IP::XS;
+use Log::Any qw( $log );
 
 use Zonemaster::Engine::Constants qw( $RESOLVER_SOURCE_OS_DEFAULT $DURATION_5_MINUTES_IN_SECONDS $DURATION_1_HOUR_IN_SECONDS $DURATION_4_HOURS_IN_SECONDS $DURATION_12_HOURS_IN_SECONDS $DURATION_1_DAY_IN_SECONDS $DURATION_1_WEEK_IN_SECONDS $DURATION_180_DAYS_IN_SECONDS );
 
@@ -57,7 +58,7 @@ my %profile_properties_details = (
         default => "$RESOLVER_SOURCE_OS_DEFAULT",
         test    => sub {
             if ( $_[0] ne $RESOLVER_SOURCE_OS_DEFAULT ) {
-                Net::IP::XS->new( $_[0] ) || die "Property resolver.source must be an IP address or the exact string $RESOLVER_SOURCE_OS_DEFAULT";
+                Net::IP::XS->new( $_[0] ) || $log->warning( "Property resolver.source must be an IP address or the exact string $RESOLVER_SOURCE_OS_DEFAULT" );
             }
         }
     },
@@ -66,7 +67,7 @@ my %profile_properties_details = (
         default => "",
         test    => sub {
             if ( $_[0] ne '' and not Net::IP::XS::ip_is_ipv4( $_[0] ) ) {
-                die "Property resolver.source4 must be an IPv4 address or the empty string";
+                $log->warning( "Property resolver.source4 must be an IPv4 address or the empty string" );
             }
             Net::IP::XS->new( $_[0] );
         }
@@ -76,7 +77,7 @@ my %profile_properties_details = (
         default => "",
         test    => sub {
             if ( $_[0] ne '' and not Net::IP::XS::ip_is_ipv6( $_[0] ) ) {
-                die "Property resolver.source6 must be an IPv6 address or the empty string";
+                $log->warning( "Property resolver.source6 must be an IPv6 address or the empty string" );
             }
             Net::IP::XS->new( $_[0] );
         }

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -54,6 +54,7 @@ my %profile_properties_details = (
     },
     q{resolver.source} => {
         type    => q{Str},
+        default => "$RESOLVER_SOURCE_OS_DEFAULT",
         test    => sub {
             if ( $_[0] ne $RESOLVER_SOURCE_OS_DEFAULT ) {
                 Net::IP::XS->new( $_[0] ) || die "Property resolver.source must be an IP address or the exact string $RESOLVER_SOURCE_OS_DEFAULT";
@@ -642,6 +643,8 @@ replay, set this flag to false.
 
 =head2 resolver.source
 
+Deprecated (planned removal: v2024.1).
+Use L</resolver.source4> and L</resolver.source6>.
 A string that is either an IP address or the exact string C<"os_default">.
 The source address all resolver objects should use when sending queries.
 If C<"os_default">, the OS default address is used.

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -60,6 +60,16 @@ my %profile_properties_details = (
             }
         }
     },
+    q{resolver.source4} => {
+        type    => q{Str},
+        default => "",
+        test    => sub {
+            if ( $_[0] ne '' and not Net::IP::XS::ip_is_ipv4( $_[0] ) ) {
+                die "Property resolver.source4 must be an IPv4 address or the empty string";
+            }
+            Net::IP::XS->new( $_[0] );
+        }
+    },
     q{resolver.source6} => {
         type    => q{Str},
         default => "",
@@ -637,11 +647,18 @@ The source address all resolver objects should use when sending queries.
 If C<"os_default">, the OS default address is used.
 Default C<"os_default">.
 
+=head2 resolver.source4
+
+A string that is an IPv4 address or the empty string or undefined.
+The source address all resolver objects should use when sending queries over IPv4.
+If the empty string or undefined, use the OS default IPv4 address if available.
+Default "" (empty string).
+
 =head2 resolver.source6
 
 A string that is an IPv6 address or the empty string or undefined.
 The source address all resolver objects should use when sending queries over IPv6.
-If the empty string of undefinded, use the OS default IPv6 address if available.
+If the empty string or undefined, use the OS default IPv6 address if available.
 Default "" (empty string).
 
 =head2 net.ipv4

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -60,6 +60,16 @@ my %profile_properties_details = (
             }
         }
     },
+    q{resolver.source6} => {
+        type    => q{Str},
+        default => "",
+        test    => sub {
+            if ( $_[0] ne '' and not Net::IP::XS::ip_is_ipv6( $_[0] ) ) {
+                die "Property resolver.source6 must be an IPv6 address or the empty string";
+            }
+            Net::IP::XS->new( $_[0] );
+        }
+    },
     q{net.ipv4} => {
         type    => q{Bool}
     },
@@ -626,6 +636,13 @@ A string that is either an IP address or the exact string C<"os_default">.
 The source address all resolver objects should use when sending queries.
 If C<"os_default">, the OS default address is used.
 Default C<"os_default">.
+
+=head2 resolver.source6
+
+A string that is an IPv6 address or the empty string or undefined.
+The source address all resolver objects should use when sending queries over IPv6.
+If the empty string of undefinded, use the OS default IPv6 address if available.
+Default "" (empty string).
 
 =head2 net.ipv4
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -55,7 +55,6 @@ my %profile_properties_details = (
     },
     q{resolver.source} => {
         type    => q{Str},
-        default => "$RESOLVER_SOURCE_OS_DEFAULT",
         test    => sub {
             if ( $_[0] ne $RESOLVER_SOURCE_OS_DEFAULT ) {
                 Net::IP::XS->new( $_[0] ) || $log->warning( "Property resolver.source must be an IP address or the exact string $RESOLVER_SOURCE_OS_DEFAULT" );
@@ -64,20 +63,18 @@ my %profile_properties_details = (
     },
     q{resolver.source4} => {
         type    => q{Str},
-        default => "",
         test    => sub {
-            if ( $_[0] ne '' and not Net::IP::XS::ip_is_ipv4( $_[0] ) ) {
-                $log->warning( "Property resolver.source4 must be an IPv4 address or the empty string" );
+            if ( $_[0] and $_[0] ne '' and not Net::IP::XS::ip_is_ipv4( $_[0] ) ) {
+                $log->warning( "Property resolver.source4 must be an IPv4 address, the empty string or undefined" );
             }
             Net::IP::XS->new( $_[0] );
         }
     },
     q{resolver.source6} => {
         type    => q{Str},
-        default => "",
         test    => sub {
-            if ( $_[0] ne '' and not Net::IP::XS::ip_is_ipv6( $_[0] ) ) {
-                $log->warning( "Property resolver.source6 must be an IPv6 address or the empty string" );
+            if ( $_[0] and $_[0] ne '' and not Net::IP::XS::ip_is_ipv6( $_[0] ) ) {
+                $log->warning( "Property resolver.source6 must be an IPv6 address, the empty string or undefined" );
             }
             Net::IP::XS->new( $_[0] );
         }
@@ -279,7 +276,16 @@ sub default {
             $new->set( $property_name, $profile_properties_details{$property_name}{default} );
         }
     }
+    $new->check_validity;
     return $new;
+}
+
+sub check_validity {
+    my ( $self ) = @_;
+    my $resolver = $self->{profile}{resolver};
+    if ( exists $resolver->{source} and ( exists $resolver->{source4} or exists $resolver->{source6} ) ) {
+        $log->warning( "Error in profile: 'resolver.source' (deprecated) can't be used in combination with 'resolver.source4' or 'resolver.source6'." );
+    }
 }
 
 sub get {
@@ -381,6 +387,7 @@ sub merge {
             $self->_set( q{JSON}, $property_name, _get_value_from_nested_hash( $other_profile->{q{profile}}, split /[.]/, $property_name ) );
         }
     }
+    $self->check_validity;
     return $other_profile->{q{profile}};
 }
 
@@ -396,6 +403,7 @@ sub from_json {
         }
     }
 
+    $new->check_validity;
     return $new;
 }
 
@@ -515,6 +523,10 @@ section or if the property values are illegal according to the L</PROFILE
 PROPERTIES> section.
 
 =head1 INSTANCE METHODS
+
+=head2 check_validity
+
+Verify that the profile does not allow confusing combinations.
 
 =head2 get
 

--- a/share/profile.json
+++ b/share/profile.json
@@ -23,8 +23,7 @@
             "retry" : 2,
             "usevc" : false,
             "timeout": 5
-        },
-        "source": "os_default"
+        }
     },
     "test_levels" : {
         "ADDRESS" : {

--- a/share/profile_additional_properties.json
+++ b/share/profile_additional_properties.json
@@ -1,5 +1,6 @@
 {
     "resolver" : {
+        "source4": "192.0.2.53",
         "source6": "2001:db8::42"
     },
     "logfilter" : {

--- a/share/profile_additional_properties.json
+++ b/share/profile_additional_properties.json
@@ -1,4 +1,7 @@
 {
+    "resolver" : {
+        "source6": "2001:db8::42"
+    },
     "logfilter" : {
         "BASIC" : {
             "IPV6_ENABLED" : [

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -27,6 +27,7 @@ Readonly my $EXAMPLE_PROFILE_1 => q(
       "retrans": 234
     },
     "source": "192.0.2.53",
+    "source4": "192.0.2.53",
     "source6": "2001:db8::42"
   },
   "net": {
@@ -75,6 +76,7 @@ Readonly my $EXAMPLE_PROFILE_2 => q(
       "retrans": 88
     },
     "source": "198.51.100.53",
+    "source4": "198.51.100.53",
     "source6": "2001:db8::cafe"
   },
   "net": {
@@ -137,6 +139,7 @@ subtest 'new() returns a profile with all properties unset' => sub {
     is $profile->get( 'resolver.defaults.igntc' ),    undef, 'resolver.defaults.igntc is unset';
     is $profile->get( 'resolver.defaults.fallback' ), undef, 'resolver.defaults.fallback is unset';
     is $profile->get( 'resolver.source' ),            undef, 'resolver.source is unset';
+    is $profile->get( 'resolver.source4' ),           undef, 'resolver.source4 is unset';
     is $profile->get( 'resolver.source6' ),           undef, 'resolver.source6 is unset';
     is $profile->get( 'net.ipv4' ),                   undef, 'net.ipv4 is unset';
     is $profile->get( 'net.ipv6' ),                   undef, 'net.ipv6 is unset';
@@ -171,6 +174,7 @@ subtest 'default() returns a profile with all properties set' => sub {
     ok defined( $profile->get( 'resolver.defaults.retry' ) ),    'resolver.defaults.retry is set';
     ok defined( $profile->get( 'resolver.defaults.retrans' ) ),  'resolver.defaults.retrans is set';
     ok defined( $profile->get( 'resolver.source' ) ),            'resolver.source is set';
+    ok defined( $profile->get( 'resolver.source4' ) ),           'resolver.source4 is set';
     ok defined( $profile->get( 'resolver.source6' ) ),           'resolver.source6 is set';
     ok defined( $profile->get( 'logfilter' ) ),                  'logfilter is set';
     ok defined( $profile->get( 'test_levels' ) ),                'test_levels is set';
@@ -200,6 +204,7 @@ subtest 'from_json("{}") returns a profile with all properties unset' => sub {
     is $profile->get( 'resolver.defaults.retry' ),    undef, 'resolver.defaults.retry is unset';
     is $profile->get( 'resolver.defaults.retrans' ),  undef, 'resolver.defaults.retrans is unset';
     is $profile->get( 'resolver.source' ),            undef, 'resolver.source is unset';
+    is $profile->get( 'resolver.source4' ),           undef, 'resolver.source4 is unset';
     is $profile->get( 'resolver.source6' ),           undef, 'resolver.source6 is unset';
     is $profile->get( 'asnroots' ),                   undef, 'asnroots is unset';
     is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
@@ -221,6 +226,7 @@ subtest 'from_json() parses values from a string' => sub {
     is $profile->get( 'resolver.defaults.retry' ),    123,          'resolver.defaults.retry was parsed from JSON';
     is $profile->get( 'resolver.defaults.retrans' ),  234,          'resolver.defaults.retrans was parsed from JSON';
     is $profile->get( 'resolver.source' ),            '192.0.2.53', 'resolver.source was parsed from JSON';
+    is $profile->get( 'resolver.source4' ),           '192.0.2.53', 'resolver.source4 was parsed from JSON';
     is $profile->get( 'resolver.source6' ),           '2001:db8::42', 'resolver.source6 was parsed from JSON';
     eq_or_diff $profile->get( 'asnroots' ), ['example.com'], 'asnroots was parsed from JSON';
     eq_or_diff $profile->get( 'logfilter' ), { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } },
@@ -260,6 +266,8 @@ subtest 'from_json() dies on illegal values' => sub {
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":256}}}' ); } "checks upper bound of resolver.defaults.retrans";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":1.5}}}' ); } "checks type of resolver.defaults.retrans";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source":"example.com"}}' ); }     "checks type of resolver.source";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source4":"example.com"}}' ); }    "checks type of resolver.source4";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source4":"2001:db8::42"}}' ); }   "checks type of resolver.source4 (only IPv4)";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"example.com"}}' ); }    "checks type of resolver.source6";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"192.0.2.53"}}' ); }     "checks type of resolver.source6 (only IPv6)";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"asnroots":["noreply@example.com"]}' ); }      "checks type of asnroots";
@@ -377,6 +385,7 @@ subtest 'set() inserts values for unset properties' => sub {
     $profile->set( 'resolver.defaults.retry',    123 );
     $profile->set( 'resolver.defaults.retrans',  234 );
     $profile->set( 'resolver.source',            '192.0.2.53' );
+    $profile->set( 'resolver.source4',           '192.0.2.53' );
     $profile->set( 'resolver.source6',           '2001:db8::42' );
     $profile->set( 'asnroots', ['example.com'] );
     $profile->set( 'logfilter', { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } } );
@@ -394,6 +403,7 @@ subtest 'set() inserts values for unset properties' => sub {
     is $profile->get( 'resolver.defaults.retry' ),    123, 'resolver.defaults.retry can be given a value when unset';
     is $profile->get( 'resolver.defaults.retrans' ),  234, 'resolver.defaults.retrans can be given a value when unset';
     is $profile->get( 'resolver.source' ),            '192.0.2.53', 'resolver.source can be given a value when unset';
+    is $profile->get( 'resolver.source4' ),           '192.0.2.53', 'resolver.source4 can be given a value when unset';
     is $profile->get( 'resolver.source6' ),           '2001:db8::42', 'resolver.source6 can be given a value when unset';
     eq_or_diff $profile->get( 'asnroots' ), ['example.com'], 'anroots can be given a value when unset';
     eq_or_diff $profile->get( 'logfilter' ), { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } },
@@ -417,6 +427,7 @@ subtest 'set() updates values for set properties' => sub {
     $profile->set( 'resolver.defaults.retry',    99 );
     $profile->set( 'resolver.defaults.retrans',  88 );
     $profile->set( 'resolver.source',            '198.51.100.53' );
+    $profile->set( 'resolver.source4',           '198.51.100.53' );
     $profile->set( 'resolver.source6',            '2001:db8::cafe' );
     $profile->set( 'asnroots', [ 'asn1.example.com', 'asn2.example.com' ] );
     $profile->set( 'logfilter', { Nameserver => { OTHER_TAG => [ { when => { apples => 1 }, set => 'INFO' } ] } } );
@@ -433,6 +444,7 @@ subtest 'set() updates values for set properties' => sub {
     is $profile->get( 'resolver.defaults.retry' ),   99,              'resolver.defaults.retry was updated';
     is $profile->get( 'resolver.defaults.retrans' ), 88,              'resolver.defaults.retrans was updated';
     is $profile->get( 'resolver.source' ),           '198.51.100.53', 'resolver.source was updated';
+    is $profile->get( 'resolver.source4' ),          '198.51.100.53', 'resolver.source4 was updated';
     is $profile->get( 'resolver.source6' ),          '2001:db8::cafe', 'resolver.source6 was updated';
     eq_or_diff $profile->get( 'asnroots' ), [ 'asn1.example.com', 'asn2.example.com' ], 'asnroots was updated';
     eq_or_diff $profile->get( 'logfilter' ),
@@ -455,7 +467,8 @@ subtest 'set() dies on attempts to unset properties' => sub {
     throws_ok { $profile->set( 'resolver.defaults.retry',    undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.retry';
     throws_ok { $profile->set( 'resolver.defaults.retrans',  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.retans';
     throws_ok { $profile->set( 'resolver.source',            undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source';
-    throws_ok { $profile->set( 'resolver.source6',            undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source6';
+    throws_ok { $profile->set( 'resolver.source4',           undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source4';
+    throws_ok { $profile->set( 'resolver.source6',           undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source6';
     throws_ok { $profile->set( 'asnroots',                   undef ); } qr/^.* can not be undef/, 'dies on attempt to unset asnroots';
     throws_ok { $profile->set( 'logfilter',                  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset logfilter';
     throws_ok { $profile->set( 'test_levels',                undef ); } qr/^.* can not be undef/, 'dies on attempt to unset test_levels';
@@ -489,6 +502,7 @@ subtest 'set() dies on illegal value' => sub {
     dies_ok { $profile->set( 'resolver.defaults.retrans', 256 ); } 'checks upper bound of resolver.defaults.retrans';
     dies_ok { $profile->set( 'resolver.defaults.retrans', 1.5 ); } 'checks type of resolver.defaults.retrans';
     dies_ok { $profile->set( 'resolver.source', ['192.0.2.53'] ); } 'checks type of resolver.source';
+    dies_ok { $profile->set( 'resolver.source4', ['192.0.2.53'] ); } 'checks type of resolver.source4';
     dies_ok { $profile->set( 'resolver.source6', ['2001:db8::42'] ); } 'checks type of resolver.source6';
     dies_ok { $profile->set( 'asnroots',        ['noreply@example.com'] ); } 'checks type of asnroots';
     dies_ok { $profile->set( 'logfilter',       [] ); } 'checks type of logfilter';
@@ -501,6 +515,9 @@ subtest 'set() accepts sentinel values' => sub {
 
     $profile->set( 'resolver.source', $RESOLVER_SOURCE_OS_DEFAULT );
     is $profile->get( 'resolver.source' ), $RESOLVER_SOURCE_OS_DEFAULT, 'resolver.source was updated';
+
+    $profile->set( 'resolver.source4', '' );
+    is $profile->get( 'resolver.source4' ), '', 'resolver.source4 was updated';
 
     $profile->set( 'resolver.source6', '' );
     is $profile->get( 'resolver.source6' ), '', 'resolver.source6 was updated';
@@ -558,6 +575,7 @@ subtest 'merge() with a profile with all properties unset' => sub {
     is $profile1->get( 'resolver.defaults.retry' ),    123,          'keeps value of resolver.defaults.retry';
     is $profile1->get( 'resolver.defaults.retrans' ),  234,          'keeps value of resolver.defaults.retrans';
     is $profile1->get( 'resolver.source' ),            '192.0.2.53', 'keeps value of resolver.source';
+    is $profile1->get( 'resolver.source4' ),           '192.0.2.53', 'keeps value of resolver.source4';
     is $profile1->get( 'resolver.source6' ),           '2001:db8::42', 'keeps value of resolver.source6';
     eq_or_diff $profile1->get( 'asnroots' ), ['example.com'], 'keeps value of asnroots';
     eq_or_diff $profile1->get( 'logfilter' ), { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } },
@@ -583,6 +601,7 @@ subtest 'merge() with a profile with all properties set' => sub {
     is $profile1->get( 'resolver.defaults.retry' ),    99,              'updates resolver.defaults.retry';
     is $profile1->get( 'resolver.defaults.retrans' ),  88,              'updates resolver.defaults.retrans';
     is $profile1->get( 'resolver.source' ),            '198.51.100.53', 'updates resolver.source';
+    is $profile1->get( 'resolver.source4' ),           '198.51.100.53', 'updates resolver.source4';
     is $profile1->get( 'resolver.source6' ),           '2001:db8::cafe', 'updates resolver.source6';
     eq_or_diff $profile1->get( 'asnroots' ), [ 'asn1.example.com', 'asn2.example.com' ], 'updates asnroots';
     eq_or_diff $profile1->get( 'logfilter' ),
@@ -605,6 +624,7 @@ subtest 'merge() does not update the other profile' => sub {
     is $profile2->get( 'resolver.defaults.igntc' ),    undef, 'resolver.defaults.igntc was untouched in other';
     is $profile2->get( 'resolver.defaults.fallback' ), undef, 'resolver.defaults.fallback was untouched in other';
     is $profile2->get( 'resolver.source' ),            undef, 'resolver.source was untouched in other';
+    is $profile2->get( 'resolver.source4' ),           undef, 'resolver.source was untouched in other4';
     is $profile2->get( 'resolver.source6' ),           undef, 'resolver.source6 was untouched in other';
     is $profile2->get( 'net.ipv4' ),                   undef, 'net.ipv4 was untouched in other';
     is $profile2->get( 'net.ipv6' ),                   undef, 'net.ipv6 was untouched in other';
@@ -722,6 +742,25 @@ subtest 'to_json() serializes each property' => sub {
         my $json = $profile->to_json;
 
         eq_or_diff decode_json( $json ), decode_json( qq({"resolver":{"source":"$RESOLVER_SOURCE_OS_DEFAULT"}}) );
+    };
+
+
+    subtest 'resolver.source4' => sub {
+        my $profile = Zonemaster::Engine::Profile->new;
+        $profile->set( 'resolver.source4', '192.0.2.53' );
+
+        my $json = $profile->to_json;
+
+        eq_or_diff decode_json( $json ), decode_json( '{"resolver":{"source4":"192.0.2.53"}}' );
+    };
+
+    subtest 'resolver.source4 sentinel value' => sub {
+        my $profile = Zonemaster::Engine::Profile->new;
+        $profile->set( 'resolver.source4', '' );
+
+        my $json = $profile->to_json;
+
+        eq_or_diff decode_json( $json ), decode_json( qq({"resolver":{"source4":""}}) );
     };
 
     subtest 'resolver.source6' => sub {

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -1,7 +1,7 @@
 use 5.006;
 use strict;
 use warnings FATAL   => 'all';
-use Test::More tests => 30;
+use Test::More tests => 31;
 use Log::Any::Test;    # Must come before use Log::Any
 
 use JSON::PP;
@@ -140,9 +140,6 @@ subtest 'new() returns a profile with all properties unset' => sub {
     is $profile->get( 'resolver.defaults.retry' ),    undef, 'resolver.defaults.retry is unset';
     is $profile->get( 'resolver.defaults.igntc' ),    undef, 'resolver.defaults.igntc is unset';
     is $profile->get( 'resolver.defaults.fallback' ), undef, 'resolver.defaults.fallback is unset';
-    is $profile->get( 'resolver.source' ),            undef, 'resolver.source is unset';
-    is $profile->get( 'resolver.source4' ),           undef, 'resolver.source4 is unset';
-    is $profile->get( 'resolver.source6' ),           undef, 'resolver.source6 is unset';
     is $profile->get( 'net.ipv4' ),                   undef, 'net.ipv4 is unset';
     is $profile->get( 'net.ipv6' ),                   undef, 'net.ipv6 is unset';
     is $profile->get( 'no_network' ),                 undef, 'no_network is unset';
@@ -175,9 +172,6 @@ subtest 'default() returns a profile with all properties set' => sub {
     ok defined( $profile->get( 'no_network' ) ),                 'no_network is set';
     ok defined( $profile->get( 'resolver.defaults.retry' ) ),    'resolver.defaults.retry is set';
     ok defined( $profile->get( 'resolver.defaults.retrans' ) ),  'resolver.defaults.retrans is set';
-    ok defined( $profile->get( 'resolver.source' ) ),            'resolver.source is set';
-    ok defined( $profile->get( 'resolver.source4' ) ),           'resolver.source4 is set';
-    ok defined( $profile->get( 'resolver.source6' ) ),           'resolver.source6 is set';
     ok defined( $profile->get( 'logfilter' ) ),                  'logfilter is set';
     ok defined( $profile->get( 'test_levels' ) ),                'test_levels is set';
     ok defined( $profile->get( 'test_cases' ) ),                 'test_cases is set';
@@ -241,6 +235,12 @@ subtest 'from_json() parses sentinel values from a string' => sub {
     my $profile = Zonemaster::Engine::Profile->from_json( $EXAMPLE_PROFILE_3 );
 
     is $profile->get( 'resolver.source' ), $RESOLVER_SOURCE_OS_DEFAULT, 'resolver.source was parsed from JSON';
+};
+
+subtest 'from_json() emits warnings on profile validity' => sub {
+    $log->clear();
+    my $profile = Zonemaster::Engine::Profile->from_json( $EXAMPLE_PROFILE_1 );
+    $log->contains_ok( qr/resolver\.source.*can't be used/, 'warning with confusing configuration' );
 };
 
 subtest 'from_json() dies on illegal paths' => sub {

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -26,7 +26,8 @@ Readonly my $EXAMPLE_PROFILE_1 => q(
       "retry": 123,
       "retrans": 234
     },
-    "source": "192.0.2.53"
+    "source": "192.0.2.53",
+    "source6": "2001:db8::42"
   },
   "net": {
     "ipv4": true,
@@ -73,7 +74,8 @@ Readonly my $EXAMPLE_PROFILE_2 => q(
       "retry": 99,
       "retrans": 88
     },
-    "source": "198.51.100.53"
+    "source": "198.51.100.53",
+    "source6": "2001:db8::cafe"
   },
   "net": {
     "ipv4": false,
@@ -135,6 +137,7 @@ subtest 'new() returns a profile with all properties unset' => sub {
     is $profile->get( 'resolver.defaults.igntc' ),    undef, 'resolver.defaults.igntc is unset';
     is $profile->get( 'resolver.defaults.fallback' ), undef, 'resolver.defaults.fallback is unset';
     is $profile->get( 'resolver.source' ),            undef, 'resolver.source is unset';
+    is $profile->get( 'resolver.source6' ),           undef, 'resolver.source6 is unset';
     is $profile->get( 'net.ipv4' ),                   undef, 'net.ipv4 is unset';
     is $profile->get( 'net.ipv6' ),                   undef, 'net.ipv6 is unset';
     is $profile->get( 'no_network' ),                 undef, 'no_network is unset';
@@ -168,6 +171,7 @@ subtest 'default() returns a profile with all properties set' => sub {
     ok defined( $profile->get( 'resolver.defaults.retry' ) ),    'resolver.defaults.retry is set';
     ok defined( $profile->get( 'resolver.defaults.retrans' ) ),  'resolver.defaults.retrans is set';
     ok defined( $profile->get( 'resolver.source' ) ),            'resolver.source is set';
+    ok defined( $profile->get( 'resolver.source6' ) ),           'resolver.source6 is set';
     ok defined( $profile->get( 'logfilter' ) ),                  'logfilter is set';
     ok defined( $profile->get( 'test_levels' ) ),                'test_levels is set';
     ok defined( $profile->get( 'test_cases' ) ),                 'test_cases is set';
@@ -196,6 +200,7 @@ subtest 'from_json("{}") returns a profile with all properties unset' => sub {
     is $profile->get( 'resolver.defaults.retry' ),    undef, 'resolver.defaults.retry is unset';
     is $profile->get( 'resolver.defaults.retrans' ),  undef, 'resolver.defaults.retrans is unset';
     is $profile->get( 'resolver.source' ),            undef, 'resolver.source is unset';
+    is $profile->get( 'resolver.source6' ),           undef, 'resolver.source6 is unset';
     is $profile->get( 'asnroots' ),                   undef, 'asnroots is unset';
     is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
     is $profile->get( 'test_levels' ),                undef, 'test_levels is unset';
@@ -216,6 +221,7 @@ subtest 'from_json() parses values from a string' => sub {
     is $profile->get( 'resolver.defaults.retry' ),    123,          'resolver.defaults.retry was parsed from JSON';
     is $profile->get( 'resolver.defaults.retrans' ),  234,          'resolver.defaults.retrans was parsed from JSON';
     is $profile->get( 'resolver.source' ),            '192.0.2.53', 'resolver.source was parsed from JSON';
+    is $profile->get( 'resolver.source6' ),           '2001:db8::42', 'resolver.source6 was parsed from JSON';
     eq_or_diff $profile->get( 'asnroots' ), ['example.com'], 'asnroots was parsed from JSON';
     eq_or_diff $profile->get( 'logfilter' ), { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } },
       'logfilter was parsed from JSON';
@@ -266,6 +272,10 @@ subtest 'from_json() dies on illegal values' => sub {
     "checks type of resolver.defaults.retrans";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source":"example.com"}}' ); }
     "checks type of resolver.source";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"example.com"}}' ); }
+    "checks type of resolver.source6";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"192.0.2.53"}}' ); }
+    "checks type of resolver.source6 (only IPv6)";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"asnroots":["noreply@example.com"]}' ); }
     "checks type of asnroots";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"logfilter":[]}' ); } "checks type of logfilter";
@@ -382,6 +392,7 @@ subtest 'set() inserts values for unset properties' => sub {
     $profile->set( 'resolver.defaults.retry',    123 );
     $profile->set( 'resolver.defaults.retrans',  234 );
     $profile->set( 'resolver.source',            '192.0.2.53' );
+    $profile->set( 'resolver.source6',           '2001:db8::42' );
     $profile->set( 'asnroots', ['example.com'] );
     $profile->set( 'logfilter', { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } } );
     $profile->set( 'test_levels', { Zone => { TAG => 'INFO' } } );
@@ -398,6 +409,7 @@ subtest 'set() inserts values for unset properties' => sub {
     is $profile->get( 'resolver.defaults.retry' ),    123, 'resolver.defaults.retry can be given a value when unset';
     is $profile->get( 'resolver.defaults.retrans' ),  234, 'resolver.defaults.retrans can be given a value when unset';
     is $profile->get( 'resolver.source' ),            '192.0.2.53', 'resolver.source can be given a value when unset';
+    is $profile->get( 'resolver.source6' ),           '2001:db8::42', 'resolver.source6 can be given a value when unset';
     eq_or_diff $profile->get( 'asnroots' ), ['example.com'], 'anroots can be given a value when unset';
     eq_or_diff $profile->get( 'logfilter' ), { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } },
       'logfilter can be given a value when unset';
@@ -420,6 +432,7 @@ subtest 'set() updates values for set properties' => sub {
     $profile->set( 'resolver.defaults.retry',    99 );
     $profile->set( 'resolver.defaults.retrans',  88 );
     $profile->set( 'resolver.source',            '198.51.100.53' );
+    $profile->set( 'resolver.source6',            '2001:db8::cafe' );
     $profile->set( 'asnroots', [ 'asn1.example.com', 'asn2.example.com' ] );
     $profile->set( 'logfilter', { Nameserver => { OTHER_TAG => [ { when => { apples => 1 }, set => 'INFO' } ] } } );
     $profile->set( 'test_levels', { Nameserver => { OTHER_TAG => 'ERROR' } } );
@@ -435,6 +448,7 @@ subtest 'set() updates values for set properties' => sub {
     is $profile->get( 'resolver.defaults.retry' ),   99,              'resolver.defaults.retry was updated';
     is $profile->get( 'resolver.defaults.retrans' ), 88,              'resolver.defaults.retrans was updated';
     is $profile->get( 'resolver.source' ),           '198.51.100.53', 'resolver.source was updated';
+    is $profile->get( 'resolver.source6' ),          '2001:db8::cafe', 'resolver.source6 was updated';
     eq_or_diff $profile->get( 'asnroots' ), [ 'asn1.example.com', 'asn2.example.com' ], 'asnroots was updated';
     eq_or_diff $profile->get( 'logfilter' ),
       { Nameserver => { OTHER_TAG => [ { when => { apples => 1 }, set => 'INFO' } ] } }, 'logfilter was updated';
@@ -456,6 +470,7 @@ subtest 'set() dies on attempts to unset properties' => sub {
     throws_ok { $profile->set( 'resolver.defaults.retry',    undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.retry';
     throws_ok { $profile->set( 'resolver.defaults.retrans',  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.retans';
     throws_ok { $profile->set( 'resolver.source',            undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source';
+    throws_ok { $profile->set( 'resolver.source6',            undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source6';
     throws_ok { $profile->set( 'asnroots',                   undef ); } qr/^.* can not be undef/, 'dies on attempt to unset asnroots';
     throws_ok { $profile->set( 'logfilter',                  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset logfilter';
     throws_ok { $profile->set( 'test_levels',                undef ); } qr/^.* can not be undef/, 'dies on attempt to unset test_levels';
@@ -489,6 +504,7 @@ subtest 'set() dies on illegal value' => sub {
     dies_ok { $profile->set( 'resolver.defaults.retrans', 256 ); } 'checks upper bound of resolver.defaults.retrans';
     dies_ok { $profile->set( 'resolver.defaults.retrans', 1.5 ); } 'checks type of resolver.defaults.retrans';
     dies_ok { $profile->set( 'resolver.source', ['192.0.2.53'] ); } 'checks type of resolver.source';
+    dies_ok { $profile->set( 'resolver.source6', ['2001:db8::42'] ); } 'checks type of resolver.source6';
     dies_ok { $profile->set( 'asnroots',        ['noreply@example.com'] ); } 'checks type of asnroots';
     dies_ok { $profile->set( 'logfilter',       [] ); } 'checks type of logfilter';
     dies_ok { $profile->set( 'test_levels',     [] ); } 'checks type of test_levels';
@@ -499,8 +515,10 @@ subtest 'set() accepts sentinel values' => sub {
     my $profile = Zonemaster::Engine::Profile->new;
 
     $profile->set( 'resolver.source', $RESOLVER_SOURCE_OS_DEFAULT );
-
     is $profile->get( 'resolver.source' ), $RESOLVER_SOURCE_OS_DEFAULT, 'resolver.source was updated';
+
+    $profile->set( 'resolver.source6', '' );
+    is $profile->get( 'resolver.source6' ), '', 'resolver.source6 was updated';
 };
 
 subtest 'set() uses standard truthiness rules for boolean properties' => sub {
@@ -555,6 +573,7 @@ subtest 'merge() with a profile with all properties unset' => sub {
     is $profile1->get( 'resolver.defaults.retry' ),    123,          'keeps value of resolver.defaults.retry';
     is $profile1->get( 'resolver.defaults.retrans' ),  234,          'keeps value of resolver.defaults.retrans';
     is $profile1->get( 'resolver.source' ),            '192.0.2.53', 'keeps value of resolver.source';
+    is $profile1->get( 'resolver.source6' ),           '2001:db8::42', 'keeps value of resolver.source6';
     eq_or_diff $profile1->get( 'asnroots' ), ['example.com'], 'keeps value of asnroots';
     eq_or_diff $profile1->get( 'logfilter' ), { Zone => { TAG => [ { when => { bananas => 0 }, set => 'WARNING' } ] } },
       'keeps value of logfilter';
@@ -579,6 +598,7 @@ subtest 'merge() with a profile with all properties set' => sub {
     is $profile1->get( 'resolver.defaults.retry' ),    99,              'updates resolver.defaults.retry';
     is $profile1->get( 'resolver.defaults.retrans' ),  88,              'updates resolver.defaults.retrans';
     is $profile1->get( 'resolver.source' ),            '198.51.100.53', 'updates resolver.source';
+    is $profile1->get( 'resolver.source6' ),           '2001:db8::cafe', 'updates resolver.source6';
     eq_or_diff $profile1->get( 'asnroots' ), [ 'asn1.example.com', 'asn2.example.com' ], 'updates asnroots';
     eq_or_diff $profile1->get( 'logfilter' ),
       { Nameserver => { OTHER_TAG => [ { when => { apples => 1 }, set => 'INFO' } ] } }, 'updates logfilter';
@@ -600,6 +620,7 @@ subtest 'merge() does not update the other profile' => sub {
     is $profile2->get( 'resolver.defaults.igntc' ),    undef, 'resolver.defaults.igntc was untouched in other';
     is $profile2->get( 'resolver.defaults.fallback' ), undef, 'resolver.defaults.fallback was untouched in other';
     is $profile2->get( 'resolver.source' ),            undef, 'resolver.source was untouched in other';
+    is $profile2->get( 'resolver.source6' ),           undef, 'resolver.source6 was untouched in other';
     is $profile2->get( 'net.ipv4' ),                   undef, 'net.ipv4 was untouched in other';
     is $profile2->get( 'net.ipv6' ),                   undef, 'net.ipv6 was untouched in other';
     is $profile2->get( 'no_network' ),                 undef, 'no_network was untouched in other';
@@ -716,6 +737,24 @@ subtest 'to_json() serializes each property' => sub {
         my $json = $profile->to_json;
 
         eq_or_diff decode_json( $json ), decode_json( qq({"resolver":{"source":"$RESOLVER_SOURCE_OS_DEFAULT"}}) );
+    };
+
+    subtest 'resolver.source6' => sub {
+        my $profile = Zonemaster::Engine::Profile->new;
+        $profile->set( 'resolver.source6', '2001:db8::42' );
+
+        my $json = $profile->to_json;
+
+        eq_or_diff decode_json( $json ), decode_json( '{"resolver":{"source6":"2001:db8::42"}}' );
+    };
+
+    subtest 'resolver.source6 sentinel value' => sub {
+        my $profile = Zonemaster::Engine::Profile->new;
+        $profile->set( 'resolver.source6', '' );
+
+        my $json = $profile->to_json;
+
+        eq_or_diff decode_json( $json ), decode_json( qq({"resolver":{"source6":""}}) );
     };
 
     subtest 'asnroots' => sub {

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -245,42 +245,27 @@ subtest 'from_json() dies on illegal paths' => sub {
 };
 
 subtest 'from_json() dies on illegal values' => sub {
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"usevc":0}}}' ); }
-    "checks type of resolver.defaults.usevc";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"dnssec":1}}}' ); }
-    "checks type of resolver.defaults.dnssec";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"recurse":0}}}' ); }
-    "checks type of resolver.defaults.recurse";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"igntc":1}}}' ); }
-    "checks type of resolver.defaults.igntc";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"fallback":0}}}' ); }
-    "checks type of resolver.defaults.fallback";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"net":{"ipv4":1}}' ); } "checks type of net.ipv4";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"net":{"ipv6":0}}' ); } "checks type of net.ipv6";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"no_network":1}' ); } "checks type of no_network";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":0}}}' ); }
-    "checks lower bound of resolver.defaults.retry";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":256}}}' ); }
-    "checks upper bound of resolver.defaults.retry";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":1.5}}}' ); }
-    "checks type of resolver.defaults.retry";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":0}}}' ); }
-    "checks lower bound of resolver.defaults.retrans";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":256}}}' ); }
-    "checks upper bound of resolver.defaults.retrans";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":1.5}}}' ); }
-    "checks type of resolver.defaults.retrans";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source":"example.com"}}' ); }
-    "checks type of resolver.source";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"example.com"}}' ); }
-    "checks type of resolver.source6";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"192.0.2.53"}}' ); }
-    "checks type of resolver.source6 (only IPv6)";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"asnroots":["noreply@example.com"]}' ); }
-    "checks type of asnroots";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"logfilter":[]}' ); } "checks type of logfilter";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"test_levels":[]}' ); } "checks type of test_levels";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"test_cases":{}}' ); } "checks type of test_cases";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"usevc":0}}}' ); }     "checks type of resolver.defaults.usevc";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"dnssec":1}}}' ); }    "checks type of resolver.defaults.dnssec";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"recurse":0}}}' ); }   "checks type of resolver.defaults.recurse";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"igntc":1}}}' ); }     "checks type of resolver.defaults.igntc";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"fallback":0}}}' ); }  "checks type of resolver.defaults.fallback";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"net":{"ipv4":1}}' ); }                        "checks type of net.ipv4";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"net":{"ipv6":0}}' ); }                        "checks type of net.ipv6";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"no_network":1}' ); }                          "checks type of no_network";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":0}}}' ); }     "checks lower bound of resolver.defaults.retry";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":256}}}' ); }   "checks upper bound of resolver.defaults.retry";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":1.5}}}' ); }   "checks type of resolver.defaults.retry";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":0}}}' ); }   "checks lower bound of resolver.defaults.retrans";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":256}}}' ); } "checks upper bound of resolver.defaults.retrans";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":1.5}}}' ); } "checks type of resolver.defaults.retrans";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source":"example.com"}}' ); }     "checks type of resolver.source";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"example.com"}}' ); }    "checks type of resolver.source6";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"source6":"192.0.2.53"}}' ); }     "checks type of resolver.source6 (only IPv6)";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"asnroots":["noreply@example.com"]}' ); }      "checks type of asnroots";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"logfilter":[]}' ); }                          "checks type of logfilter";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"test_levels":[]}' ); }                        "checks type of test_levels";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"test_cases":{}}' ); }                         "checks type of test_cases";
 };
 
 subtest 'get() returns 1 for true' => sub {


### PR DESCRIPTION
## Purpose

Provide new properties "resolver.source4" and "resolver.source6" to allow configuring an IPv4 and an IPv6 source address. The "resolver.source" is untouched:

* "resolver.source" can hold an IPv4 or an IPv6 and is marked as deprecated
* "resolver.source4" can only hold an IPv4 (or the empty string) and takes precedence
* "resolver.source6" can only hold an IPv6 (or the empty string) and takes precedence

## Context

zonemaster/zonemaster-cli#315 

## Changes

* Check that if set, the "resolver.source4" property holds an IPv4 (or the empty string)
* Check that if set, the "resolver.source6" property holds an IPv6 (or the empty string)
* If set and querying over IPv4, use the "resolver.source4" value. Fallback to "resolver.source" otherwise.
* If set and querying over IPv6, use the "resolver.source6" value. Fallback to "resolver.source" otherwise.

## How to test this PR

New unit tests are provided. They should pass.

Set "resolver.source4" and/or "resolver.source6" to a value in share/profile.json and check that these interface are correctly used when running Zonemaster.
```
zonemaster-cli --show-testcase --show-module --level DEBUG --test connectivity/connectivity01 zonemaster.net
```