### PR TITLE
Reword messages when no response is received

### DIFF
--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -249,7 +249,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     B02_NS_NO_RESPONSE => sub {
         __x    # BASIC:B02_NS_NO_RESPONSE
-          'Name server "{ns}" does not respond to an SOA query.', @_;
+          'No response received from name server "{ns}" to SOA query.', @_;
     },
     B02_UNEXPECTED_RCODE => sub {
         __x    # BASIC:B02_UNEXPECTED_RCODE

--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -190,15 +190,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CN01_NO_RESPONSE_NS_QUERY_UDP => sub {
         __x    # CONNECTIVITY:CN01_NO_RESPONSE_NS_QUERY_UDP
-          'Nameserver {ns} does not respond to NS queries over UDP.', @_;
+          'No response received from name server "{ns}" to NS queries over UDP.', @_;
     },
     CN01_NO_RESPONSE_SOA_QUERY_UDP => sub {
         __x    # CONNECTIVITY:CN01_NO_RESPONSE_SOA_QUERY_UDP
-          'Nameserver {ns} does not respond to SOA queries over UDP.', @_;
+          'No response received from name server "{ns}" to SOA queries over UDP.', @_;
     },
     CN01_NO_RESPONSE_UDP => sub {
         __x    # CONNECTIVITY:CN01_NO_RESPONSE_UDP
-          'Nameserver {ns} does not respond to any queries over UDP.', @_;
+          'No response received from name server "{ns}" to any queries over UDP.', @_;
     },
     CN01_NS_RECORD_NOT_AA_UDP => sub {
         __x    # CONNECTIVITY:CN01_NS_RECORD_NOT_AA_UDP
@@ -234,15 +234,15 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     CN02_NO_RESPONSE_NS_QUERY_TCP => sub {
         __x    # CONNECTIVITY:CN02_NO_RESPONSE_NS_QUERY_TCP
-          'Nameserver {ns} does not respond to NS queries over TCP.', @_;
+          'No response received from name server "{ns}" to NS queries over TCP.', @_;
     },
     CN02_NO_RESPONSE_SOA_QUERY_TCP => sub {
         __x    # CONNECTIVITY:CN02_NO_RESPONSE_SOA_QUERY_TCP
-          'Nameserver {ns} does not respond to SOA queries over TCP.', @_;
+          'No response received from name server "{ns}" to SOA queries over TCP.', @_;
     },
     CN02_NO_RESPONSE_TCP => sub {
         __x    # CONNECTIVITY:CN02_NO_RESPONSE_TCP
-          'Nameserver {ns} does not respond to any queries over TCP.', @_;
+          'No response received from name server "{ns}" to any queries over TCP.', @_;
     },
     CN02_NS_RECORD_NOT_AA_TCP => sub {
         __x    # CONNECTIVITY:CN02_NS_RECORD_NOT_AA_TCP

--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -402,7 +402,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     Z01_MNAME_NO_RESPONSE => sub {
         __x    # ZONE:Z01_MNAME_NO_RESPONSE
-          'SOA MNAME name server "{ns}" does not respond to an SOA query.', @_;
+          'No response received from SOA MNAME name server "{ns}" to SOA query.', @_;
     },
     Z01_MNAME_NOT_AUTHORITATIVE => sub {
         __x    # ZONE:Z01_MNAME_NOT_AUTHORITATIVE


### PR DESCRIPTION
## Purpose

Clarify that zonemaster doesn't actually know if the server didn't receive the request, didn't send a response, or if the response was lost somewhere along the way.

## Context

Fixes #1354
https://github.com/zonemaster/zonemaster/pull/1277

I'm mostly avoiding harmonizing `query` and `queries` here per https://github.com/zonemaster/zonemaster-engine/issues/1354#issuecomment-2189214720 although I am dropping some `an` that I don't think are valuable. I can adjust (restoring the an, or doing the harmonization) -- but I'd kinda like to avoid a broader harmonization for `queries` as that'd require more care and attention than the `name server` work which I'm drafting...

## Changes

Error messages are reworded to `No response received from name server ...`

## How to test this PR

Oddly, none of these changes appear to require changing the tests... But, testing would involve using zonemaster-engine in these cases and checking the error messages
