### PR TITLE
Disable blacklisting for queries by NAMESERVER15

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -1375,7 +1375,7 @@ sub nameserver15 {
         my $found_string = 0;
 
         foreach my $query_name ( q{version.bind}, q{version.server} ) {
-            my $p = $ns->query( $query_name, q{TXT}, { class => q{CH} } );
+            my $p = $ns->query( $query_name, q{TXT}, { class => q{CH}, blacklisting_disabled => 1 } );
 
             if ( $p and $p->rcode eq q{NOERROR} and scalar $p->get_records_for_name( q{TXT}, $query_name, q{answer} ) ) {
                 foreach my $rr ( $p->get_records_for_name(q{TXT}, $query_name, q{answer} ) ) {


### PR DESCRIPTION
## Purpose

Some DNS operate autoritative DNS servers in environments that drop queries performed by the NAMESERVER15 test case, i.e. `version.bind/CH/TXT` and `version.server/CH/TXT`.

In those setups, the name servers in question could be mistakenly deemed unresponsive, causing subsequent queries not to be attempted at all. This leads to false warnings in other test cases.

This commit disables the blacklisting of name servers that do not respond to our version probes, preventing false warnings from being emitted.

## Context

Fixes #1281 (or at least, the situation leading to the creation of the issue).

## Changes

Disable blacklisting of name servers not responding to `version.{bind,server}/CH/TXT` queries.

## How to test this PR

Before:
```
$ zonemaster-cli festo.press --test basic --test nameserver/nameserver15 --test zone/zone09
Seconds Level     Message
======= ========= =======
   0.22 WARNING   No response on MX query from name servers "185.136.96.210;185.136.97.210;185.136.98.210;185.136.99.210".
```

After:
```
$ zonemaster-cli festo.press  --test basic --test nameserver/nameserver15 --test zone/zone09
Seconds Level     Message
======= ========= =======
Looks OK.
```