### PR TITLE
Remove Nameserver14 Test Case

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -314,10 +314,6 @@ Readonly my %TAG_DESCRIPTIONS => (
         __x    # NAMESERVER:NAMESERVER13
             'Test for truncated response on EDNS query';
     },
-    NAMESERVER14 => sub {
-        __x    # NAMESERVER:NAMESERVER14
-            'Test for unknown version with unknown OPTION-CODE';
-    },
     NAMESERVER15 => sub {
         __x    # NAMESERVER:NAMESERVER15
             'Checking for revealed software version';


### PR DESCRIPTION
## Purpose

This PR removes the Nameserver14 Test Case. Note that this Test Case was not implemented in the first place.

Specification is removed by https://github.com/zonemaster/zonemaster/pull/1300.

## Context

Fixes #920 

Replaces #1033 

## How to test this PR

N/A. No mention of this Test Case should be present in the repository (besides for files updated at release time).
