### PR TITLE
Provide a way for third-party test modules to be installed.

### DIFF
--- a/lib/Zonemaster/Engine/Test.pm
+++ b/lib/Zonemaster/Engine/Test.pm
@@ -167,7 +167,8 @@ sub install_custom_test_module {
     # existing case
     foreach my $case ( @cases ) {
         if ( any { $_ eq $case } @{$profile->{profile}->{test_cases}} ) {
-            carp( sprintf "case '%s' already exists", $case );
+            carp sprintf "case '%s' already exists", $case ;
+            return undef;
         }
     }
 
@@ -177,7 +178,7 @@ sub install_custom_test_module {
     # append cases to the profile
     push @{$profile->{profile}->{test_cases}}, @cases;
 
-    return;
+    return 1;
 }
 
 =pod

--- a/lib/Zonemaster/Engine/Test.pm
+++ b/lib/Zonemaster/Engine/Test.pm
@@ -28,7 +28,7 @@ use File::Slurp qw[read_file];
 use Scalar::Util qw[blessed];
 use POSIX qw[strftime];
 use Carp;
-use List::Util qw(any);
+use List::MoreUtils qw(any);
 
 =head1 NAME
 

--- a/lib/Zonemaster/Engine/Test.pm
+++ b/lib/Zonemaster/Engine/Test.pm
@@ -138,7 +138,7 @@ sub _log_versions {
 
 =item install()
 
-    Zonemaster::Engine::Test->install('My::Module');
+    Zonemaster::Engine::Test->install_custom_test_module('My::Module');
 
 Installs a custom module outside of the C<Zonemaster::Engine::Test::> namespace.
 This module must be a modules that implements the same interface as the modules
@@ -151,7 +151,7 @@ module.
 
 =cut
 
-sub install {
+sub install_custom_test_module {
     my ( $class, $module ) = @_;
 
     push @all_test_modules, $module;

--- a/t/custom.module
+++ b/t/custom.module
@@ -1,0 +1,63 @@
+package My::Module;
+use strict;
+use vars qw($VERSION %TAG_DESCRIPTIONS);
+use Zonemaster::Engine::Util;
+use Locale::TextDomain qw(Zonemaster-Engine);
+use warnings;
+
+$VERSION = q{1.0.0};
+
+%TAG_DESCRIPTIONS = (
+    TEST_CASE_START => sub { __x('TEST_CASE_START {testcase}.', @_) },
+    TEST_CASE_END   => sub { __x('TEST_CASE_END {testcase}.', @_) },
+    THIS_IS_A_TEST  => sub { __x('THIS IS A TEST.', @_) },
+);
+
+sub version {
+    return $VERSION;
+}
+
+sub metadata {
+    my ( $class ) = @_;
+    return {
+        test01 => [qw(
+            TEST_CASE_START
+            TEST_CASE_END
+            THIS_IS_A_TEST
+        )],
+    };
+}
+
+sub tag_descriptions {
+    return \%TAG_DESCRIPTIONS;
+}
+
+sub all {
+    my ( $class, $zone ) = @_;
+
+    my @results;
+
+    push @results, $class->test01( $zone ) if Zonemaster::Engine::Util::should_run_test(q{test01});
+
+    return @results;
+}
+
+sub test01 {
+    my ( $class, $zone ) = @_;
+
+    my @results;
+
+    push(@results, _emit_log(TEST_CASE_START => {testcase => q{test01}}));
+
+    push(@results, _emit_log(THIS_IS_A_TEST => {}));
+
+    push(@results, _emit_log(TEST_CASE_END => {testcase => q{test01}}));
+
+    return @results;
+}
+
+sub _emit_log {
+    return Zonemaster::Engine->logger->add(@_[0..1], __PACKAGE__);
+}
+
+1;

--- a/t/custom.t
+++ b/t/custom.t
@@ -22,7 +22,7 @@ require_ok $modfile;
 
 $module->import();
 
-Zonemaster::Engine::Test->install( $module );
+Zonemaster::Engine::Test->install_custom_test_module( $module );
 
 ok any { $_ eq $module } Zonemaster::Engine::Test->modules();
 

--- a/t/custom.t
+++ b/t/custom.t
@@ -1,0 +1,35 @@
+use Cwd qw(abs_path);
+use List::Util qw(any);
+use File::Spec;
+use File::Basename qw(dirname);
+use Test::More;
+use strict;
+use warnings;
+
+BEGIN {
+    use_ok( q{Zonemaster::Engine} );
+    use_ok( q{Zonemaster::Engine::Nameserver} );
+}
+
+my $module  = 'My::Module';
+
+my $modfile = abs_path( File::Spec->catfile(
+    dirname( __FILE__ ),
+    'custom.module'
+) );
+
+require_ok $modfile;
+
+$module->import();
+
+Zonemaster::Engine::Test->install( $module );
+
+ok any { $_ eq $module } Zonemaster::Engine::Test->modules();
+
+my @results = Zonemaster::Engine->test_module( $module, q{example.com} );
+
+ok scalar @results > 0;
+
+ok scalar ( grep { 'THIS_IS_A_TEST' eq $_->tag } @results ) > 0;
+
+done_testing;


### PR DESCRIPTION
## Purpose

This PR adds a new method called `install_custom_test_module()` to `Zonemaster::Engine::Test`. It allows custom modules outside the `Zonemaster::Engine::Test::` namespace to be added to Zonemaster as test modules. Currently the only way to do this is to patch the `modules.txt` file and intrude upon the Zonemaster namespace.

## Context

I am developing a new [Registry System Testing (RST) service](https://icann.github.io/rst-test-specs/) that uses Zonemaster for DNS and DNSSEC testing. There are a handful of RST test cases that Zonemaster doesn't currently cover, which I don't think are appropriate for inclusion in the main Zonemaster test suite _(for example, checking for the presence of valid IDNA2008 labels in SOA `mname` and `rname` fields, which is not something that most Zonemaster users will care about)_. However, I still want to use Zonemaster to run these test cases, and I think the ability to install custom modules may be more generally useful _(for example, in future it might allow plugins for Zonemaster to be distributed separately, via CPAN)_.

## Changes

There are two main changes:

1. the `install_custom_test_module()` method has been added to `Zonemaster::Engine::Test`. It accepts a class name in a string, eg:

```perl
Zonemaster::Engine::Test->install_custom_test_module( 'My::Module' );
```

It adds the module name to the internal module list, and updates the effective profile to add the module's test cases to the test sequence, checking to make sure that they don't collide with existing test case names.

2. the `run_all_for()`, `run_module()` and `run_one()` methods have been changed so that if a module name looks like a Perl class name (that is, it contains `::`) it is used as-is rather than being prefixed with `Zonemaster::Engine::Test::`.

## How to test this PR

This PR includes a test cast. Use `prove t/custom.t` to run it.
