### PR TITLE
Add Try::Tiny in zonemaster-cli runtime Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,5 @@ RUN apk add --no-cache \
     perl-mailtools \
     perl-module-install \
     perl-net-ip \
-    perl-text-csv
+    perl-text-csv \
+    perl-try-tiny

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zonemaster/ldns:local as build
+FROM zonemaster/ldns:local AS build
 
 RUN apk add --no-cache \
     # Only needed for CPAN deps


### PR DESCRIPTION
## Purpose

This PR installs a missing runtime dependency in the Docker container for Zonemaster-CLI.

## Context

Release testing for the upcoming 2024.2 release.

## Changes

 * Install Try::Tiny in the second (runtime) stage Docker container.
 * As a drive-by change: address a warning emitted by `docker build` due to the capitalization of the `as` keyword on the first line of the Dockerfile.

## How to test this PR

Build the Docker container, then perform the “smoke test” for Zonemaster::Engine:
```
docker run --rm zonemaster/engine:local perl -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("BASIC", "zonemaster.net")'
```

The program should complete, and should not error out because of a missing package.