### PR TITLE
Profile fixes

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver/Cache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache.pm
@@ -16,12 +16,10 @@ sub get_cache_type {
     my ( $class, $profile ) = @_;
     my $cache_type = 'LocalCache';
 
-    if ( $profile->get( 'cache' ) ) {
-        my %cache_config = %{ $profile->get( 'cache' ) };
+    my %cache_config = %{ $profile->get( 'cache' ) };
 
-        if ( exists $cache_config{'redis'} ) {
-            $cache_type = 'RedisCache';
-        }
+    if ( exists $cache_config{'redis'} ) {
+        $cache_type = 'RedisCache';
     }
 
     return $cache_type;

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -49,7 +49,8 @@ my %profile_properties_details = (
                     }
                 }
             }
-        }
+        },
+        default => {},
     },
     q{resolver.defaults.debug} => {
         type    => q{Bool}
@@ -83,7 +84,7 @@ my %profile_properties_details = (
         type    => q{Str},
         test    => sub {
             unless ( $_[0] eq '' or validate_ipv4( $_[0] ) ) {
-                die "Property resolver.source4 must be a valid IPv4 address";
+                die "Property resolver.source4 must be an IPv4 address or the empty string";
             }
         },
         default => q{}
@@ -92,7 +93,7 @@ my %profile_properties_details = (
         type    => q{Str},
         test    => sub {
             unless ( $_[0] eq '' or validate_ipv6( $_[0] ) ) {
-                die "Property resolver.source6 must be a valid IPv6 address";
+                die "Property resolver.source6 must be a valid IPv6 address or the empty string";
             }
         },
         default => q{}
@@ -117,7 +118,8 @@ my %profile_properties_details = (
                     die "Property asnroots has a non domain name item" if $label !~ /^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/;
                 }
             }
-        }
+        },
+        default => ["asnlookup.zonemaster.net"],
     },
     q{asn_db.style} => {
         type    => q{Str},
@@ -152,7 +154,7 @@ my %profile_properties_details = (
                 }
             }
         },
-        default => { cymru => [ "asnlookup.zonemaster.net" ] }
+        default => { cymru => [ "asnlookup.zonemaster.net" ] },
     },
     q{logfilter} => {
         type    => q{HashRef},
@@ -296,6 +298,11 @@ sub default {
     }
 
     return $new;
+}
+
+sub all_properties {
+    my ( $class ) = @_;
+    return sort keys %profile_properties_details;
 }
 
 sub get {
@@ -613,6 +620,12 @@ Serialize the profile to the L</JSON REPRESENTATION> format.
 
 Returns a string.
 
+=head2 all_properties
+
+Get the names of all properties.
+
+Returns a sorted list of strings.
+
 =head1 SUBROUTINES
 
 =head2 _get_profile_paths
@@ -744,12 +757,9 @@ Default C<"asnlookup.zonemaster.net">.
 =head2 cache (EXPERIMENTAL)
 
 A hash of hashes. The currently supported keys are C<"redis">.
+Default C<{}>.
 
-See more information in L<cache.redis>.
-
-Undefined by default.
-
-=head2 cache.redis (EXPERIMENTAL)
+=head3 redis
 
 A hashref. The currently supported keys are C<"server"> and C<"expire">.
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -27,11 +27,11 @@ my %profile_properties_details = (
             my @allowed_keys = ( 'redis' );
             foreach my $cache_database ( keys %{$_[0]} ) {
                 if ( not grep( /^$cache_database$/, @allowed_keys ) ) {
-                    die "Property cache keys have " . scalar @allowed_keys . " possible values: " . join(", ", @allowed_keys);
+                    die "Property cache keys have " . scalar @allowed_keys . " possible values: " . join(", ", @allowed_keys) . "\n";
                 }
 
                 if ( not scalar keys %{ $_[0]->{$cache_database} } ) {
-                    die "Property cache.$cache_database has no items";
+                    die "Property cache.$cache_database has no items\n";
                 }
                 else {
                     my @allowed_subkeys;
@@ -41,11 +41,11 @@ my %profile_properties_details = (
 
                     foreach my $key ( keys %{ $_[0]->{$cache_database} } ) {
                         if ( not grep( /^$key$/, @allowed_subkeys ) ) {
-                            die "Property cache.$cache_database subkeys have " . scalar @allowed_subkeys . " possible values: " . join(", ", @allowed_subkeys);
+                            die "Property cache.$cache_database subkeys have " . scalar @allowed_subkeys . " possible values: " . join(", ", @allowed_subkeys) . "\n";
                         }
 
-                        die "Property cache.$cache_database.$key has a NULL or empty item" if not $_[0]->{$cache_database}->{$key};
-                        die "Property cache.$cache_database.$key has a negative value" if ( looks_like_number( $_[0]->{$cache_database}->{$key} ) and $_[0]->{$cache_database}->{$key} < 0 ) ;
+                        die "Property cache.$cache_database.$key has a NULL or empty item\n" if not $_[0]->{$cache_database}->{$key};
+                        die "Property cache.$cache_database.$key has a negative value\n" if ( looks_like_number( $_[0]->{$cache_database}->{$key} ) and $_[0]->{$cache_database}->{$key} < 0 ) ;
                     }
                 }
             }
@@ -84,7 +84,7 @@ my %profile_properties_details = (
         type    => q{Str},
         test    => sub {
             unless ( $_[0] eq '' or validate_ipv4( $_[0] ) ) {
-                die "Property resolver.source4 must be an IPv4 address or the empty string";
+                die "Property resolver.source4 must be an IPv4 address or the empty string\n";
             }
         },
         default => q{}
@@ -93,7 +93,7 @@ my %profile_properties_details = (
         type    => q{Str},
         test    => sub {
             unless ( $_[0] eq '' or validate_ipv6( $_[0] ) ) {
-                die "Property resolver.source6 must be a valid IPv6 address or the empty string";
+                die "Property resolver.source6 must be a valid IPv6 address or the empty string\n";
             }
         },
         default => q{}
@@ -111,11 +111,11 @@ my %profile_properties_details = (
         type    => q{ArrayRef},
         test    => sub {
             foreach my $ndd ( @{$_[0]} ) {
-                die "Property asnroots has a NULL item" if not defined $ndd;
-                die "Property asnroots has a non scalar item" if not defined ref($ndd);
-                die "Property asnroots has an item too long" if length($ndd) > 255;
+                die "Property asnroots has a NULL item\n" if not defined $ndd;
+                die "Property asnroots has a non scalar item\n" if not defined ref($ndd);
+                die "Property asnroots has an item too long\n" if length($ndd) > 255;
                 foreach my $label ( split /[.]/, $ndd ) {
-                    die "Property asnroots has a non domain name item" if $label !~ /^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/;
+                    die "Property asnroots has a non domain name item\n" if $label !~ /^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/;
                 }
             }
         },
@@ -125,7 +125,7 @@ my %profile_properties_details = (
         type    => q{Str},
         test    => sub {
             if ( lc($_[0]) ne q{cymru} and lc($_[0]) ne q{ripe} ) {
-                die "Property asn_db.style has 2 possible values : Cymru or RIPE (case insensitive)";
+                die "Property asn_db.style has 2 possible values : Cymru or RIPE (case insensitive)\n";
             }
             $_[0] = lc($_[0]);
         },
@@ -136,18 +136,18 @@ my %profile_properties_details = (
         test    => sub {
             foreach my $db_style ( keys %{$_[0]} ) {
                 if ( lc($db_style) ne q{cymru} and lc($db_style) ne q{ripe} ) {
-                    die "Property asn_db.sources keys have 2 possible values : Cymru or RIPE (case insensitive)";
+                    die "Property asn_db.sources keys have 2 possible values : Cymru or RIPE (case insensitive)\n";
                 }
                 if ( not scalar @{ ${$_[0]}{$db_style} } ) {
-                    die "Property asn_db.sources.$db_style has no items";
+                    die "Property asn_db.sources.$db_style has no items\n";
                 }
                 else {
                     foreach my $ndd ( @{ ${$_[0]}{$db_style} } ) {
-                        die "Property asn_db.sources.$db_style has a NULL item" if not defined $ndd;
-                        die "Property asn_db.sources.$db_style has a non scalar item" if not defined ref($ndd);
-                        die "Property asn_db.sources.$db_style has an item too long" if length($ndd) > 255;
+                        die "Property asn_db.sources.$db_style has a NULL item\n" if not defined $ndd;
+                        die "Property asn_db.sources.$db_style has a non scalar item\n" if not defined ref($ndd);
+                        die "Property asn_db.sources.$db_style has an item too long\n" if length($ndd) > 255;
                         foreach my $label ( split /[.]/, $ndd ) {
-                            die "Property asn_db.sources.$db_style has a non domain name item" if $label !~ /^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/;
+                            die "Property asn_db.sources.$db_style has a non domain name item\n" if $label !~ /^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/;
                         }
                     }
                     ${$_[0]}{lc($db_style)} = delete ${$_[0]}{$db_style};
@@ -308,7 +308,7 @@ sub all_properties {
 sub get {
     my ( $self, $property_name ) = @_;
 
-    die "Unknown property '$property_name'"  if not exists $profile_properties_details{$property_name};
+    die "Unknown property '$property_name'\n"  if not exists $profile_properties_details{$property_name};
 
     if ( $profile_properties_details{$property_name}->{type} eq q{ArrayRef} or $profile_properties_details{$property_name}->{type} eq q{HashRef} ) {
         return clone _get_value_from_nested_hash( $self->{q{profile}}, split /[.]/, $property_name );
@@ -328,7 +328,7 @@ sub _set {
     my $value_type = reftype($value);
     my $data_details;
 
-    die "Unknown property '$property_name'" if not exists $profile_properties_details{$property_name};
+    die "Unknown property '$property_name'\n" if not exists $profile_properties_details{$property_name};
 
     $data_details = sprintf "[TYPE=%s][FROM=%s][VALUE_TYPE=%s][VALUE=%s]\n%s",
                             exists $profile_properties_details{$property_name}->{type} ? $profile_properties_details{$property_name}->{type} : q{UNDEF},
@@ -338,7 +338,7 @@ sub _set {
                             Data::Dumper::Dumper($value);
     # $value is a Scalar
     if ( ! $value_type  or $value_type eq q{SCALAR} ) {
-        die "Property $property_name can not be undef" if not defined $value;
+        die "Property $property_name can not be undef\n" if not defined $value;
 
         # Boolean
         if ( $profile_properties_details{$property_name}->{type} eq q{Bool} ) {
@@ -355,19 +355,19 @@ sub _set {
                 $value = JSON::PP::true;
             }
             else {
-                die "Property $property_name is of type Boolean $data_details";
+                die "Property $property_name is of type Boolean $data_details\n";
             }
         }
         # Number. In our case, only non-negative integers
         elsif ( $profile_properties_details{$property_name}->{type} eq q{Num} ) {
             if ( $value !~ /^(\d+)$/ ) {
-                die "Property $property_name is of type non-negative integer $data_details";
+                die "Property $property_name is of type non-negative integer $data_details\n";
             }
             if ( exists $profile_properties_details{$property_name}->{min} and $value < $profile_properties_details{$property_name}->{min} ) {
-                die "Property $property_name value is out of limit (smaller)";
+                die "Property $property_name value is out of limit (smaller)\n";
             }
             if ( exists $profile_properties_details{$property_name}->{max} and $value > $profile_properties_details{$property_name}->{max} ) {
-                die "Property $property_name value is out of limit (bigger)";
+                die "Property $property_name value is out of limit (bigger)\n";
             }
 
             $value = 0+ $value;    # Make sure JSON::PP doesn't serialize it as a JSON string
@@ -376,14 +376,14 @@ sub _set {
     else {
         # Array
         if ( $profile_properties_details{$property_name}->{type} eq q{ArrayRef} and reftype($value) ne q{ARRAY} ) {
-            die "Property $property_name is not a ArrayRef $data_details";
+            die "Property $property_name is not a ArrayRef $data_details\n";
         }
         # Hash
         elsif ( $profile_properties_details{$property_name}->{type} eq q{HashRef} and reftype($value) ne q{HASH} ) {
-            die "Property $property_name is not a HashRef $data_details";
+            die "Property $property_name is not a HashRef $data_details\n";
         }
         elsif ( $profile_properties_details{$property_name}->{type} eq q{Bool} or $profile_properties_details{$property_name}->{type} eq q{Num} or $profile_properties_details{$property_name}->{type} eq q{Str} ) {
-            die "Property $property_name is a Scalar $data_details";
+            die "Property $property_name is a Scalar $data_details\n";
         }
     }
 
@@ -397,7 +397,7 @@ sub _set {
 sub merge {
     my ( $self, $other_profile ) = @_;
 
-    die "Merge with ", __PACKAGE__, " only" if ref($other_profile) ne __PACKAGE__;
+    die "Merge with ", __PACKAGE__, " only\n" if ref($other_profile) ne __PACKAGE__;
 
     foreach my $property_name ( keys %profile_properties_details ) {
         if ( defined _get_value_from_nested_hash( $other_profile->{q{profile}}, split /[.]/, $property_name ) ) {

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -10,9 +10,7 @@ use Test::Differences;
 use Test::Exception;
 use Log::Any qw( $log );
 
-BEGIN {
-    use_ok 'Zonemaster::Engine::Profile';
-}
+use Zonemaster::Engine::Profile;
 
 # YAML representation of an example profile with all properties set
 Readonly my $EXAMPLE_PROFILE_1_YAML => q(

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -174,22 +174,9 @@ subtest 'new() returns a new profile every time' => sub {
 subtest 'new() returns a profile with all properties unset' => sub {
     my $profile = Zonemaster::Engine::Profile->new;
 
-    is $profile->get( 'resolver.defaults.usevc' ),    undef, 'resolver.defaults.usevc is unset';
-    is $profile->get( 'resolver.defaults.retrans' ),  undef, 'resolver.defaults.retrans is unset';
-    is $profile->get( 'resolver.defaults.recurse' ),  undef, 'resolver.defaults.recurse is unset';
-    is $profile->get( 'resolver.defaults.retry' ),    undef, 'resolver.defaults.retry is unset';
-    is $profile->get( 'resolver.defaults.igntc' ),    undef, 'resolver.defaults.igntc is unset';
-    is $profile->get( 'resolver.defaults.fallback' ), undef, 'resolver.defaults.fallback is unset';
-    is $profile->get( 'resolver.source4' ),           undef, 'resolver.source4 is unset';
-    is $profile->get( 'resolver.source6' ),           undef, 'resolver.source6 is unset';
-    is $profile->get( 'net.ipv4' ),                   undef, 'net.ipv4 is unset';
-    is $profile->get( 'net.ipv6' ),                   undef, 'net.ipv6 is unset';
-    is $profile->get( 'no_network' ),                 undef, 'no_network is unset';
-    is $profile->get( 'asnroots' ),                   undef, 'asnroots is unset';
-    is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
-    is $profile->get( 'test_levels' ),                undef, 'test_levels is unset';
-    is $profile->get( 'test_cases' ),                 undef, 'test_cases is unset';
-    is $profile->get( 'cache' ),                      undef, 'cache is unset';
+    for my $property ( Zonemaster::Engine::Profile->all_properties ) {
+        is $profile->get( $property ), undef, "$property is unset";
+    }
 };
 
 subtest 'default() returns a new profile every time' => sub {
@@ -205,18 +192,9 @@ subtest 'default() returns a new profile every time' => sub {
 subtest 'default() returns a profile with all properties set' => sub {
     my $profile = Zonemaster::Engine::Profile->default;
 
-    ok defined( $profile->get( 'resolver.defaults.usevc' ) ),    'resolver.defaults.usevc is set';
-    ok defined( $profile->get( 'resolver.defaults.recurse' ) ),  'resolver.defaults.recurse is set';
-    ok defined( $profile->get( 'resolver.defaults.igntc' ) ),    'resolver.defaults.igntc is set';
-    ok defined( $profile->get( 'resolver.defaults.fallback' ) ), 'resolver.defaults.fallback is set';
-    ok defined( $profile->get( 'net.ipv4' ) ),                   'net.ipv4 is set';
-    ok defined( $profile->get( 'net.ipv6' ) ),                   'net.ipv6 is set';
-    ok defined( $profile->get( 'no_network' ) ),                 'no_network is set';
-    ok defined( $profile->get( 'resolver.defaults.retry' ) ),    'resolver.defaults.retry is set';
-    ok defined( $profile->get( 'resolver.defaults.retrans' ) ),  'resolver.defaults.retrans is set';
-    ok defined( $profile->get( 'logfilter' ) ),                  'logfilter is set';
-    ok defined( $profile->get( 'test_levels' ) ),                'test_levels is set';
-    ok defined( $profile->get( 'test_cases' ) ),                 'test_cases is set';
+    for my $property ( Zonemaster::Engine::Profile->all_properties ) {
+        ok defined( $profile->get( $property ) ), "$property is set";
+    }
 };
 
 subtest 'from_json() returns a new profile every time' => sub {
@@ -231,22 +209,9 @@ subtest 'from_json() returns a new profile every time' => sub {
 subtest 'from_json("{}") returns a profile with all properties unset' => sub {
     my $profile = Zonemaster::Engine::Profile->from_json( "{}" );
 
-    is $profile->get( 'resolver.defaults.usevc' ),    undef, 'resolver.defaults.usevc is unset';
-    is $profile->get( 'resolver.defaults.recurse' ),  undef, 'resolver.defaults.recurse is unset';
-    is $profile->get( 'resolver.defaults.igntc' ),    undef, 'resolver.defaults.igntc is unset';
-    is $profile->get( 'resolver.defaults.fallback' ), undef, 'resolver.defaults.fallback is unset';
-    is $profile->get( 'net.ipv4' ),                   undef, 'net.ipv4 is unset';
-    is $profile->get( 'net.ipv6' ),                   undef, 'net.ipv6 is unset';
-    is $profile->get( 'no_network' ),                 undef, 'no_network is unset';
-    is $profile->get( 'resolver.defaults.retry' ),    undef, 'resolver.defaults.retry is unset';
-    is $profile->get( 'resolver.defaults.retrans' ),  undef, 'resolver.defaults.retrans is unset';
-    is $profile->get( 'resolver.source4' ),           undef, 'resolver.source4 is unset';
-    is $profile->get( 'resolver.source6' ),           undef, 'resolver.source6 is unset';
-    is $profile->get( 'asnroots' ),                   undef, 'asnroots is unset';
-    is $profile->get( 'logfilter' ),                  undef, 'logfilter is unset';
-    is $profile->get( 'test_levels' ),                undef, 'test_levels is unset';
-    is $profile->get( 'test_cases' ),                 undef, 'test_cases is unset';
-    is $profile->get( 'cache' ),                      undef, 'cache is unset';
+    for my $property ( Zonemaster::Engine::Profile->all_properties ) {
+        is $profile->get( $property ), undef, "$property is unset";
+    }
 };
 
 subtest 'from_json() parses values from a string' => sub {
@@ -501,22 +466,9 @@ subtest 'set() updates values for set properties' => sub {
 subtest 'set() dies on attempts to unset properties' => sub {
     my $profile = Zonemaster::Engine::Profile->from_json( $EXAMPLE_PROFILE_1 );
 
-    throws_ok { $profile->set( 'resolver.defaults.usevc',    undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.usevc';
-    throws_ok { $profile->set( 'resolver.defaults.recurse',  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.recurse';
-    throws_ok { $profile->set( 'resolver.defaults.igntc',    undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.igntc';
-    throws_ok { $profile->set( 'resolver.defaults.fallback', undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.fallback';
-    throws_ok { $profile->set( 'net.ipv4',                   undef ); } qr/^.* can not be undef/, 'dies on attempt to unset net.ipv4';
-    throws_ok { $profile->set( 'net.ipv6',                   undef ); } qr/^.* can not be undef/, 'dies on attempt to unset net.ipv6';
-    throws_ok { $profile->set( 'no_network',                 undef ); } qr/^.* can not be undef/, 'dies on attempt to unset no_network';
-    throws_ok { $profile->set( 'resolver.defaults.retry',    undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.retry';
-    throws_ok { $profile->set( 'resolver.defaults.retrans',  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.defaults.retans';
-    throws_ok { $profile->set( 'resolver.source4',           undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source4';
-    throws_ok { $profile->set( 'resolver.source6',           undef ); } qr/^.* can not be undef/, 'dies on attempt to unset resolver.source6';
-    throws_ok { $profile->set( 'asnroots',                   undef ); } qr/^.* can not be undef/, 'dies on attempt to unset asnroots';
-    throws_ok { $profile->set( 'logfilter',                  undef ); } qr/^.* can not be undef/, 'dies on attempt to unset logfilter';
-    throws_ok { $profile->set( 'test_levels',                undef ); } qr/^.* can not be undef/, 'dies on attempt to unset test_levels';
-    throws_ok { $profile->set( 'test_cases',                 undef ); } qr/^.* can not be undef/, 'dies on attempt to unset test_cases';
-    throws_ok { $profile->set( 'cache',                      undef ); } qr/^.* can not be undef/, 'dies on attempt to unset cache';
+    for my $property ( Zonemaster::Engine::Profile->all_properties ) {
+        throws_ok { $profile->set( $property, undef ); } qr/^.* can not be undef/, "dies on attempt to unset $property";
+    }
 };
 
 subtest 'set() dies if the given property name is invalid' => sub {

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -1,7 +1,7 @@
 use 5.006;
 use strict;
-use warnings FATAL   => 'all';
-use Test::More tests => 29;
+use warnings FATAL => 'all';
+use Test::More;
 use Log::Any::Test;    # Must come before use Log::Any
 
 use JSON::PP;
@@ -844,3 +844,5 @@ subtest 'effective() returns the same profile every time' => sub {
 
     is $profile1->get( 'resolver.defaults.retry' ), 222;
 };
+
+done_testing;

--- a/t/profiles.t
+++ b/t/profiles.t
@@ -549,13 +549,15 @@ subtest 'set() dies on illegal value' => sub {
     dies_ok { $profile->set( 'resolver.defaults.retrans', 0 ); } 'checks lower bound of resolver.defaults.retrans';
     dies_ok { $profile->set( 'resolver.defaults.retrans', 256 ); } 'checks upper bound of resolver.defaults.retrans';
     dies_ok { $profile->set( 'resolver.defaults.retrans', 1.5 ); } 'checks type of resolver.defaults.retrans';
-    dies_ok { $profile->set( 'resolver.source4', ['192.0.2.53'] ); } 'checks type of resolver.source4';
-    dies_ok { $profile->set( 'resolver.source6', ['2001:db8::42'] ); } 'checks type of resolver.source6';
-    dies_ok { $profile->set( 'asnroots',        ['noreply@example.com'] ); } 'checks type of asnroots';
-    dies_ok { $profile->set( 'logfilter',       [] ); } 'checks type of logfilter';
-    dies_ok { $profile->set( 'test_levels',     [] ); } 'checks type of test_levels';
-    dies_ok { $profile->set( 'test_cases',      {} ); } 'checks type of test_cases';
-    dies_ok { $profile->set( 'cache',           [] ); } 'checks type of cache';
+    dies_ok { $profile->set( 'resolver.source4', 'example.com' ); } 'resolver.source4 rejects domain name string';
+    dies_ok { $profile->set( 'resolver.source4', ['192.0.2.53'] ); } 'resolver.source4 rejects arrayref';
+    dies_ok { $profile->set( 'resolver.source6', 'example.com' ); } 'resolver.source6 rejects domain name string';
+    dies_ok { $profile->set( 'resolver.source6', ['2001:db8::42'] ); } 'resolver.source6 rejects arrayref';
+    dies_ok { $profile->set( 'asnroots',         ['noreply@example.com'] ); } 'checks type of asnroots';
+    dies_ok { $profile->set( 'logfilter',        [] ); } 'checks type of logfilter';
+    dies_ok { $profile->set( 'test_levels',      [] ); } 'checks type of test_levels';
+    dies_ok { $profile->set( 'test_cases',       {} ); } 'checks type of test_cases';
+    dies_ok { $profile->set( 'cache',            [] ); } 'checks type of cache';
 };
 
 subtest 'set() accepts sentinel values' => sub {


### PR DESCRIPTION
## Purpose

The initial aim of this PR was to add some missing properties to the default profile. But in the process of making the update I discovered more problems with the profile and I'm including fixes for all of them here.

## Context

Fixes #1355.

Conflicts but is not blocked by #1257.

I marked this minor because of the new Zonemaster::Engine::Profile->all_properties method. Otherwise this would be V-Patch.

## Changes

* The default value for one property is specified:
  * `cache`
* The default values for some properties are implemented:
  * `asnroots`
  * `cache`
* Validation error messages are updated to state that the empty string is a valid value for some properties:
  * `resolver.source4`
  * `resolver.source6`
* Unit tests for invariants that cover all properties are updated to loop over the properties. Historically we tried and failed to include all properties in these tests.
  * 'new() returns a profile with all properties unset'
  * 'default() returns a profile with all properties set'
  * 'from_json("{}") returns a profile with all properties unset'
  * 'set() dies on attempts to unset properties'
* A new method is introduced to facilitate the improved unit testing:
  * Zonemaster::Engine::Profile->all_properties()

## How to test this PR

Run the unit tests.