### PR TITLE
Fix polymorphism in Translator

### DIFF
--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -131,7 +131,7 @@ sub initialize {
 
     my $obj = {
         _locale               => $locale // _init_locale(),
-        _all_tag_descriptions => _build_all_tag_descriptions(),
+        _all_tag_descriptions => $class->_build_all_tag_descriptions(),
         _last_language        => _build_last_language(),
     };
 
@@ -195,6 +195,8 @@ sub _load_data {
 }
 
 sub _build_all_tag_descriptions {
+    my ( $class ) = @_;
+
     my %all_tag_descriptions;
 
     $all_tag_descriptions{System} = \%TAG_DESCRIPTIONS;

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -135,7 +135,7 @@ sub initialize {
         _last_language        => _build_last_language(),
     };
 
-    $instance = bless $obj, __PACKAGE__;
+    $instance = bless $obj, $class;
 
     return;
 }


### PR DESCRIPTION
## Purpose

This PR fixes some regressions, presumably introduced by #1319, that could not be caught in Zonemaster::Engine’s unit tests.

## Context

### Problems

In Zonemaster::Backend, there is a `Zonemaster::Backend::Translator` class which inherits from `Zonemaster::Engine::Translator`. This is done in order to override the `translate_tag` method with a custom version.

When “un-Moosing” Zonemaster::Engine, however, changes were introduced that were harmless for Zonemaster::Engine, but not for Zonemaster::Backend. This caused two issues to emerge:

 - firstly, commands such as `zmb get_test_results`, that rely on translating messages pulled from the database, stopped working;
 - secondly, messages generated by the backend itself were no longer translated.

### Cause

The root cause of the first problem is that when calling `Zonemaster::Backend::Translator->new()`, the newly-created instance was always blessed as Zonemaster::Engine::Translator (the superclass), not as the inheriting class. Thus, `translate_tag()` method calls always called the method in the superclass instead of the inheriting class.

As for the second problem, this is due to Backend’s Translator overriding another method, `_build_all_tag_descriptions`, from Engine’s Translator, and the initialization code in Zonemaster::Engine::Translator failing to call the overridden `_build_all_tag_description` when invoked as the Backend’s Translator class.

## Changes

 - In the constructor, instead of blessing with `__PACKAGE__` (a macro that always expands to `Zonemaster::Engine::Translator`), bless with `$class` instead.
 - Make the `_build_all_tag_descriptions` subroutine a proper class method and have `initialize` hand over to the method of the correct class.

## How to test this PR

1. Make sure https://github.com/zonemaster/zonemaster-backend/pull/1166 is merged first.

2. Run a test with `zmb` and grab the test ID (or have a test ID of a previous test handy and skip the following command):
```
TEST_ID=`zmb start_domain_test --domain localhost | jq -r .result`
```

3. Then, run the following after the test is done:
```
zmb get_test_results --lang fr --test-id $TEST_ID | jq -e .result.params.domain
```
This command should print `"localhost"` (or whatever the domain under test was) and set an exit status of 0. Any other result, or `null`, is abnormal.

4. Using `zmtest`, run a test on a domain name that causes Zonemaster to time out, such as `pool.ntp.org`. The error message stating that the test took too long to complete should be translated (i.e., the raw untranslated message tag must not appear).