### PR TITLE
Updates global cache

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -91,8 +91,8 @@ sub set_key {
             }
         }
         $ttl = $ttl < $redis_expire ? $ttl : $redis_expire;
-        # Redis requires cache time to be greater than 0.
-        $ttl = 1 if $ttl == 0;
+        # Redis requires cache time to be greater than 0 to be stored.
+        return if $ttl == 0;
         $self->redis->set( $key, $msg, 'EX', $ttl );
     } else {
         $self->redis->set( $key, '', 'EX', $ttl );

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -135,7 +135,7 @@ Zonemaster::Engine::Nameserver::Cache::RedisCache - global shared caches for nam
 
 =head1 SYNOPSIS
 
-    This is an EXPERIMENTAL caching layer and might change in the future.
+    This is a global caching layer.
 
 =head1 ATTRIBUTES
 

--- a/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
+++ b/lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
@@ -69,7 +69,7 @@ sub set_key {
     # Never cache with answer, NXDOMAIN or NODATA longer than this.
     my $redis_expire = $self->{config}->{expire};
 
-    # If no response or response without answer or SOA in authority
+    # If no response or response without answer or SOA in authority,
     # cache this many seconds (e.g. SERVFAIL or REFUSED).
     my $ttl_no_response = 1200;
 
@@ -175,8 +175,8 @@ Cache time is the shortest time of TTL in the DNS packet
 and cache.redis.expire in the profile. Default value of
 cache.redis.expire is 300 seconds.
 
-If the there is no TTL value to be used in the DNS packet
+If there is no TTL value to be used in the DNS packet
 (e.g. SERVFAIL or no response), then cache time is fixed
-to 1200 seconds.
+to 1200 seconds instead.
 
 =cut

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -750,7 +750,8 @@ Specifies the address of the Redis server used to perform global caching
 (C<cache.redis.server>) and an optional expire time (C<cache.redis.expire>).
 
 C<cache.redis.server> must be a string in the form C<host:port>.
-C<cache.redis.expire> must be a non-negative integer and defines a time in seconds. Default 5 seconds.
+C<cache.redis.expire> must be a non-negative integer and defines a time in seconds.
+Default is 300 seconds.
 
 =head2 logfilter
 

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -737,9 +737,9 @@ item in the list will be used, the rest are backups in case the previous ones di
 
 Default C<{Cymru: [ "asnlookup.zonemaster.net", "asn.cymru.com" ], RIPE: [ "riswhois.ripe.net" ]}>.
 
-=head2 cache (EXPERIMENTAL)
+=head2 cache
 
-A hash of hashes. The currently supported keys are C<"redis">.
+A hash of hashes. The currently supported key is C<"redis">.
 Default C<{}>.
 
 =head3 redis


### PR DESCRIPTION
## Purpose

This PR does three things about global (Redis) cache:
1. Updates how and what caching time an item gets (more below).
2. Changes the logic when TTL==0 by not saving to cache instead of setting TTL to 1 and chache that.
3. Removes the experimental status of global cache.

### Caching time and default for that

A DNS response can be of three type (when it comes to caching):
1. Normal response with data in answer section, NXDOMAIN or NODATA. In these cases a TTL can be  extracted from the DNS packet.
2. Another response such as REFUSED or SERVFAIL where no TTL can be extracted from the packet.
3. No response at all.

For response type 1 the extracted TTL value was used, but limited to cache.redis.expire (default 300 seconds, but much higher is needed to get full effect). For type 2 and 3 cache.redis.expire was used.

With this PR the logic for response type 1 is kept as it. For responses of type 2 and 3 a fixed value of 1200 seconds is used. The plan is to create a new profile element for type 2 and 3 to make that caching time settable.

## Context

Global cache was introduced in release v2023.2 and has shown no issues. With this PR together with https://github.com/zonemaster/zonemaster/pull/1303 it will become stable.


## How to test this PR

1. Review.
2. Install Redis and activate.
3. Update a profile with Redis and set expire not equal to 1200.
4. Run an undelegated test with `--ns` that points at something outside that does not respond on port 53.
5. Use `redis-cli KEYS '*'`, `redis-cli TTL KEY` and `redis-cli flushall`
6. `for key in $( redis-cli KEYS '*' | cut -f2 ) ; do redis-cli TTL $key ; done`