### PR TITLE
Fix spelling errors

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -289,7 +289,7 @@ Returns the global L<Zonemaster::Engine::Logger> object.
 
 =item all_tags()
 
-Returns a list of all the tags that can be logged for all avilable test modules.
+Returns a list of all the tags that can be logged for all available test modules.
 
 =item all_methods()
 

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -724,7 +724,7 @@ A L<Net::IP::XS> object holding the nameserver's address.
 
 =item dns
 
-The L<Zonemaster::LDNS> object used to actually send and recieve DNS queries.
+The L<Zonemaster::LDNS> object used to actually send and receive DNS queries.
 
 =item cache
 

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -426,7 +426,7 @@ argument.
 
 =head2 add_fake_addresses($domain, $data)
 
-Class method to create fake adresses for fake delegations for a specified domain from data provided.
+Class method to create fake addresses for fake delegations for a specified domain from data provided.
 
 =head2 has_fake_addresses($domain)
 


### PR DESCRIPTION
(Note, this patch has initially been forwarded to [RT CPAN].)

[RT CPAN]: https://rt.cpan.org/Public/Bug/Display.html?id=118720

## Purpose

This PR fixes three typos that were initially addressed in Debian only.

## Context

N/A.

## Changes

Three typos were fixed.

## How to test this PR

N/A.
