### PR TITLE
Fix po-files.t test

### DIFF
--- a/t/po-files.t
+++ b/t/po-files.t
@@ -43,7 +43,7 @@ subtest "check po files" => sub {
 };
 
 subtest "check msg args" => sub {
-    my ( $output, $status ) = make "check-msg-args";
+    my ( $output ) = make "check-msg-args";
     is $output, "", $makebin . ' check-msg-args gives empty output';
 };
 


### PR DESCRIPTION
## Purpose

Fix unit test on Ubuntu 22.04.

## Context

The `po-files.t` test fails on Ubuntu 22.04 with message
```
Can't use global $_ in "my" at t/po-files.t line 46, near ", $_ "
Execution of t/po-files.t aborted due to compilation errors.
```

## Changes

* Give a name to the variable.

## How to test this PR

Running the test on Ubuntu 22.04 should succeed.
