### PR TITLE
CI: update Ubuntu and Perl versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
           - develop
           #- latest
         perl:
-          - '5.32'
+          - '5.36'
+          - '5.30'
           - '5.26'
-          - '5.16'
         runner:
-          - ubuntu-20.04
+          - ubuntu-22.04
 
     runs-on: ${{ matrix.runner }}
 

--- a/share/fr.po
+++ b/share/fr.po
@@ -112,8 +112,8 @@ msgstr "Tous les enregistrements PTR correspondent aux serveurs de noms."
 #, perl-brace-format
 msgid "No response from nameserver(s) on PTR query ({domain})."
 msgstr ""
-"Aucune réponse des serveurs de noms sur une requête de type \"PTR"
-"\" ({domain})."
+"Aucune réponse des serveurs de noms sur une requête de type "
+"\"PTR\" ({domain})."
 
 #. ADDRESS:TEST_CASE_END
 #. BASIC:TEST_CASE_END
@@ -867,22 +867,22 @@ msgstr ""
 #, perl-brace-format
 msgid "A single SOA mname value was seen ({mname})."
 msgstr ""
-"Un unique serveur maître a été trouvé dans les enregistrements de type \"SOA"
-"\" de la zone testée ({mname})."
+"Un unique serveur maître a été trouvé dans les enregistrements de type "
+"\"SOA\" de la zone testée ({mname})."
 
 #. CONSISTENCY:ONE_SOA_RNAME
 #, perl-brace-format
 msgid "A single SOA rname value was found ({rname})."
 msgstr ""
-"Une unique adresse mail a été trouvée dans les enregistrements de type \"SOA"
-"\" de la zone testée ({rname})."
+"Une unique adresse mail a été trouvée dans les enregistrements de type "
+"\"SOA\" de la zone testée ({rname})."
 
 #. CONSISTENCY:ONE_SOA_SERIAL
 #, perl-brace-format
 msgid "A single SOA serial number was found ({serial})."
 msgstr ""
-"Un unique numéro de série a été trouvé dans les enregistrements de type \"SOA"
-"\" de la zone testée ({serial})."
+"Un unique numéro de série a été trouvé dans les enregistrements de type "
+"\"SOA\" de la zone testée ({serial})."
 
 #. CONSISTENCY:ONE_SOA_TIME_PARAMETER_SET
 #, perl-brace-format
@@ -1658,8 +1658,8 @@ msgid ""
 "({ns_ip_list})."
 msgstr ""
 "Les serveurs de noms ayant une des adresses IP suivantes \"{ns_ip_list}\" "
-"retournent un ensemble d'enregistrements de type \"CDNSKEY\" et de type \"CDS"
-"\"."
+"retournent un ensemble d'enregistrements de type \"CDNSKEY\" et de type "
+"\"CDS\"."
 
 #. DNSSEC:DS15_HAS_CDS_NO_CDNSKEY
 #, perl-brace-format
@@ -1690,14 +1690,14 @@ msgid ""
 "addresses ({ns_ip_list}) but they do not match."
 msgstr ""
 "Les serveurs de noms ayant une des adresses IP suivantes \"{ns_ip_list}\" "
-"retournent un ensemble d'enregistrements de type \"CDNSKEY\" et de type \"CDS"
-"\" mais ceux-ci ne correspondent pas."
+"retournent un ensemble d'enregistrements de type \"CDNSKEY\" et de type "
+"\"CDS\" mais ceux-ci ne correspondent pas."
 
 #. DNSSEC:DS15_NO_CDS_CDNSKEY
 msgid "No CDS or CDNSKEY RRsets are found on any name server."
 msgstr ""
-"Aucun des serveurs de noms ne retourne d'enregistrements de type \"CDNSKEY"
-"\"  ou de type \"CDS\"."
+"Aucun des serveurs de noms ne retourne d'enregistrements de type \"CDNSKEY\" "
+"ou de type \"CDS\"."
 
 #. DNSSEC:DS16_CDS_INVALID_RRSIG
 #, perl-brace-format
@@ -1868,9 +1868,9 @@ msgid ""
 "\"{ns_ip_list}\"."
 msgstr ""
 "L'ensemble d'enregistrements de type \"CDNSKEY\" n'est pas signé par la clé "
-"(DNSKEY) correspondant au tag {keytag} de l'enregistrement de type \"CDNSKEY"
-"\". Information retournée par les serveurs de noms ayant une des adresses IP "
-"suivantes \"{ns_ip_list}\"."
+"(DNSKEY) correspondant au tag {keytag} de l'enregistrement de type "
+"\"CDNSKEY\". Information retournée par les serveurs de noms ayant une des "
+"adresses IP suivantes \"{ns_ip_list}\"."
 
 #. DNSSEC:DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY
 #, perl-brace-format
@@ -2399,8 +2399,8 @@ msgstr ""
 msgid "Empty NOERROR response to SOA query was received from {ns}."
 msgstr ""
 "Une réponse à une requête pour un enregistrement de type \"SOA\" sur le "
-"serveur de noms {ns} a été reçue vide alors que le code retour est \"NOERROR"
-"\"."
+"serveur de noms {ns} a été reçue vide alors que le code retour est "
+"\"NOERROR\"."
 
 #. DELEGATION:TOTAL_NAME_MISMATCH
 msgid "None of the nameservers listed at the parent are listed at the child."
@@ -2490,8 +2490,8 @@ msgstr ""
 #, perl-brace-format
 msgid "Nameserver {ns} dropped AAAA query."
 msgstr ""
-"Le serveur de noms {ns} ne répond pas aux requêtes portant sur le type \"AAAA"
-"\"."
+"Le serveur de noms {ns} ne répond pas aux requêtes portant sur le type "
+"\"AAAA\"."
 
 #. NAMESERVER:AAAA_UNEXPECTED_RCODE
 #, perl-brace-format
@@ -2843,8 +2843,8 @@ msgstr ""
 #, perl-brace-format
 msgid "Nameserver {ns} has one or more unknown EDNS Z flag bits set."
 msgstr ""
-"Le serveur de noms {ns} répond à une requête avec a un ou plusieurs bits \"Z"
-"\" (EDNS) positionnés."
+"Le serveur de noms {ns} répond à une requête avec un ou plusieurs bits "
+"\"Z\" (EDNS) positionnés."
 
 #. SYNTAX:SYNTAX01
 msgid "No illegal characters in the domain name"
@@ -3427,8 +3427,8 @@ msgstr ""
 msgid ""
 "Non-authoritative response on MX query from name servers \"{ns_ip_list}\"."
 msgstr ""
-"La réponse des serveurs de noms \"{ns_ip_list}\" à une requête de type \"MX"
-"\" ne fait pas autorité."
+"La réponse des serveurs de noms \"{ns_ip_list}\" à une requête de type "
+"\"MX\" ne fait pas autorité."
 
 #. ZONE:Z09_NO_MX_FOUND
 #, perl-brace-format

--- a/share/nb.po
+++ b/share/nb.po
@@ -1557,8 +1557,8 @@ msgid ""
 "The CDS record with tag {keytag} matches a DNSKEY record with zone bit (bit "
 "7) unset. Fetched from the nameservers with IP addresses \"{ns_ip_list}\"."
 msgstr ""
-"CDS-posten med \"key tag\" {keytag} matcher en DNSKEY-post uten \"zone bit"
-"\" (bit 7) satt. Hentet fra navnetjenere med IP-adressene ({ns_ip_list})."
+"CDS-posten med \"key tag\" {keytag} matcher en DNSKEY-post uten \"zone "
+"bit\" (bit 7) satt. Hentet fra navnetjenere med IP-adressene ({ns_ip_list})."
 
 #. DNSSEC:DS16_CDS_MATCHES_NO_DNSKEY
 #, perl-brace-format
@@ -1576,8 +1576,8 @@ msgid ""
 "{keytag} points to. Fetched from the nameservers with IP addresses "
 "\"{ns_ip_list}\"."
 msgstr ""
-"CDS-posten er ikke signert av DNSKEY referert av CDS-posten med \"key tag"
-"\" {keytag}. Hentet fra navnetjenere med IP-adressene ({ns_ip_list})."
+"CDS-posten er ikke signert av DNSKEY referert av CDS-posten med \"key "
+"tag\" {keytag}. Hentet fra navnetjenere med IP-adressene ({ns_ip_list})."
 
 #. DNSSEC:DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY
 #, perl-brace-format
@@ -1622,8 +1622,8 @@ msgid ""
 "{keytag} points to. Fetched from the nameservers with IP addresses "
 "\"{ns_ip_list}\"."
 msgstr ""
-"DNSKEY-posten er ikke signert av DNSKEY referert av CDS-posten med \"key tag"
-"\" {keytag}. Hentet fra navnetjenere med IP-adressene ({ns_ip_list})."
+"DNSKEY-posten er ikke signert av DNSKEY referert av CDS-posten med \"key "
+"tag\" {keytag}. Hentet fra navnetjenere med IP-adressene ({ns_ip_list})."
 
 #. DNSSEC:DS16_MIXED_DELETE_CDS
 #, perl-brace-format
@@ -1679,8 +1679,8 @@ msgid ""
 "tag {keytag} points to. Fetched from the nameservers with IP addresses "
 "\"{ns_ip_list}\"."
 msgstr ""
-"CDNSKEY-posten er ikke signert av den DNSKEY som CDNSKEY-posten med \"key tag"
-"\" {keytag} refererer til. Hentet fra navnetjenere med IP-adressene "
+"CDNSKEY-posten er ikke signert av den DNSKEY som CDNSKEY-posten med \"key "
+"tag\" {keytag} refererer til. Hentet fra navnetjenere med IP-adressene "
 "({ns_ip_list})."
 
 #. DNSSEC:DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY
@@ -1728,8 +1728,8 @@ msgid ""
 "tag {keytag} points to. Fetched from the nameservers with IP addresses "
 "\"{ns_ip_list}\"."
 msgstr ""
-"DNSKEY-posten er ikke signert av den DNSKEY som CDNSKEY-posten med \"key tag"
-"\" {keytag} refererer til. Hentet fra navnetjenere med IP-adressene "
+"DNSKEY-posten er ikke signert av den DNSKEY som CDNSKEY-posten med \"key "
+"tag\" {keytag} refererer til. Hentet fra navnetjenere med IP-adressene "
 "({ns_ip_list})."
 
 #. DNSSEC:DS17_MIXED_DELETE_CDNSKEY

--- a/share/sv.po
+++ b/share/sv.po
@@ -1612,8 +1612,8 @@ msgid ""
 "{keytag} points to. Fetched from the nameservers with IP addresses "
 "\"{ns_ip_list}\"."
 msgstr ""
-"CDS RRset har inte signerats av den DNSKEY-post som CDS-posten med \"key tag"
-"\" {keytag} refererar till. Hämtat från namnservrarna med IP-adresserna "
+"CDS RRset har inte signerats av den DNSKEY-post som CDS-posten med \"key "
+"tag\" {keytag} refererar till. Hämtat från namnservrarna med IP-adresserna "
 "\"{ns_ip_list}\"."
 
 #. DNSSEC:DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY
@@ -3058,8 +3058,8 @@ msgid ""
 "SOA MNAME is specified as \".\" which usually means \"no server\". Fetched "
 "from name servers \"{ns_ip_list}\"."
 msgstr ""
-"Namnservernamnet i SOA MNAME är \".\", vilket normalt betyder \"ingen server"
-"\". Hämtad från namnservrarna med IP-adresserna \"{ns_ip_list}\"."
+"Namnservernamnet i SOA MNAME är \".\", vilket normalt betyder \"ingen "
+"server\". Hämtad från namnservrarna med IP-adresserna \"{ns_ip_list}\"."
 
 #. ZONE:Z01_MNAME_IS_LOCALHOST
 #, perl-brace-format

--- a/t/po-files.t
+++ b/t/po-files.t
@@ -60,7 +60,8 @@ subtest "tidy po files" => sub {
         is $output, "", $makebin . ' tidy-po gives empty output';
 
         $output = `git diff --numstat`;
-        is $output, "", 'all files are tidied (if not run "make tidy-po")';
+        is $output, "", 'all files are tidied (if not run "make tidy-po")'
+            or diag `git diff`;
     }
 };
 


### PR DESCRIPTION
## Purpose

This PR updates the versions of Ubuntu and Perl to use in Github actions.

## Context

Discussion during work group meeting.

## Changes

- Use Ubuntu 22.04 instead of 20.04;
- Test against Perl 5.36, 5.30 and 5.26 instead of 5.30, 5.26 and 5.16;
- Reformat PO files according to newer version of gettext provided by Ubuntu 22.04.

## How to test this PR

The Github Action should succeed.
