### PR TITLE
Corrects MANIFEST missed in #1268

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,7 +1,6 @@
 Changes
 CONTRIBUTING.md
 docs/Implementing_Tests.pod
-docs/logentry_args.md
 docs/Translation.pod
 docs/Translation-translators.md
 inc/Module/Install.pm


### PR DESCRIPTION
## Purpose

This PR updates `MANIFEST`. The update was missed in #1268, which was just merged to develop branch.

## Changes

Updates `MANIFEST` to make develop branch pass CI.

## How to test this PR

If CI passes, it is fine.