### PR TITLE
sort generated data files

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -523,6 +523,8 @@ sub save {
 
     my $old = POSIX::setlocale( POSIX::LC_ALL, 'C' );
     my $json = JSON::PP->new->allow_blessed->convert_blessed;
+    $json = $json->canonical(1);
+
     open my $fh, '>', $filename or die "Cache save failed: $!";
     foreach my $name ( sort keys %object_cache ) {
         foreach my $addr ( sort keys %{ $object_cache{$name} } ) {

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -528,6 +528,13 @@ sub save {
     open my $fh, '>', $filename or die "Cache save failed: $!";
     foreach my $name ( sort keys %object_cache ) {
         foreach my $addr ( sort keys %{ $object_cache{$name} } ) {
+
+            # set ID field of packets to 0
+            my %data = %{$object_cache{$name}{$addr}->cache->data};
+            foreach my $key ( keys %data){
+                $data{$key}->packet->id(0) if defined($data{$key});
+            }
+
             say $fh "$name $addr " . $json->encode( $object_cache{$name}{$addr}->cache->data );
         }
     }

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -524,8 +524,8 @@ sub save {
     my $old = POSIX::setlocale( POSIX::LC_ALL, 'C' );
     my $json = JSON::PP->new->allow_blessed->convert_blessed;
     open my $fh, '>', $filename or die "Cache save failed: $!";
-    foreach my $name ( keys %object_cache ) {
-        foreach my $addr ( keys %{ $object_cache{$name} } ) {
+    foreach my $name ( sort keys %object_cache ) {
+        foreach my $addr ( sort keys %{ $object_cache{$name} } ) {
             say $fh "$name $addr " . $json->encode( $object_cache{$name}{$addr}->cache->data );
         }
     }

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -528,13 +528,6 @@ sub save {
     open my $fh, '>', $filename or die "Cache save failed: $!";
     foreach my $name ( sort keys %object_cache ) {
         foreach my $addr ( sort keys %{ $object_cache{$name} } ) {
-
-            # set ID field of packets to 0
-            my %data = %{ $object_cache{$name}{$addr}->cache->data };
-            foreach my $key ( keys %data ){
-                $data{$key}->packet->id( 0 ) if defined( $data{$key} );
-            }
-
             say $fh "$name $addr " . $json->encode( $object_cache{$name}{$addr}->cache->data );
         }
     }

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -523,16 +523,16 @@ sub save {
 
     my $old = POSIX::setlocale( POSIX::LC_ALL, 'C' );
     my $json = JSON::PP->new->allow_blessed->convert_blessed;
-    $json = $json->canonical(1);
+    $json = $json->canonical( 1 );
 
     open my $fh, '>', $filename or die "Cache save failed: $!";
     foreach my $name ( sort keys %object_cache ) {
         foreach my $addr ( sort keys %{ $object_cache{$name} } ) {
 
             # set ID field of packets to 0
-            my %data = %{$object_cache{$name}{$addr}->cache->data};
-            foreach my $key ( keys %data){
-                $data{$key}->packet->id(0) if defined($data{$key});
+            my %data = %{ $object_cache{$name}{$addr}->cache->data };
+            foreach my $key ( keys %data ){
+                $data{$key}->packet->id( 0 ) if defined( $data{$key} );
             }
 
             say $fh "$name $addr " . $json->encode( $object_cache{$name}{$addr}->cache->data );


### PR DESCRIPTION
## Purpose

This PR improve generating data files by sorting entries in *.data files and ensuring JSON dump are also sorted.
The goal is to reduce the mess of deletions and insertions from `git diff` when `t/*.data` files are modified.

## Context

Fixes #1265 

## How to test this PR

run ```ZONEMASTER_RECORD=1 make test``` to save new formated *.data file.

- "t/*.data" file must be sorted
- each "Zonemaster::LDNS::Packet" JSON dump must also be sorted

## Notes

To improve visibility of change we can also activate indentation of JSON dump with `$json->indent( 1 );`.
This makes it easier to read the differences between JSON dump with `vimdiff` or `git diff` but makes `*.data` files less readable/compact.