### PR TITLE
Resolve IP addresses directly from Engine for out-of-bailiwick names in fake delegations

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -141,7 +141,7 @@ sub add_fake_delegation {
             if (   !@{ $href->{$name} }
                 && !$class->zone( $domain )->is_in_zone( $name ) )
             {
-                my @ips = Zonemaster::LDNS->new->name2addr( $name );
+                my @ips = map { $_->ip } Zonemaster::Engine::Recursor->get_addresses_for( $name );
                 push @{ $href->{$name} }, @ips;
                 if ( !@ips ) {
                     $incomplete_delegation = 1;


### PR DESCRIPTION
## Purpose

This PR proposes to resolve IP addresses directly from Engine for out-of-bailiwick names in fake delegations. In particular this will allow the use of private (custom) root for this use case.

## Context

Fixes #1344 

## Changes

- Use `Zonemaster::Engine::Recursor->get_addresses_for()` instead of `Zonemaster::LDNS->name2addr()`

## How to test this PR

From #1344:
```
zonemaster-cli --raw  --show-testcase --test basic01 --hints zonemaster/test-zone-data/COMMON/hintfile  --ns ns3-undelegated-child.basic01.xa --ns nsa.dnsnode.net child.parent.good-undel-1.basic01.xa
   0.16 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=child.parent.good-undel-1.basic01.xa; nsname=nsa.dnsnode.net
```
Names in private root are now properly resolved.