### PR TITLE
Document and update method '_emit_log()' in all Test modules

### DIFF
--- a/lib/Zonemaster/Engine/Test/Address.pm
+++ b/lib/Zonemaster/Engine/Test/Address.pm
@@ -17,8 +17,6 @@ use Zonemaster::Engine::Constants qw[:addresses :ip];
 use Zonemaster::Engine::TestMethods;
 use Zonemaster::Engine::Util;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Address' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Address - Module implementing tests focused on IP addresses of name servers
@@ -194,11 +192,32 @@ sub version {
     return "$Zonemaster::Engine::Test::Address::VERSION";
 }
 
+=head1 INTERNAL METHODS
+
 =over
 
-=item find_special_address()
+=item _emit_log()
 
-    my $hash_ref = find_special_address( $ip );
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Address' ); }
+
+=over
+
+=item _find_special_address()
+
+    my $hash_ref = _find_special_address( $ip );
 
 Verifies if an IP address is a special (private, reserved, ...) one.
 
@@ -210,7 +229,7 @@ Returns a reference to a hash if true (see L<Zonemaster::Engine::Constants/_extr
 
 =cut
 
-sub find_special_address {
+sub _find_special_address {
     my ( $class, $ip ) = @_;
     my @special_addresses;
 
@@ -261,7 +280,7 @@ sub address01 {
 
         next if $ips{ $local_ns->address->short };
 
-        my $ip_details_ref = $class->find_special_address( $local_ns->address );
+        my $ip_details_ref = $class->_find_special_address( $local_ns->address );
 
         if ( $ip_details_ref ) {
             push @results,

--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -19,8 +19,6 @@ use Zonemaster::Engine::Test::Syntax;
 use Zonemaster::Engine::TestMethods;
 use Zonemaster::Engine::Util;
 
-sub _emit_log { Zonemaster::Engine->logger->add( @_, 'Basic' ) }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Basic - Module implementing tests focused on basic zone functionality
@@ -369,6 +367,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Basic' ); }
 
 =over
 

--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -18,8 +18,6 @@ use Zonemaster::Engine::Constants qw[:ip];
 use Zonemaster::Engine::TestMethods;
 use Zonemaster::Engine::Util;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Connectivity' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Connectivity - Module implementing tests focused on name servers reachability
@@ -409,6 +407,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Connectivity' ); }
 
 =over
 

--- a/lib/Zonemaster/Engine/Test/Consistency.pm
+++ b/lib/Zonemaster/Engine/Test/Consistency.pm
@@ -18,8 +18,6 @@ use Zonemaster::Engine::Test::Address;
 use Zonemaster::Engine::Util;
 use Zonemaster::Engine::TestMethods;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Consistency' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Consistency - Module implementing tests focused on name servers responses consistency
@@ -350,6 +348,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Consistency' ); }
 
 =over
 

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -19,8 +19,6 @@ use Zonemaster::Engine::Constants qw[:algo :soa :ip];
 use Zonemaster::Engine::Util;
 use Zonemaster::Engine::TestMethods;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'DNSSEC' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::DNSSEC - Module implementing tests focused on DNSSEC
@@ -1466,6 +1464,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'DNSSEC' ); }
 
 =over
 

--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -21,8 +21,6 @@ use Zonemaster::Engine::Util;
 use Zonemaster::LDNS::Packet;
 use Zonemaster::LDNS::RR;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Delegation' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Delegation - Module implementing tests focused on zone delegation
@@ -417,6 +415,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Delegation' ); }
 
 =over
 

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -19,8 +19,6 @@ use Zonemaster::Engine::Test::Address;
 use Zonemaster::Engine::Util;
 use Zonemaster::Engine::TestMethods;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Nameserver' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Nameserver - Module implementing tests focused on the properties of a name server
@@ -580,6 +578,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Nameserver' ); }
 
 =over
 

--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -23,8 +23,6 @@ use Zonemaster::Engine::TestMethods;
 use Zonemaster::Engine::Util;
 use Zonemaster::LDNS;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Syntax' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Syntax - Module implementing tests focused on validating the syntax of host names and other data
@@ -394,6 +392,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Syntax' ); }
 
 =over
 

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -24,8 +24,6 @@ use Zonemaster::Engine::Test::Address;
 use Zonemaster::Engine::TestMethods;
 use Zonemaster::Engine::Util;
 
-sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Zone' ); }
-
 =head1 NAME
 
 Zonemaster::Engine::Test::Zone - Module implementing tests focused on the DNS zone content, such as SOA and MX records
@@ -497,6 +495,25 @@ sub version {
 }
 
 =head1 INTERNAL METHODS
+
+=over
+
+=item _emit_log()
+
+    my $log_entry = _emit_log( $message_tag_string, $hash_ref );
+
+Adds a message to the L<logger|Zonemaster::Engine::Logger> for this module.
+See L<Zonemaster::Engine::Logger::Entry/add($tag, $argref, $module, $testcase)> for more details.
+
+Takes a string (message tag) and a reference to a hash (arguments).
+
+Returns a L<Zonemaster::Engine::Logger::Entry> object.
+
+=back
+
+=cut
+
+sub _emit_log { my ( $tag, $argref ) = @_; return Zonemaster::Engine->logger->add( $tag, $argref, 'Zone' ); }
 
 =over
 

--- a/t/Test-address.t
+++ b/t/Test-address.t
@@ -21,7 +21,7 @@ Zonemaster::Engine::Profile->effective->merge( $profile_test );
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{0.255.255.255} )
         )
     ),
@@ -30,7 +30,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{10.255.255.255} )
         )
     ),
@@ -39,7 +39,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.168.255.255} )
         )
     ),
@@ -48,7 +48,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{172.17.255.255} )
         )
     ),
@@ -57,7 +57,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{100.65.255.255} )
         )
     ),
@@ -66,7 +66,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{127.255.255.255} )
         )
     ),
@@ -75,7 +75,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{169.254.255.255} )
         )
     ),
@@ -84,7 +84,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.0.0.255} )
         )
     ),
@@ -93,7 +93,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.0.0.7} )
         )
     ),
@@ -102,7 +102,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.0.0.170} )
         )
     ),
@@ -111,7 +111,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.0.0.171} )
         )
     ),
@@ -120,7 +120,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.0.2.255} )
         )
     ),
@@ -129,7 +129,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{198.51.100.255} )
         )
     ),
@@ -138,7 +138,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{203.0.113.255} )
         )
     ),
@@ -147,7 +147,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.88.99.255} )
         )
     ),
@@ -156,7 +156,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{198.19.255.255} )
         )
     ),
@@ -165,7 +165,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{240.255.255.255} )
         )
     ),
@@ -174,7 +174,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{255.255.255.255} )
         )
     ),
@@ -183,7 +183,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{::1} )
         )
     ),
@@ -192,7 +192,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{::} )
         )
     ),
@@ -201,7 +201,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{::ffff:cafe:cafe} )
         )
     ),
@@ -210,7 +210,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{64:ff9b::cafe:cafe} )
         )
     ),
@@ -219,7 +219,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{100::cafe:cafe:cafe:cafe} )
         )
     ),
@@ -228,7 +228,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{2001:1ff:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -237,7 +237,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{2001::cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -246,7 +246,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{2001:2::cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -255,7 +255,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{2001:db8:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -264,7 +264,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{2001:1f::cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -273,7 +273,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{2002:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -282,7 +282,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{fdff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -291,7 +291,7 @@ ok(
 
 ok(
     defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{febf:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
         )
     ),
@@ -302,7 +302,7 @@ SKIP: {
     skip "::cafe:cafe Was RFC4291: Deprecated (IPv4-compatible Address) (Zonemaster::Engine::Constants prior to 1.2.0 version)", 1;
     ok(
         defined(
-            Zonemaster::Engine::Test::Address->find_special_address(
+            Zonemaster::Engine::Test::Address->_find_special_address(
                 Net::IP::XS->new( q{::cafe:cafe} )
             )
         ),
@@ -314,7 +314,7 @@ SKIP: {
     skip "5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe Was RFC3701: unallocated (ex 6bone) (Zonemaster::Engine::Constants prior to 1.2.0 version)", 1;
     ok(
         defined(
-            Zonemaster::Engine::Test::Address->find_special_address(
+            Zonemaster::Engine::Test::Address->_find_special_address(
                 Net::IP::XS->new( q{5fff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
             )
         ),
@@ -326,7 +326,7 @@ SKIP: {
     skip "ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe Was RFC4291: IPv6 multicast addresses (Zonemaster::Engine::Constants prior to 1.2.0 version)", 1;
     ok(
         defined(
-            Zonemaster::Engine::Test::Address->find_special_address(
+            Zonemaster::Engine::Test::Address->_find_special_address(
                 Net::IP::XS->new( q{ffff:cafe:cafe:cafe:cafe:cafe:cafe:cafe} )
             )
         ),
@@ -336,7 +336,7 @@ SKIP: {
 
 ok(
     !defined(
-        Zonemaster::Engine::Test::Address->find_special_address(
+        Zonemaster::Engine::Test::Address->_find_special_address(
             Net::IP::XS->new( q{192.134.4.45} )
         )
     ),


### PR DESCRIPTION
## Purpose

This PR documents and updates the [recently added](https://github.com/zonemaster/zonemaster-engine/pull/1302) `_emit_log()` internal method. See the **Changes** section below.

## Context

https://github.com/zonemaster/zonemaster-engine/pull/1302

## Changes

- Move '_emit_log()' to the proper section in each Test modules
- Add documentation for '_emit_log()' in each Test modules
- Align implementation of 'Zonemaster::Engine::Test::Basic::_emit_log()' with its counterpart from other Test modules
- Make 'Zonemaster::Engine::Test::Address::find_private_address()' an internal method

## How to test this PR

Tests should pass.

POD documentation should show correctly, e.g. using [pod2text](https://perldoc.perl.org/pod2text).