### PR TITLE
Fix undef eq comparison

### DIFF
--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -85,7 +85,8 @@ my %profile_properties_details = (
             unless ( $_[0] eq '' or validate_ipv4( $_[0] ) ) {
                 die "Property resolver.source4 must be a valid IPv4 address";
             }
-        }
+        },
+        default => q{}
     },
     q{resolver.source6} => {
         type    => q{Str},
@@ -93,7 +94,8 @@ my %profile_properties_details = (
             unless ( $_[0] eq '' or validate_ipv6( $_[0] ) ) {
                 die "Property resolver.source6 must be a valid IPv6 address";
             }
-        }
+        },
+        default => q{}
     },
     q{net.ipv4} => {
         type    => q{Bool}


### PR DESCRIPTION
## Purpose

This PR fixes an oversight from #1343.

## Changes

- Set default value of properties 'resolver.source{4,6}' in Profile.pm

## How to test this PR

Checks should now pass.
