### PR TITLE
Fix regression in Syntax04

### DIFF
--- a/lib/Zonemaster/Engine/Test/Syntax.pm
+++ b/lib/Zonemaster/Engine/Test/Syntax.pm
@@ -834,7 +834,7 @@ sub syntax04 {
         )
       )
     {
-        push @results, _check_name_syntax( q{NAMESERVER}, $zone->name );
+        push @results, _check_name_syntax( q{NAMESERVER}, $local_nsname );
     }
 
     return ( @results, _emit_log( TEST_CASE_END => { testcase => $Zonemaster::Engine::Logger::TEST_CASE_NAME } ) );


### PR DESCRIPTION
## Purpose

This PR fixes a small regression caused by code refactoring.

## Context

See #1368 (and the original changes that introduced the regression being addressed by this PR: #1322).

## Changes

- Refer to the correct variable inside a loop checking the syntax of a zone’s name servers’ names.

## How to test this PR

Run the following two tests.

Firstly, run the following command:
```
perl -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_method("syntax", "syntax04", "hipotel.fr");'
``` 

Expect one of the lines in the output to have a `NAMESERVER_NON_ALLOWED_CHARS` message like so:
```
Syntax:Syntax04:NAMESERVER_NON_ALLOWED_CHARS domain="100\\0321\\032443\\032sipdir.online.lync.com"
```

Secondly, run a complete test on `hipotel.fr`, either using `zonemaster-cli hipotel.fr` or from GUI. Expect an error message stating “Found illegal characters in the nameserver (100\0321\032443\032sipdir.online.lync.com).”.