### PR TITLE
Delegation05: include QNAME and QTYPE in diagnostics for failed queries

### DIFF
--- a/lib/Zonemaster/Engine/Test/Delegation.pm
+++ b/lib/Zonemaster/Engine/Test/Delegation.pm
@@ -273,7 +273,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     NO_RESPONSE => sub {
         __x    # DELEGATION:NO_RESPONSE
-          "Nameserver {ns} did not respond.", @_;
+          'Nameserver {ns} did not respond to a query for name {query_name} and type {rrtype}.', @_;
     },
     NOT_ENOUGH_IPV4_NS_CHILD => sub {
         __x    # DELEGATION:NOT_ENOUGH_IPV4_NS_CHILD
@@ -373,7 +373,7 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     UNEXPECTED_RCODE => sub {
         __x    # DELEGATION:UNEXPECTED_RCODE
-          'Nameserver {ns} answered query with an unexpected rcode ({rcode}).', @_;
+          'Nameserver {ns} answered query for name {query_name} and type {rrtype} with RCODE {rcode}.', @_;
     },
 
 );
@@ -925,8 +925,9 @@ sub delegation05 {
             for my $key ( sort keys %nss ) {
                 my $ns = $nss{$key};
                 my $ns_args = {
-                    ns     => $ns->string,
-                    rrtype => q{A},
+                    ns         => $ns->string,
+                    query_name => $local_nsname,
+                    rrtype     => q{A},
                 };
 
                 if ( _ip_disabled_message( \@results, $ns, q{A} ) ) {


### PR DESCRIPTION
## Purpose

This PR is a quick-and-dirty improvement to the messages generated by Delegation05.

Delegation05 can generate NO_RESPONSE or UNEXPECTED_RCODE message tags when a name server doesn’t respond, or responds with an RCODE different from NOERROR.

The error messages only state the name server that gave the erroneous response. They do not give any details on the QNAME or the QTYPE, making debugging harder. In one case, I’ve had to redo a test with zonemaster-cli and crank the verbosity level right up to DEBUG3 before I could figure out why I got UNEXPECTED_RCODE messages.

Adding the QNAME and QTYPE to the messages being generated in these cases helps debugging significantly.

## Context

Fixes #1391.

## Changes

Include QNAME and QTYPE of the query that failed, in message tags generated by Delegation05.

## How to test this PR

For now, there is no easy way to test. At the time of writing, the `ci` zone has this problem but it might be fixed pretty soon.