### PR TITLE
Fixes a bug in Redis global cache triggered when TTL is 0

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -93,6 +93,8 @@ sub set_key {
             }
         }
         $ttl = $ttl < $redis_expire ? $ttl : $redis_expire;
+        # Redis requires cache time to be greater than 0.
+        $ttl = 1 if $ttl == 0;
         $self->redis->set( $key, $msg, 'EX', $ttl );
     } else {
         $self->redis->set( $key, '', 'EX', $ttl );


### PR DESCRIPTION
## Purpose

This PR fixes the bug described in #1326 by setting the lowest TTL value to 1.

This should be seen as a temporary solution. There should probably be a shortest time that messages are cached in Redis to make sure that in the normal case the same query should not be sent more than once when running a test. In issue #1326 we can see that the TTL of "iis.se. CDS" is 0, and a query for that would be sent several times if not cached.

That shortest time should be configurable in the profile.

## Context

Fixes #1326.

## How to test this PR

Find a zone that returns TTL=0 for some record that Zonemaster queries for a verify that there is no fatal error of the type describe in #1326.