### PR TITLE
Update Nameserver15

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -287,6 +287,10 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # NAMESERVER:NAMESERVER14
             'Test for unknown version with unknown OPTION-CODE', @_;
     },
+    NAMESERVER15 => sub {
+        __x    # NAMESERVER:NAMESERVER15
+            'Checking for revealed software version', @_;
+    },
     AAAA_BAD_RDATA => sub {
         __x    # NAMESERVER:AAAA_BAD_RDATA
             'Nameserver {ns} answered AAAA query with an unexpected RDATA length ({length} instead of 16).', @_;


### PR DESCRIPTION
## Purpose

This PR adds a missing message tag for the Test Case description of Nameserver15 that was missed in https://github.com/zonemaster/zonemaster-engine/pull/1218.

## Changes
`
lib/Zonemaster/Engine/Test/Nameserver.pm`

- Add missing message tag `NAMESERVER15`

## How to test this PR

```
$ perl -MZonemaster::Engine::Translator -E 'my $translator = Zonemaster::Engine::Translator->new(); say $translator->test_case_description("NAMESERVER15")'
Checking for revealed software version
```