### PR TITLE
Fix bareword in Zonemaster::Engine.

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -37,7 +37,7 @@ my $init_done = 0;
 
 sub init_engine {
     return if $init_done++;
-    Zonemaster::Engine::Recursor::init_recursor;
+    Zonemaster::Engine::Recursor::init_recursor();
 }
 
 sub logger {


### PR DESCRIPTION
## Purpose

This request consists in invoking Zonemaster::Engine::Recursor::init_recursor method instead of readying it for futher invocation, as a syntax check flags it as a Bareword.

## Context

Running Debian Perl Team's syntax checks on Zonemaster::Engine reveals the following issues:

	# Bareword "Zonemaster::Engine::Recursor::init_recursor" not allowed while "strict subs" in use at /usr/share/perl5/Zonemaster/Engine.pm line 40.
	# Compilation failed in require at /usr/share/perl5/Zonemaster/Engine/Recursor.pm line 15.
	# BEGIN failed--compilation aborted at /usr/share/perl5/Zonemaster/Engine/Recursor.pm line 15.
	# Compilation failed in require at /usr/share/perl5/Zonemaster/Engine/Test/Address.pm line 13.
	# BEGIN failed--compilation aborted at /usr/share/perl5/Zonemaster/Engine/Test/Address.pm line 13.
	# Compilation failed in require at /usr/share/perl5/Zonemaster/Engine/Test/Consistency.pm line 14.
	# BEGIN failed--compilation aborted at /usr/share/perl5/Zonemaster/Engine/Test/Consistency.pm line 14.
	not ok 17 - /usr/bin/perl -wc /usr/share/perl5/Zonemaster/Engine/Test/Consistency.pm exited successfully
	[…]
	# Bareword "Zonemaster::Engine::Recursor::init_recursor" not allowed while "strict subs" in use at /usr/share/perl5/Zonemaster/Engine.pm line 40.
	# Compilation failed in require at /usr/share/perl5/Zonemaster/Engine/Recursor.pm line 15.
	# BEGIN failed--compilation aborted at /usr/share/perl5/Zonemaster/Engine/Recursor.pm line 15.
	# Compilation failed in require at /usr/share/perl5/Zonemaster/Engine/Test/Zone.pm line 19.
	# BEGIN failed--compilation aborted at /usr/share/perl5/Zonemaster/Engine/Test/Zone.pm line 19.
	not ok 20 - /usr/bin/perl -wc /usr/share/perl5/Zonemaster/Engine/Test/Zone.pm exited successfully

This seems to be caused by missing parenthesis to trigger the invocation of Zonemaster::Engine::Recursor::init_recursor method.

## Changes

Restoring these parenthesis looks to fix, or at least works around, the issue.

## How to test this PR

I ran the Debian Perl Team test, which includes routines to invoke the full upstream test suite but also the syntax check, and made sure the issue was resolved.