### PR TITLE
Fix Zonemaster::Engine::Translator’s instance() method

### DIFF
--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -107,7 +107,7 @@ sub instance {
     my ( $class ) = @_;
 
     if ( !defined $instance ) {
-        $instance = $class->initialize();
+        $class->initialize();
     }
 
     return $instance;
@@ -321,7 +321,7 @@ Zonemaster::Engine::Translator - translation support for Zonemaster
 
 =head1 SYNOPSIS
 
-    Zonemaster::Engine::Translator->initialize( { locale => 'sv_SE.UTF-8' } );
+    Zonemaster::Engine::Translator->initialize( locale => 'sv_SE.UTF-8' );
 
     my $trans = Zonemaster::Engine::Translator->instance;
     say $trans->to_string($entry);
@@ -376,7 +376,7 @@ end-users.
 
 Provide initial values for the single instance of this class.
 
-    Zonemaster::Engine::Translator->initialize( { locale => 'sv_SE.UTF-8' } );
+    Zonemaster::Engine::Translator->initialize( locale => 'sv_SE.UTF-8' );
 
 This method must be called at most once and before the first call to instance().
 

--- a/lib/Zonemaster/Engine/Translator.pm
+++ b/lib/Zonemaster/Engine/Translator.pm
@@ -393,8 +393,6 @@ is the same as if initialize() had been called without arguments.
 
 Use of this method is deprecated.
 
-See L<MooseX::Singleton->new|MooseX::Singleton/"Singleton->new">.
-
 =over
 
 =item locale

--- a/t/translator.t
+++ b/t/translator.t
@@ -17,8 +17,13 @@ $json        = read_file( 't/profiles/Test-all-levels.json' );
 $profile_tmp = Zonemaster::Engine::Profile->from_json( $json );
 Zonemaster::Engine::Profile->effective->merge( $profile_tmp );
 
+Zonemaster::Engine::Translator->initialize( locale => 'C' );
+
 subtest 'Everything but Test::NoWarnings' => sub {
-    my $trans = new_ok( 'Zonemaster::Engine::Translator' => [ locale => 'C' ] );
+    my $trans = Zonemaster::Engine::Translator->instance();
+    isa_ok $trans, 'Zonemaster::Engine::Translator',
+        'Zonemaster::Engine::Translator->instance()';
+
     ok( exists $trans->data->{Basic}{B01_PARENT_FOUND}, 'expected key from file exists' );
     ok( exists $trans->data->{DNSSEC}{ALGORITHM_OK},    'expected key from module exists' );
 


### PR DESCRIPTION
## Purpose

This PR fixes a bug in Zonemaster::Engine::Translator that causes problems in Zonemaster::Backend::Translator (in Backend, not Engine), which inherits from Zonemaster::Engine::Translator.

## Context

While adding unit tests in Zonemaster::Backend for its Translator module, I noticed that the `instance()` method in Zonemaster::Engine::Translator always returned `undef` instead of a Translator object.

## Changes

- Fix a bug in the `instance()` method which prevented it from working as documented.
- Fix small mistakes in the module’s documentation.
- Change unit test so that it calls `instance()` instead of `new()`, to exercise the code.

## How to test this PR

Run the test suite in Zonemaster::Engine. Expect all unit tests to pass.