### PR TITLE
Disable DNSSEC10

### DIFF
--- a/share/profile.json
+++ b/share/profile.json
@@ -513,7 +513,6 @@
         "dnssec07",
         "dnssec08",
         "dnssec09",
-        "dnssec10",
         "dnssec11",
         "dnssec13",
         "dnssec14",

--- a/share/profile.yaml
+++ b/share/profile.yaml
@@ -46,7 +46,7 @@ test_cases:
   - dnssec07
   - dnssec08
   - dnssec09
-  - dnssec10
+#  - dnssec10 # Temporarily disabled due to https://github.com/zonemaster/zonemaster/issues/1153
   - dnssec11
   - dnssec13
   - dnssec14


### PR DESCRIPTION
## Purpose

This PR disables DNSSEC10 since there are errors in specification and implementation that creates false errors. See https://github.com/zonemaster/zonemaster/issues/1153

## Changes

The test case is disabled in the profile.

## How to test this PR

Run a test and make sure that the test case is not run.
