### PR TITLE
Cleanup in Syntax test module

### DIFF
--- a/t/Test-syntax.t
+++ b/t/Test-syntax.t
@@ -11,20 +11,6 @@ BEGIN {
     use_ok( q{Zonemaster::Engine::Test::Syntax} );
 }
 
-sub name_gives {
-    my ( $test, $name, $gives ) = @_;
-
-    my @res = Zonemaster::Engine->test_method( q{Syntax}, $test, $name );
-    ok( ( grep { $_->tag eq $gives } @res ), "$name gives $gives" );
-}
-
-sub name_gives_not {
-    my ( $test, $name, $gives ) = @_;
-
-    my @res = Zonemaster::Engine->test_method( q{Syntax}, $test, $name );
-    ok( !( grep { $_->tag eq $gives } @res ), "$name does not give $gives" );
-}
-
 sub zone_gives {
     my ( $test, $zone, $gives ) = @_;
 
@@ -67,41 +53,41 @@ $json         = read_file( 't/profiles/Test-syntax-all.json' );
 $profile_test = Zonemaster::Engine::Profile->from_json( $json );
 Zonemaster::Engine::Profile->effective->merge( $profile_test );
 
-my $ns_ok = Zonemaster::Engine::DNSName->new( q{ns1.nic.fr} );
-my $dn_ok = Zonemaster::Engine::DNSName->new( q{www.nic.se} );
-my $dn_ko = Zonemaster::Engine::DNSName->new( q{www.nic&nac.se} );
-name_gives( q{syntax01}, $dn_ok, q{ONLY_ALLOWED_CHARS} );
-name_gives_not( q{syntax01}, $dn_ko, q{ONLY_ALLOWED_CHARS} );
-name_gives( q{syntax01}, $dn_ko, q{NON_ALLOWED_CHARS} );
-name_gives_not( q{syntax01}, $dn_ok, q{NON_ALLOWED_CHARS} );
+my $ns_ok = Zonemaster::Engine->zone( q{ns1.nic.fr} );
+my $dn_ok = Zonemaster::Engine->zone( q{www.nic.se} );
+my $dn_ko = Zonemaster::Engine->zone( q{www.nic&nac.se} );
+zone_gives( q{syntax01}, $dn_ok, q{ONLY_ALLOWED_CHARS} );
+zone_gives_not( q{syntax01}, $dn_ko, q{ONLY_ALLOWED_CHARS} );
+zone_gives( q{syntax01}, $dn_ko, q{NON_ALLOWED_CHARS} );
+zone_gives_not( q{syntax01}, $dn_ok, q{NON_ALLOWED_CHARS} );
 
-$dn_ko = Zonemaster::Engine::DNSName->new( q{www.-nic.se} );
-name_gives( q{syntax02}, $dn_ko, q{INITIAL_HYPHEN} );
-name_gives_not( q{syntax02}, $dn_ko, q{NO_ENDING_HYPHENS} );
-name_gives_not( q{syntax02}, $dn_ok, q{INITIAL_HYPHEN} );
-name_gives( q{syntax02}, $dn_ok, q{NO_ENDING_HYPHENS} );
+$dn_ko = Zonemaster::Engine->zone( q{www.-nic.se} );
+zone_gives( q{syntax02}, $dn_ko, q{INITIAL_HYPHEN} );
+zone_gives_not( q{syntax02}, $dn_ko, q{NO_ENDING_HYPHENS} );
+zone_gives_not( q{syntax02}, $dn_ok, q{INITIAL_HYPHEN} );
+zone_gives( q{syntax02}, $dn_ok, q{NO_ENDING_HYPHENS} );
 
-$dn_ko = Zonemaster::Engine::DNSName->new( q{www.nic-.se} );
-name_gives( q{syntax02}, $dn_ko, q{TERMINAL_HYPHEN} );
-name_gives_not( q{syntax02}, $dn_ko, q{NO_ENDING_HYPHENS} );
-name_gives_not( q{syntax02}, $dn_ok, q{TERMINAL_HYPHEN} );
+$dn_ko = Zonemaster::Engine->zone( q{www.nic-.se} );
+zone_gives( q{syntax02}, $dn_ko, q{TERMINAL_HYPHEN} );
+zone_gives_not( q{syntax02}, $dn_ko, q{NO_ENDING_HYPHENS} );
+zone_gives_not( q{syntax02}, $dn_ok, q{TERMINAL_HYPHEN} );
 
-my $dn_idn_ok = Zonemaster::Engine::DNSName->new( q{www.xn--nic.se} );
-$dn_ko = Zonemaster::Engine::DNSName->new( q{www.ni--c.se} );
-name_gives( q{syntax03}, $dn_ko, q{DISCOURAGED_DOUBLE_DASH} );
-name_gives_not( q{syntax03}, $dn_ko,     q{NO_DOUBLE_DASH} );
-name_gives_not( q{syntax03}, $dn_ok,     q{DISCOURAGED_DOUBLE_DASH} );
-name_gives_not( q{syntax03}, $dn_idn_ok, q{DISCOURAGED_DOUBLE_DASH} );
-name_gives( q{syntax03}, $dn_ok,     q{NO_DOUBLE_DASH} );
-name_gives( q{syntax03}, $dn_idn_ok, q{NO_DOUBLE_DASH} );
+my $dn_idn_ok = Zonemaster::Engine->zone( q{www.xn--nic.se} );
+$dn_ko = Zonemaster::Engine->zone( q{www.ni--c.se} );
+zone_gives( q{syntax03}, $dn_ko, q{DISCOURAGED_DOUBLE_DASH} );
+zone_gives_not( q{syntax03}, $dn_ko,     q{NO_DOUBLE_DASH} );
+zone_gives_not( q{syntax03}, $dn_ok,     q{DISCOURAGED_DOUBLE_DASH} );
+zone_gives_not( q{syntax03}, $dn_idn_ok, q{DISCOURAGED_DOUBLE_DASH} );
+zone_gives( q{syntax03}, $dn_ok,     q{NO_DOUBLE_DASH} );
+zone_gives( q{syntax03}, $dn_idn_ok, q{NO_DOUBLE_DASH} );
 
-my $ns_double_dash = Zonemaster::Engine::DNSName->new( q{ns1.ns--nic.fr} );
-name_gives( q{syntax04}, $ns_double_dash, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
-name_gives_not( q{syntax04}, $ns_ok, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
+my $ns_double_dash = Zonemaster::Engine->zone( q{ns1.ns--nic.fr} );
+zone_gives( q{syntax04}, $ns_double_dash, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
+zone_gives_not( q{syntax04}, $ns_ok, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
 
-my $ns_num_tld = Zonemaster::Engine::DNSName->new( q{ns1.nic.47} );
-name_gives( q{syntax04}, $ns_num_tld, q{NAMESERVER_NUMERIC_TLD} );
-name_gives_not( q{syntax04}, $ns_ok, q{NAMESERVER_NUMERIC_TLD} );
+my $ns_num_tld = Zonemaster::Engine->zone( q{ns1.nic.47} );
+zone_gives( q{syntax04}, $ns_num_tld, q{NAMESERVER_NUMERIC_TLD} );
+zone_gives_not( q{syntax04}, $ns_ok, q{NAMESERVER_NUMERIC_TLD} );
 
 my %res;
 my $zone;

--- a/t/old-bugs.t
+++ b/t/old-bugs.t
@@ -36,7 +36,7 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine::Profile->effective->set( q{no_network}, 1 );
 }
 
-my @res = Zonemaster::Engine->test_method( 'Syntax', 'syntax03', 'XN--MGBERP4A5D4AR' );
+my @res = Zonemaster::Engine->test_method( 'Syntax', 'syntax03', Zonemaster::Engine->zone( 'XN--MGBERP4A5D4AR' ) );
 is( $res[3]->tag, q{NO_DOUBLE_DASH}, 'No complaint for XN--MGBERP4A5D4AR' );
 
 my $zft_zone = Zonemaster::Engine->zone( 'zft.rd.nic.fr' );


### PR DESCRIPTION
## Purpose

This PR proposes an update to the Syntax test module. See **Changes** section below.

## Context

Fixes #1283 and #1274

## Changes

- Remove internal helper function `_get_name()`
- Correct return value in Syntax08
- Correct POD typo in link for Syntax04

## How to test this PR

Tests should pass.

Also, there should now be a `TEST_CASE_END` message for Syntax08 once it finishes:

```
$ zonemaster-cli --show-testcase --test=syntax --level=debug --no-ipv6 --raw 'zonemaster.net' | grep TEST_CASE_
   0.00 DEBUG    SYNTAX01       TEST_CASE_START   testcase=syntax01
   0.00 DEBUG    SYNTAX01       TEST_CASE_END   testcase=syntax01
   0.00 DEBUG    SYNTAX02       TEST_CASE_START   testcase=syntax02
   0.00 DEBUG    SYNTAX02       TEST_CASE_END   testcase=syntax02
   0.00 DEBUG    SYNTAX03       TEST_CASE_START   testcase=syntax03
   0.00 DEBUG    SYNTAX03       TEST_CASE_END   testcase=syntax03
   1.03 DEBUG    SYNTAX04       TEST_CASE_START   testcase=syntax04
   1.03 DEBUG    SYNTAX04       TEST_CASE_END   testcase=syntax04
   1.03 DEBUG    SYNTAX04       TEST_CASE_START   testcase=syntax04
   1.03 DEBUG    SYNTAX04       TEST_CASE_END   testcase=syntax04
   1.03 DEBUG    SYNTAX04       TEST_CASE_START   testcase=syntax04
   1.03 DEBUG    SYNTAX04       TEST_CASE_END   testcase=syntax04
   1.03 DEBUG    SYNTAX04       TEST_CASE_START   testcase=syntax04
   1.03 DEBUG    SYNTAX04       TEST_CASE_END   testcase=syntax04
   1.03 DEBUG    SYNTAX05       TEST_CASE_START   testcase=syntax05
   1.03 DEBUG    SYNTAX05       TEST_CASE_END   testcase=syntax05
   1.03 DEBUG    SYNTAX06       TEST_CASE_START   testcase=syntax06
   1.46 DEBUG    SYNTAX06       TEST_CASE_END   testcase=syntax06
   1.46 DEBUG    SYNTAX07       TEST_CASE_START   testcase=syntax07
   1.46 DEBUG    SYNTAX07       TEST_CASE_END   testcase=syntax07
   1.46 DEBUG    SYNTAX08       TEST_CASE_START   testcase=syntax08
   1.47 DEBUG    SYNTAX08       TEST_CASE_END   testcase=syntax08
```