### PR TITLE
Updates for the usage of Zonemaster::Engine::Translator

### DIFF
--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -76,15 +76,15 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     ADDRESS01 => sub {
         __x    # ADDRESS:ADDRESS01
-          'Name server address must be globally routable', @_;
+          'Name server address must be globally routable';
     },
     ADDRESS02 => sub {
         __x    # ADDRESS:ADDRESS02
-          'Reverse DNS entry exists for name server IP address', @_;
+          'Reverse DNS entry exists for name server IP address';
     },
     ADDRESS03 => sub {
         __x    # ADDRESS:ADDRESS03
-          'Reverse DNS entry matches name server name', @_;
+          'Reverse DNS entry matches name server name';
     },
     NAMESERVER_IP_WITHOUT_REVERSE => sub {
         __x    # ADDRESS:NAMESERVER_IP_WITHOUT_REVERSE

--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -134,19 +134,19 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     BASIC00 => sub {
         __x    # BASIC:BASIC00
-          'Domain name must be valid', @_;
+          'Domain name must be valid';
     },
     BASIC01 => sub {
         __x    # BASIC:BASIC01
-          'The domain must have a parent domain', @_;
+          'The domain must have a parent domain';
     },
     BASIC02 => sub {
         __x    # BASIC:BASIC02
-          'The domain must have at least one working name server', @_;
+          'The domain must have at least one working name server';
     },
     BASIC03 => sub {
         __x    # BASIC:BASIC03
-          'The Broken but functional test', @_;
+          'The Broken but functional test';
     },
     A_QUERY_NO_RESPONSES => sub {
         __x    # BASIC:A_QUERY_NO_RESPONSES

--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -127,21 +127,20 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     CONNECTIVITY01 => sub {
         __x    # CONNECTIVITY:CONNECTIVITY01
-          'UDP connectivity', @_;
+          'UDP connectivity';
     },
     CONNECTIVITY02 => sub {
         __x    # CONNECTIVITY:CONNECTIVITY02
-          'TCP connectivity', @_;
+          'TCP connectivity';
     },
     CONNECTIVITY03 => sub {
         __x    # CONNECTIVITY:CONNECTIVITY03
-          'AS Diversity', @_;
+          'AS Diversity';
     },
     CONNECTIVITY04 => sub {
         __x    # CONNECTIVITY:CONNECTIVITY04
-          'IP Prefix Diversity', @_;
+          'IP Prefix Diversity';
     },
-
     CN01_IPV4_DISABLED => sub {
         __x    # CONNECTIVITY:CN01_IPV4_DISABLED
           'IPv4 is disabled. No DNS queries are sent to these name servers: "{ns_list}".', @_;
@@ -332,7 +331,6 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # CONNECTIVITY:ASN_INFOS_ANNOUNCE_IN
           'Name server IP address "{ns_ip}" is announced in prefix "{prefix}".', @_;
     },
-
     TEST_CASE_END => sub {
         __x    # CONNECTIVITY:TEST_CASE_END
           'TEST_CASE_END {testcase}.', @_;

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -138,27 +138,27 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     CONSISTENCY01 => sub {
         __x    # CONSISTENCY:CONSISTENCY01
-          'SOA serial number consistency', @_;
+          'SOA serial number consistency';
     },
     CONSISTENCY02 => sub {
         __x    # CONSISTENCY:CONSISTENCY02
-          'SOA RNAME consistency', @_;
+          'SOA RNAME consistency';
     },
     CONSISTENCY03 => sub {
         __x    # CONSISTENCY:CONSISTENCY03
-          'SOA timers consistency', @_;
+          'SOA timers consistency';
     },
     CONSISTENCY04 => sub {
         __x    # CONSISTENCY:CONSISTENCY04
-          'Name server NS consistency', @_;
+          'Name server NS consistency';
     },
     CONSISTENCY05 => sub {
         __x    # CONSISTENCY:CONSISTENCY05
-          'Consistency between glue and authoritative data', @_;
+          'Consistency between glue and authoritative data';
     },
     CONSISTENCY06 => sub {
         __x    # CONSISTENCY:CONSISTENCY06
-          'SOA MNAME consistency', @_;
+          'SOA MNAME consistency';
     },
     ADDRESSES_MATCH => sub {
         __x    # CONSISTENCY:ADDRESSES_MATCH

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -515,75 +515,75 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     DNSSEC01 => sub {
         __x    # DNSSEC:DNSSEC01
-          "Legal values for the DS hash digest algorithm", @_;
+          "Legal values for the DS hash digest algorithm";
     },
     DNSSEC02 => sub {
         __x    # DNSSEC:DNSSEC02
-          "DS must match a valid DNSKEY in the child zone", @_;
+          "DS must match a valid DNSKEY in the child zone";
     },
     DNSSEC03 => sub {
         __x    # DNSSEC:DNSSEC03
-          "Check for too many NSEC3 iterations", @_;
+          "Check for too many NSEC3 iterations";
     },
     DNSSEC04 => sub {
         __x    # DNSSEC:DNSSEC04
-          "Check for too short or too long RRSIG lifetimes", @_;
+          "Check for too short or too long RRSIG lifetimes";
     },
     DNSSEC05 => sub {
         __x    # DNSSEC:DNSSEC05
-          "Check for invalid DNSKEY algorithms", @_;
+          "Check for invalid DNSKEY algorithms";
     },
     DNSSEC06 => sub {
         __x    # DNSSEC:DNSSEC06
-          "Verify DNSSEC additional processing", @_;
+          "Verify DNSSEC additional processing";
     },
     DNSSEC07 => sub {
         __x    # DNSSEC:DNSSEC07
-          "If DNSKEY at child, parent should have DS", @_;
+          "If DNSKEY at child, parent should have DS";
     },
     DNSSEC08 => sub {
         __x    # DNSSEC:DNSSEC08
-          "Valid RRSIG for DNSKEY", @_;
+          "Valid RRSIG for DNSKEY";
     },
     DNSSEC09 => sub {
         __x    # DNSSEC:DNSSEC09
-          "RRSIG(SOA) must be valid and created by a valid DNSKEY", @_;
+          "RRSIG(SOA) must be valid and created by a valid DNSKEY";
     },
     DNSSEC10 => sub {
         __x    # DNSSEC:DNSSEC10
-          "Zone contains NSEC or NSEC3 records", @_;
+          "Zone contains NSEC or NSEC3 records";
     },
     DNSSEC11 => sub {
         __x    # DNSSEC:DNSSEC11
-          "DS in delegation requires signed zone", @_;
+          "DS in delegation requires signed zone";
     },
     DNSSEC12 => sub {
         __x    # DNSSEC:DNSSEC12
-          "Test for DNSSEC Algorithm Completeness", @_;
+          "Test for DNSSEC Algorithm Completeness";
     },
     DNSSEC13 => sub {
         __x    # DNSSEC:DNSSEC13
-          "All DNSKEY algorithms used to sign the zone", @_;
+          "All DNSKEY algorithms used to sign the zone";
     },
     DNSSEC14 => sub {
         __x    # DNSSEC:DNSSEC14
-          "Check for valid RSA DNSKEY key size", @_;
+          "Check for valid RSA DNSKEY key size";
     },
     DNSSEC15 => sub {
         __x    # DNSSEC:DNSSEC15
-          "Existence of CDS and CDNSKEY", @_;
+          "Existence of CDS and CDNSKEY";
     },
     DNSSEC16 => sub {
         __x    # DNSSEC:DNSSEC16
-          "Validate CDS", @_;
+          "Validate CDS";
     },
     DNSSEC17 => sub {
         __x    # DNSSEC:DNSSEC17
-          "Validate CDNSKEY", @_;
+          "Validate CDNSKEY";
     },
     DNSSEC18 => sub {
         __x    # DNSSEC:DNSSEC18
-          "Validate trust from DS to CDS and CDNSKEY ", @_;
+          "Validate trust from DS to CDS and CDNSKEY";
     },
     ADDITIONAL_DNSKEY_SKIPPED => sub {
         __x    # DNSSEC:ADDITIONAL_DNSKEY_SKIPPED

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -136,31 +136,31 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     DELEGATION01 => sub {
         __x    # DELEGATION:DELEGATION01
-          "Minimum number of name servers", @_;
+          "Minimum number of name servers";
     },
     DELEGATION02 => sub {
         __x    # DELEGATION:DELEGATION02
-          "Name servers must have distinct IP addresses", @_;
+          "Name servers must have distinct IP addresses";
     },
     DELEGATION03 => sub {
         __x    # DELEGATION:DELEGATION03
-          "No truncation of referrals", @_;
+          "No truncation of referrals";
     },
     DELEGATION04 => sub {
         __x    # DELEGATION:DELEGATION04
-          "Name server is authoritative", @_;
+          "Name server is authoritative";
     },
     DELEGATION05 => sub {
         __x    # DELEGATION:DELEGATION05
-          "Name server must not point at CNAME alias", @_;
+          "Name server must not point at CNAME alias";
     },
     DELEGATION06 => sub {
         __x    # DELEGATION:DELEGATION06
-          "Existence of SOA", @_;
+          "Existence of SOA";
     },
     DELEGATION07 => sub {
         __x    # DELEGATION:DELEGATION07
-          "Parent glue name records present in child", @_;
+          "Parent glue name records present in child";
     },
     ARE_AUTHORITATIVE => sub {
         __x    # DELEGATION:ARE_AUTHORITATIVE

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -233,63 +233,63 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     NAMESERVER01 => sub {
         __x    # NAMESERVER:NAMESERVER01
-            'A name server should not be a recursor', @_;
+            'A name server should not be a recursor';
     },
     NAMESERVER02 => sub {
         __x    # NAMESERVER:NAMESERVER02
-            'Test of EDNS0 support', @_;
+            'Test of EDNS0 support';
     },
     NAMESERVER03 => sub {
         __x    # NAMESERVER:NAMESERVER03
-            'Test availability of zone transfer (AXFR)', @_;
+            'Test availability of zone transfer (AXFR)';
     },
     NAMESERVER04 => sub {
         __x    # NAMESERVER:NAMESERVER04
-            'Same source address', @_;
+            'Same source address';
     },
     NAMESERVER05 => sub {
         __x    # NAMESERVER:NAMESERVER05
-            'Behaviour against AAAA query', @_;
+            'Behaviour against AAAA query';
     },
     NAMESERVER06 => sub {
         __x    # NAMESERVER:NAMESERVER06
-            'NS can be resolved', @_;
+            'NS can be resolved';
     },
     NAMESERVER07 => sub {
         __x    # NAMESERVER:NAMESERVER07
-            'To check whether authoritative name servers return an upward referral', @_;
+            'To check whether authoritative name servers return an upward referral';
     },
     NAMESERVER08 => sub {
         __x    # NAMESERVER:NAMESERVER08
-            'Testing QNAME case insensitivity', @_;
+            'Testing QNAME case insensitivity';
     },
     NAMESERVER09 => sub {
         __x    # NAMESERVER:NAMESERVER09
-            'Testing QNAME case sensitivity', @_;
+            'Testing QNAME case sensitivity';
     },
     NAMESERVER10 => sub {
         __x    # NAMESERVER:NAMESERVER10
-            'Test for undefined EDNS version', @_;
+            'Test for undefined EDNS version';
     },
     NAMESERVER11 => sub {
         __x    # NAMESERVER:NAMESERVER11
-            'Test for unknown EDNS OPTION-CODE', @_;
+            'Test for unknown EDNS OPTION-CODE';
     },
     NAMESERVER12 => sub {
         __x    # NAMESERVER:NAMESERVER12
-            'Test for unknown EDNS flags', @_;
+            'Test for unknown EDNS flags';
     },
     NAMESERVER13 => sub {
         __x    # NAMESERVER:NAMESERVER13
-            'Test for truncated response on EDNS query', @_;
+            'Test for truncated response on EDNS query';
     },
     NAMESERVER14 => sub {
         __x    # NAMESERVER:NAMESERVER14
-            'Test for unknown version with unknown OPTION-CODE', @_;
+            'Test for unknown version with unknown OPTION-CODE';
     },
     NAMESERVER15 => sub {
         __x    # NAMESERVER:NAMESERVER15
-            'Checking for revealed software version', @_;
+            'Checking for revealed software version';
     },
     AAAA_BAD_RDATA => sub {
         __x    # NAMESERVER:AAAA_BAD_RDATA

--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -151,35 +151,35 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     SYNTAX01 => sub {
         __x    # SYNTAX:SYNTAX01
-          'No illegal characters in the domain name', @_;
+          'No illegal characters in the domain name';
     },
     SYNTAX02 => sub {
         __x    # SYNTAX:SYNTAX02
-          'No hyphen (\'-\') at the start or end of the domain name', @_;
+          'No hyphen (\'-\') at the start or end of the domain name';
     },
     SYNTAX03 => sub {
         __x    # SYNTAX:SYNTAX03
-          'There must be no double hyphen (\'--\') in position 3 and 4 of the domain name', @_;
+          'There must be no double hyphen (\'--\') in position 3 and 4 of the domain name';
     },
     SYNTAX04 => sub {
         __x    # SYNTAX:SYNTAX04
-          'The NS name must have a valid domain/hostname', @_;
+          'The NS name must have a valid domain/hostname';
     },
     SYNTAX05 => sub {
         __x    # SYNTAX:SYNTAX05
-          'Misuse of \'@\' character in the SOA RNAME field', @_;
+          'Misuse of \'@\' character in the SOA RNAME field';
     },
     SYNTAX06 => sub {
         __x    # SYNTAX:SYNTAX06
-          'No illegal characters in the SOA RNAME field', @_;
+          'No illegal characters in the SOA RNAME field';
     },
     SYNTAX07 => sub {
         __x    # SYNTAX:SYNTAX07
-          'No illegal characters in the SOA MNAME field', @_;
+          'No illegal characters in the SOA MNAME field';
     },
     SYNTAX08 => sub {
         __x    # SYNTAX:SYNTAX08
-          'MX name must have a valid hostname', @_;
+          'MX name must have a valid hostname';
     },
     DISCOURAGED_DOUBLE_DASH => sub {
         __x    # SYNTAX:DISCOURAGED_DOUBLE_DASH

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -178,43 +178,43 @@ sub metadata {
 Readonly my %TAG_DESCRIPTIONS => (
     ZONE01 => sub {
         __x    # ZONE:ZONE01
-          'Fully qualified master nameserver in SOA', @_;
+          'Fully qualified master nameserver in SOA';
     },
     ZONE02 => sub {
         __x    # ZONE:ZONE02
-          'SOA \'refresh\' minimum value', @_;
+          'SOA \'refresh\' minimum value';
     },
     ZONE03 => sub {
         __x    # ZONE:ZONE03
-          'SOA \'retry\' lower than \'refresh\'', @_;
+          'SOA \'retry\' lower than \'refresh\'';
     },
     ZONE04 => sub {
         __x    # ZONE:ZONE04
-          'SOA \'retry\' at least 1 hour', @_;
+          'SOA \'retry\' at least 1 hour';
     },
     ZONE05 => sub {
         __x    # ZONE:ZONE05
-          'SOA \'expire\' minimum value', @_;
+          'SOA \'expire\' minimum value';
     },
     ZONE06 => sub {
         __x    # ZONE:ZONE06
-          'SOA \'minimum\' maximum value', @_;
+          'SOA \'minimum\' maximum value';
     },
     ZONE07 => sub {
         __x    # ZONE:ZONE07
-          'SOA master is not an alias', @_;
+          'SOA master is not an alias';
     },
     ZONE08 => sub {
         __x    # ZONE:ZONE08
-          'MX is not an alias', @_;
+          'MX is not an alias';
     },
     ZONE09 => sub {
         __x    # ZONE:ZONE09
-          'MX record present', @_;
+          'MX record present';
     },
     ZONE10 => sub {
         __x    # ZONE:ZONE10
-          'No multiple SOA records', @_;
+          'No multiple SOA records';
     },
     RETRY_MINIMUM_VALUE_LOWER => sub {
         __x    # ZONE:RETRY_MINIMUM_VALUE_LOWER

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -273,7 +273,7 @@ Zonemaster::Engine::Translator - translation support for Zonemaster
 
 =head1 SYNOPSIS
 
-    Zonemaster::Engine::Translator->initialize({ locale => 'sv_SE.UTF-8' });
+    Zonemaster::Engine::Translator->initialize( { locale => 'sv_SE.UTF-8' } );
 
     my $trans = Zonemaster::Engine::Translator->instance;
     say $trans->to_string($entry);
@@ -326,7 +326,7 @@ end-users.
 
 Provide initial values for the single instance of this class.
 
-    Zonemaster::Engine::Translator->initialize( locale => 'sv_SE.UTF-8' );
+    Zonemaster::Engine::Translator->initialize( { locale => 'sv_SE.UTF-8' } );
 
 This method must be called at most once and before the first call to instance().
 
@@ -359,13 +359,13 @@ setlocale( LC_MESSAGES, "" ).
 Takes a L<Zonemaster::Engine::Logger::Entry> object as its argument and returns a translated string with the timestamp, level, message and arguments in the
 entry.
 
-=item translate_tag
+=item translate_tag($entry)
 
 Takes a L<Zonemaster::Engine::Logger::Entry> object as its argument and returns a translation of its tag and arguments.
 
-=item test_case_description
+=item test_case_description($testcase)
 
-Returns the translated test case description for a given test case ID.
+Takes a string (test case ID) and returns the translated test case description.
 
 =item BUILD
 

--- a/t/translator.t
+++ b/t/translator.t
@@ -33,8 +33,6 @@ like(
     'string to_stringd as expected'
 );
 
-
-
 my $untranslated = Zonemaster::Engine::Logger::Entry->new(
     {
         module => 'SYSTEM',
@@ -44,5 +42,13 @@ my $untranslated = Zonemaster::Engine::Logger::Entry->new(
 );
 
 ok( $trans->translate_tag( $untranslated ), 'Untranslated tag gets output' );
+
+my %methods = Zonemaster::Engine->all_methods();
+
+foreach my $module ( keys %methods ) {
+    foreach my $testmethod ( @{ $methods{$module } } ) {
+        ok( $trans->_translate_tag( uc( $module ), uc( $testmethod ), {}), 'Test method '. uc( $testmethod ) . ' has message tag with description');
+    }
+}
 
 done_testing;


### PR DESCRIPTION
## Purpose

This PR proposes updates to the usage of Zonemaster::Engine::Translator. It updates its documentation, adds unitary tests, and harmonizes message tags in each Test Case modules.

## Context

https://github.com/zonemaster/zonemaster-engine/pull/1144 mentions missing unitary tests and [unneeded parameters](https://github.com/zonemaster/zonemaster-engine/pull/1144#pullrequestreview-1190256946).

## Changes

`lib/Zonemaster/Engine/Translator.pm`
- Update documentation

`t/translator.t`
- Update unitary tests to check that a message tag exists for each implemented Test Case

`lib/Zonemaster/Engine/Test/[ Address ... Zone ].pm`
- Remove useless parameter in Test Case ID message tags in each Test Case module

## How to test this PR

Tests should pass.
