### PR TITLE
Make syntax04 take zone name instead of ns name

### DIFF
--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -60,12 +60,8 @@ sub all {
 
     if ( any { $_->tag eq q{ONLY_ALLOWED_CHARS} } @results ) {
 
-        foreach my $local_nsname ( uniq map { $_ } @{ Zonemaster::Engine::TestMethods->method2( $zone ) },
-            @{ Zonemaster::Engine::TestMethods->method3( $zone ) } )
-        {
-            push @results, $class->syntax04( Zonemaster::Engine->zone( $local_nsname ) )
-              if Zonemaster::Engine::Util::should_run_test( q{syntax04} );
-        }
+        push @results, $class->syntax04( Zonemaster::Engine->zone( $zone ) )
+          if Zonemaster::Engine::Util::should_run_test( q{syntax04} );
 
         push @results, $class->syntax05( $zone ) if Zonemaster::Engine::Util::should_run_test( q{syntax05} );
 
@@ -818,9 +814,15 @@ sub syntax04 {
     local $Zonemaster::Engine::Logger::TEST_CASE_NAME = 'Syntax04';
     push my @results, _emit_log( TEST_CASE_START => { testcase => $Zonemaster::Engine::Logger::TEST_CASE_NAME } );
 
-    my $name = $zone->name;
-
-    push @results, _check_name_syntax( q{NAMESERVER}, $name );
+    foreach my $local_nsname (
+        uniq(
+            @{ Zonemaster::Engine::TestMethods->method2( $zone ) },
+            @{ Zonemaster::Engine::TestMethods->method3( $zone ) }
+        )
+      )
+    {
+        push @results, _check_name_syntax( q{NAMESERVER}, $zone->name );
+    }
 
     return ( @results, _emit_log( TEST_CASE_END => { testcase => $Zonemaster::Engine::Logger::TEST_CASE_NAME } ) );
 }

--- a/t/Test-syntax.t
+++ b/t/Test-syntax.t
@@ -80,13 +80,23 @@ zone_gives_not( q{syntax03}, $dn_idn_ok, q{DISCOURAGED_DOUBLE_DASH} );
 zone_gives( q{syntax03}, $dn_ok,     q{NO_DOUBLE_DASH} );
 zone_gives( q{syntax03}, $dn_idn_ok, q{NO_DOUBLE_DASH} );
 
-my $ns_double_dash = Zonemaster::Engine->zone( q{ns1.ns--nic.fr} );
-zone_gives( q{syntax04}, $ns_double_dash, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
+my $zone_double_dash = Zonemaster::Engine->zone( q{ns1.ns--nic.fr} );
 zone_gives_not( q{syntax04}, $ns_ok, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
+zone_gives_not( q{syntax04}, $zone_double_dash, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
+SKIP: {
+    skip "need test zone", 1;
+    my $ns_num_tld; # TODO specify test zone
+    zone_gives( q{syntax04}, $ns_num_tld, q{NAMESERVER_NUMERIC_TLD} );
+}
 
-my $ns_num_tld = Zonemaster::Engine->zone( q{ns1.nic.47} );
-zone_gives( q{syntax04}, $ns_num_tld, q{NAMESERVER_NUMERIC_TLD} );
+my $zone_num_tld = Zonemaster::Engine->zone( q{ns1.nic.47} );
 zone_gives_not( q{syntax04}, $ns_ok, q{NAMESERVER_NUMERIC_TLD} );
+zone_gives_not( q{syntax04}, $zone_num_tld, q{NAMESERVER_NUMERIC_TLD} );
+SKIP: {
+    skip "need test zone", 1;
+    my $ns_double_dash; # TODO specify test zone
+    zone_gives( q{syntax04}, $ns_double_dash, q{NAMESERVER_DISCOURAGED_DOUBLE_DASH} );
+}
 
 my %res;
 my $zone;


### PR DESCRIPTION
## Purpose

Bring syntax04 in line with other methods

## Context

Fixes #1321.

## Changes

The determination of nameserver names for syntax04 is moved from Zonemaster::Engine::Test::Syntax::all() into Zonemaster::Engine::Test::Syntax::syntax04().

## How to test this PR

Find/create zones with NS records with invalid NSDNAME:
* One NSDNAME with a numeric TLD (e.g. `ns1.nic.47`).
* One NSDNAME with a double dash (e.g. `ns1.ns--nic.fr`). 

Run this command (with ZONE replaced with your test zone) and verify that you get complaints about nameserver records.
```sh
$ perl -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_method("syntax", "syntax04", "ZONE")'
```

Unit tests have been updated to test the converse. I.e. that syntax04 does not complain about zones whose names themselves have these properties.