### PR TITLE
Normalization

### DIFF
--- a/lib/Zonemaster/Engine/Normalization.pm
+++ b/lib/Zonemaster/Engine/Normalization.pm
@@ -35,7 +35,7 @@ Zonemaster::Engine::Normalization - utility functions for names normalization
 
 
 our @EXPORT      = qw[ normalize_name ];
-our @EXPORT_OK   = qw[ normalize_name normalize_label ];
+our @EXPORT_OK   = qw[ normalize_name normalize_label trim_space ];
 
 Readonly my $ASCII => qr/^[[:ascii:]]+$/;
 Readonly my $VALID_ASCII => qr(^[A-Za-z0-9/_-]+$);
@@ -130,12 +130,28 @@ sub normalize_label {
     return \@messages, $alabel;
 }
 
+=item trim_space($str)
+
+Trim leading and trailing whitespace.
+
+Implements the space trimming part of L<normalization document|https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/RequirementsAndNormalizationOfDomainNames.md>.
+
+Returns a string.
+
+=cut
+
+sub trim_space {
+    my ( $str ) = @_;
+
+    return $str =~ s/^${$WHITE_SPACES_RE}+|${WHITE_SPACES_RE}+$//gr;
+}
+
 =item normalize_name($name)
 
 Normalize a domain name.
 
-
-The normalization process is detailed in the L<normalization document|https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/RequirementsAndNormalizationOfDomainNames.md>.
+Implements the normalization process, except the space trimming part, described
+in L<normalization document|https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/RequirementsAndNormalizationOfDomainNames.md>.
 
 Returns a tuple C<($errors: ArrayRef[Zonemaster::Engine::Normalization::Error], $name: String)>.
 
@@ -147,9 +163,6 @@ an empty error array is returned.
 sub normalize_name {
     my ( $uname ) = @_;
     my @messages;
-
-    $uname =~ s/^${$WHITE_SPACES_RE}+//;
-    $uname =~ s/${WHITE_SPACES_RE}+$//;
 
     if ( length($uname) == 0 ) {
         push @messages, Zonemaster::Engine::Normalization::Error->new(EMPTY_DOMAIN_NAME => {});

--- a/t/normalization.t
+++ b/t/normalization.t
@@ -1,9 +1,11 @@
-use Test::More;
-use Test::Exception;
-
+#!perl
+use strict;
 use utf8;
+use warnings;
+use Test::More;
 
-BEGIN { use_ok( 'Zonemaster::Engine::Normalization' ); }
+use Test::Exception;
+use Zonemaster::Engine::Normalization qw( normalize_name );
 
 sub char_to_hex_esc {
     my ($char) = @_;
@@ -83,10 +85,11 @@ subtest 'Valid domains' => sub {
         "aḍ\x{0307}a" => 'xn--aa-rub587y',
     );
 
-    while (($domain, $expected_output) = each (%input_domains)) {
+    for my $domain ( sort keys %input_domains ) {
+        my $expected_output = $input_domains{$domain};
         my $safe_domain = to_hex_esc($domain);
         subtest "Domain: '$safe_domain'" => sub {
-            my $errors, $final_domain;
+            my ( $errors, $final_domain );
             lives_ok(sub {
                 ($errors, $final_domain) = normalize_name($domain);
             }, 'correct domain should live');
@@ -126,16 +129,17 @@ subtest 'Bad domains' => sub {
         'İ.example.com' => 'AMBIGUOUS_DOWNCASING',
     );
 
-    while (($domain, $error) = each (%input_domains)) {
+    for my $domain ( sort keys %input_domains ) {
+        my $error = $input_domains{$domain};
         my $safe_domain = to_hex_esc($domain);
         subtest "Domain: '$safe_domain' ($error)" => sub {
-            my $output, $messages, $domain;
+            my ( $errors, $final_domain );
             lives_ok(sub {
                 ($errors, $final_domain) = normalize_name($domain);
             }, 'incorrect domain should live');
 
             is($final_domain, undef, 'No domain returned') or diag($final_domain);
-            is($errors->[0]->tag, $error, 'Correct error is returned') or diag($errors[0]);
+            is($errors->[0]->tag, $error, 'Correct error is returned') or diag($errors->[0]);
             note(to_hex_esc($errors->[0]))
         }
     }


### PR DESCRIPTION
## Purpose

This PR separates the normalization of what's logically part of domain names from the white space stripping that is also specified in RequirementsAndNormalizationOfDomainNames.md to make it possible to apply them individually.

## Context

This is a step towards fixing zonemaster/zonemaster-cli#364.

This is technically a major change because normalize_name() is part of the public API. However, even though we've included an implementation in prior releases, we've never actually called it (except from unit tests).

## Changes

* This PR splits out trim_space() from normalize_name().
* As a drive-by change it also improves the quality of the associated unit test.

## How to test this PR
Unit tests should pass.