### PR TITLE
Add DNAME support (to Zone objects)

### DIFF
--- a/lib/Zonemaster/Engine/Constants.pm
+++ b/lib/Zonemaster/Engine/Constants.pm
@@ -3,7 +3,7 @@ package Zonemaster::Engine::Constants;
 use v5.16.0;
 use warnings;
 
-use version; our $VERSION = version->declare("v1.2.5");
+use version; our $VERSION = version->declare("v1.2.6");
 
 use Carp;
 use English qw( -no_match_vars ) ;
@@ -37,6 +37,10 @@ DNSSEC algorithms.
 =item cname
 
 CNAME records.
+
+=item dname
+
+DNAME records.
 
 =item name
 
@@ -73,6 +77,7 @@ our @EXPORT_OK = qw[
   $BLACKLISTING_ENABLED
   $CNAME_MAX_CHAIN_LENGTH
   $CNAME_MAX_RECORDS
+  $DNAME_MAX_RECORDS
   $DURATION_5_MINUTES_IN_SECONDS
   $DURATION_1_HOUR_IN_SECONDS
   $DURATION_4_HOURS_IN_SECONDS
@@ -100,6 +105,7 @@ our %EXPORT_TAGS = (
         qw($ALGO_STATUS_DEPRECATED $ALGO_STATUS_PRIVATE $ALGO_STATUS_RESERVED $ALGO_STATUS_UNASSIGNED $ALGO_STATUS_OTHER $ALGO_STATUS_NOT_ZONE_SIGN $ALGO_STATUS_NOT_RECOMMENDED)
     ],
     cname => [ qw($CNAME_MAX_CHAIN_LENGTH $CNAME_MAX_RECORDS) ],
+    dname => [ qw($DNAME_MAX_RECORDS) ],
     name => [qw($FQDN_MAX_LENGTH $LABEL_MAX_LENGTH)],
     ip   => [qw($IP_VERSION_4 $IP_VERSION_6)],
     soa  => [
@@ -135,6 +141,10 @@ An integer, used to define the maximum length of a CNAME chain when doing consec
 =item * C<$CNAME_MAX_RECORDS>
 
 An integer, used to define the maximum number of CNAME records in a response.
+
+=item * C<$DNAME_MAX_RECORDS>
+
+An integer, used to define the maximum number of DNAME records in a response.
 
 =item * C<$DURATION_5_MINUTES_IN_SECONDS>
 
@@ -194,6 +204,8 @@ Readonly our $BLACKLISTING_ENABLED     => 1;
 
 Readonly our $CNAME_MAX_CHAIN_LENGTH      => 10;
 Readonly our $CNAME_MAX_RECORDS           => 9;
+
+Readonly our $DNAME_MAX_RECORDS           => 9;
 
 Readonly our $DURATION_5_MINUTES_IN_SECONDS  =>             5 * 60;
 Readonly our $DURATION_1_HOUR_IN_SECONDS     =>            60 * 60;


### PR DESCRIPTION
## Purpose

This PR proposes an implementation for the support of DNAME by adding a new attribute to `Zonemaster::Engine::Zone` objects, instead of modifying `Zonemaster::Engine::Recursor`.

This means that this PR does not make recursive lookups of Zonemaster follow DNAME records (similar to #1288 for CNAME), but that querying zone data (e.g glue, name servers, etc) for any name (zone) that is an alias (DNAME) will return the proper data for that zone.

TBD:
- [ ] Discuss this implementation. 
- [ ] Add and update unitary tests, and re-record unit test data

## Context

Relates to https://github.com/zonemaster/zonemaster/issues/1075 and https://github.com/zonemaster/zonemaster/issues/472

Depends on https://github.com/zonemaster/zonemaster-ldns/pull/170

## Changes

 - Add new attribute 'dname' to `Zonemaster::Engine::Zone` objects
 - Update implementation to account for that new attribute and make queries to the appropriate zone name, if any

## How to test this PR

Unit tests are to be created. So far many existing unit tests will fail because of incomplete unit test data (I haven't re-recorded them yet).

Manual testing (zone: `xn--mori-qsa.nz`):
```
$ perl -MZonemaster::Engine -E 'my $zone = Zonemaster::Engine::Zone->new({ name => Zonemaster::Engine::DNSName->from_string("xn--mori-qsa.nz") }); say "zone: ", $zone->name; $zone->dname ? say "dname: ", $zone->dname->name : say "dname: undef"; say "ns:\n\t", join "\n\t", @{$zone->ns} if $zone->dname;'
zone: xn--mori-qsa.nz
dname: maori.nz
ns:
        ns1.dns.net.nz/2001:dce:2000:2::130
        ns1.dns.net.nz/202.46.190.130
        ns2.dns.net.nz/2001:dce:7000:2::130
        ns2.dns.net.nz/202.46.187.130
        ns3.dns.net.nz/2001:dce:d453::53
        ns3.dns.net.nz/202.46.188.130
        ns4.dns.net.nz/2001:dce:d454::53
        ns4.dns.net.nz/202.46.189.130
        ns5.dns.net.nz/185.159.197.130
        ns5.dns.net.nz/2620:10a:80aa::130
        ns6.dns.net.nz/185.159.198.130
        ns6.dns.net.nz/2620:10a:80ab::130
        ns7.dns.net.nz/194.146.106.54
        ns7.dns.net.nz/2001:67c:1010:13::53
```