### PR TITLE
Fix typo in Swedish translation of DNSSEC:DNSSEC07

### DIFF
--- a/share/sv.po
+++ b/share/sv.po
@@ -887,7 +887,7 @@ msgstr "Verifiera hantering av RRSIG-poster i \"Additional Section\""
 
 #. DNSSEC:DNSSEC07
 msgid "If DNSKEY at child, parent should have DS"
-msgstr "Om dotterzonen är DNSSEC-signerad så ska moderzonen ha DS-post for den"
+msgstr "Om dotterzonen är DNSSEC-signerad så ska moderzonen ha DS-post för den"
 
 #. DNSSEC:DNSSEC08
 msgid "Valid RRSIG for DNSKEY"

--- a/share/sv.po
+++ b/share/sv.po
@@ -887,7 +887,7 @@ msgstr "Verifiera hantering av RRSIG-poster i \"Additional Section\""
 
 #. DNSSEC:DNSSEC07
 msgid "If DNSKEY at child, parent should have DS"
-msgstr "On dotterzonen är DNSSEC-signerad så ska moderzonen ha DS-post for den"
+msgstr "Om dotterzonen är DNSSEC-signerad så ska moderzonen ha DS-post for den"
 
 #. DNSSEC:DNSSEC08
 msgid "Valid RRSIG for DNSKEY"


### PR DESCRIPTION
## Purpose

This PR fixes a typo in a translation file.

## Context

Translations.

## Changes

See patch.

## How to test this PR

Unsure if applicable. Please let me know, if so.