### PR TITLE
Update profile parameter "resolver.defaults.retry"

### DIFF
--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -47,8 +47,8 @@ my %profile_properties_details = (
     },
     q{resolver.defaults.retry} => {
         type    => q{Num},
-        min     => 1,
-        max     => 255
+        min     => 0,
+        max     => 254
     },
     q{resolver.defaults.usevc} => {
         type    => q{Bool}
@@ -681,8 +681,9 @@ This should almost certainly be kept false.
 
 =head2 resolver.defaults.retry
 
-An integer between 1 and 255 inclusive.
-The number of times a query is sent before we give up. Default 2.
+An integer between 0 and 254.
+The number of times a query is re-sent before giving up. This does not include the initial query.
+Default 1.
 
 =head2 resolver.defaults.igntc
 

--- a/share/profile.json
+++ b/share/profile.json
@@ -20,7 +20,7 @@
             "fallback" : true,
             "recurse" : false,
             "retrans" : 3,
-            "retry" : 2,
+            "retry" : 1,
             "usevc" : false,
             "timeout": 5
         }

--- a/share/profile.yaml
+++ b/share/profile.yaml
@@ -20,7 +20,7 @@ resolver:
     igntc: false
     recurse: false
     retrans: 3
-    retry: 2
+    retry: 1
     timeout: 5
     usevc: false
 test_cases:

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -295,8 +295,8 @@ subtest 'from_json() dies on illegal values' => sub {
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"net":{"ipv4":1}}' ); }                        "checks type of net.ipv4";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"net":{"ipv6":0}}' ); }                        "checks type of net.ipv6";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"no_network":1}' ); }                          "checks type of no_network";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":0}}}' ); }     "checks lower bound of resolver.defaults.retry";
-    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":256}}}' ); }   "checks upper bound of resolver.defaults.retry";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":-1}}}' ); }    "checks lower bound of resolver.defaults.retry";
+    dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":255}}}' ); }   "checks upper bound of resolver.defaults.retry";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retry":1.5}}}' ); }   "checks type of resolver.defaults.retry";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":0}}}' ); }   "checks lower bound of resolver.defaults.retrans";
     dies_ok { Zonemaster::Engine::Profile->from_json( '{"resolver":{"defaults":{"retrans":256}}}' ); } "checks upper bound of resolver.defaults.retrans";
@@ -546,8 +546,8 @@ subtest 'set() dies if the given property name is invalid' => sub {
 subtest 'set() dies on illegal value' => sub {
     my $profile = Zonemaster::Engine::Profile->new;
 
-    dies_ok { $profile->set( 'resolver.defaults.retry',   0 ); } 'checks lower bound of resolver.defaults.retry';
-    dies_ok { $profile->set( 'resolver.defaults.retry',   256 ); } 'checks upper bound of resolver.defaults.retry';
+    dies_ok { $profile->set( 'resolver.defaults.retry',   -1 ); } 'checks lower bound of resolver.defaults.retry';
+    dies_ok { $profile->set( 'resolver.defaults.retry',   255 ); } 'checks upper bound of resolver.defaults.retry';
     dies_ok { $profile->set( 'resolver.defaults.retry',   1.5 ); } 'checks type of resolver.defaults.retry';
     dies_ok { $profile->set( 'resolver.defaults.retrans', 0 ); } 'checks lower bound of resolver.defaults.retrans';
     dies_ok { $profile->set( 'resolver.defaults.retrans', 256 ); } 'checks upper bound of resolver.defaults.retrans';


### PR DESCRIPTION
## Purpose

This PR updates `resolver.defaults.retry` profile parameter by making it more proper to its name. See "Changes" section below.

## Context

Fixes #1070 

## Changes

- Make it exclude the initial query. Note that the actual value of `resolver.defaults.retry` is silently incremented before being passed to Zonemaster-LDNS. This is needed because LDNS does count the initial query as a try with this parameter.
- Update default values
- Update documentation
- Update unitary tests

## How to test this PR

Unit tests should pass.

Also you can change the value of `resolver.defaults.retry` in `share/profile.json` and test manually with :
```
$ git diff
diff --git a/lib/Zonemaster/Engine/Nameserver.pm b/lib/Zonemaster/Engine/Nameserver.pm
index f5962f8d..71ae62cf 100644
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -462,6 +462,8 @@ sub _query {
     $flags{q{timeout}}   = $href->{q{timeout}}   // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.timeout} );
     $flags{q{edns_size}} = $href->{q{edns_size}} // $UDP_EDNS_QUERY_DEFAULT;

+    say "query: ", $flags{q{retry}};
+
     if ( exists $href->{edns_details} ) {
         $flags{q{dnssec}}    = $href->{edns_details}{do} // $flags{q{dnssec}};
         $flags{q{edns_size}} = $href->{edns_details}{size} // $flags{q{edns_size}};


$ perl -MZonemaster::Engine -E 'say "default: ", Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.retry} ); my
 $ns = Zonemaster::Engine->ns( "ns2.nic.fr", "192.93.0.4" ); say "ns: ", $ns->dns->retry; my $p = $ns->query( "zonemaster.net", "A", { retry => 5 } ); say "final: ", $ns
->dns->retry;'
default: 1
ns: 2
query: 6
final: 2
```