### PR TITLE
Fix RIPE ASN lookup results parsing

### DIFF
--- a/lib/Zonemaster/Engine/ASNLookup.pm
+++ b/lib/Zonemaster/Engine/ASNLookup.pm
@@ -172,7 +172,7 @@ sub _ripe_asn_lookup {
         }
         elsif ( $str )  {
             my @fields = split( /\s+/x, $str );
-            @asns = ( $fields[0] );
+            my @asns   = split( '/',  $fields[0] );
             return \@asns, Net::IP::XS->new( $fields[1] ), $str, q{AS_FOUND};
         }
         else {

--- a/lib/Zonemaster/Engine/ASNLookup.pm
+++ b/lib/Zonemaster/Engine/ASNLookup.pm
@@ -13,6 +13,7 @@ use Zonemaster::Engine::Profile;
 use IO::Socket;
 use IO::Socket::INET;
 use Net::IP::XS;
+use Scalar::Util qw( looks_like_number );
 
 our @db_sources;
 our $db_style;
@@ -48,11 +49,12 @@ sub get_with_prefix {
         die "ASN database sources undefined";
     }
 
+    my ( $asnref, $prefix, $raw );
     if ( $db_style eq q{cymru} ) {
-        return _cymru_asn_lookup($ip);
+        ( $asnref, $prefix, $raw ) = _cymru_asn_lookup($ip);
     }
     elsif ( $db_style eq q{ripe} ) {
-        return _ripe_asn_lookup($ip);
+        ( $asnref, $prefix, $raw ) = _ripe_asn_lookup($ip);
     }
     else {
         if ( not $db_style ) {
@@ -62,6 +64,8 @@ sub get_with_prefix {
             die "ASN database style value [$db_style] is illegal";
         }
     }
+    map { looks_like_number( $_ ) || die "ASN lookup value isn't numeric: '$_'" } @$asnref;
+    return ( $asnref, $prefix, $raw );
 
 } ## end sub get_with_prefix
 


### PR DESCRIPTION
## Purpose

When using RIPE ASN lookup style, the following errors are raised:
```
$ perl -I lib/ -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("CONNECTIVITY", "paris")'
Argument "2484/2486" isn't numeric in sort at lib/Zonemaster/Engine/Test/Connectivity.pm line 482.
Argument "8561/50611/48519" isn't numeric in sort at lib/Zonemaster/Engine/Test/Connectivity.pm line 482.
Argument "8561/50611/48519" isn't numeric in sort at lib/Zonemaster/Engine/Test/Connectivity.pm line 520.
Argument "2486/2484" isn't numeric in sort at lib/Zonemaster/Engine/Test/Connectivity.pm line 520.
Argument "2484/2486" isn't numeric in sort at lib/Zonemaster/Engine/Test/Connectivity.pm line 535.
Argument "8561/50611/48519" isn't numeric in sort at lib/Zonemaster/Engine/Test/Connectivity.pm line 535.
Argument "8561/50611/48519" isn't numeric in sort at lib/Zonemaster/Engine/Test/Connectivity.pm line 537.
...
```
This fixes the parsing of the result from [RISwhois](https://www.ripe.net/analyse/archived-projects/ris-tools-web-interfaces/riswhois)

## Context

n/a

## Changes

ASNLookup.pm

## How to test this PR

Check that there is no more error:
```
perl -I lib/ -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("CONNECTIVITY", "paris")'
```