### PR TITLE
Fix typo in B01_CHILD_IS_ALIAS msgid

### DIFF
--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -162,7 +162,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     B01_CHILD_IS_ALIAS => sub {
         __x    # BASIC:B01_CHILD_IS_ALIAS
           '"{domain_child}" is not a zone. It is an alias for "{domain_target}". Run a test for "{domain_target}" instead. '
-          . 'Returned from name servers "{ns_ip_list}.', @_;
+          . 'Returned from name servers "{ns_ip_list}".', @_;
     },
     B01_CHILD_FOUND => sub {
         __x    # BASIC:B01_CHILD_FOUND


### PR DESCRIPTION
## Purpose

This PR fixes a small typo in the msgid for B01_CHILD_IS_ALIAS.

## Context

Found when preparing #1239.

## Changes

Add a missing closing quotation mark after `{ns_ip_list}`.

## How to test this PR

N/A.
