### PR TITLE
Move manifest.t to MANIFEST.SKIP 

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -74,7 +74,6 @@ t/asn.data
 t/asn.t
 t/dnsname.t
 t/logger.t
-t/manifest.t
 t/methodsv2.data
 t/methodsv2.t
 t/nameserver-axfr.data

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -77,3 +77,6 @@
 # Debian packaging
 ^debian/
 ^.pc/
+
+# Avoid MANIFEST test
+t/manifest.t


### PR DESCRIPTION
## Purpose

This PR propose to move t/manifest.t from MANIFEST to MANIFEST.SKIP to harmonize with other deposits.
see:
- https://github.com/zonemaster/zonemaster-ldns/pull/195
- https://github.com/zonemaster/zonemaster-cli/pull/383
- https://github.com/zonemaster/zonemaster-backend/pull/1183

## How to test this PR

## How to test this PR

Make sure we don't interfere with the release process:

```
git clean -dfx   # Start out with a clean repository
perl Makefile.PL # Generate the top-level Makefile
make all         # Generate MO files and modules.txt
make distcheck   # Verify that distcheck doesn't report any missing or unrecognized files
```

Run the unit tests in the source directory:

```
make distcheck     # Make sure distcheck doesn't report any missing or unrecognized files
prove t/manifest.t # Verify the new test passes
touch new.file  # Create a file but don't add it to MANIFEST
prove t/manifest.t # Verify the new test fails
echo "new.file" >> MANIFEST.SKIP 
prove t/manifest.t # Verify the new test passes
```

Run the unit tests in the dist file:

```
make distcheck                               # Make sure your repo is clean
make dist                                    # Create the dist file
cpanm --test-only Zonemaster-Backend-*.tar.gz # Run the tests included in the dist file
```

