### PR TITLE
Fix abort condition for undelegated tests in the Basic module

### DIFF
--- a/lib/Zonemaster/Engine/Test/Basic.pm
+++ b/lib/Zonemaster/Engine/Test/Basic.pm
@@ -101,11 +101,6 @@ Returns a boolean.
 sub can_continue {
     my ( $class, $zone, @results ) = @_;
 
-    my $is_undelegated = Zonemaster::Engine::Recursor->has_fake_addresses( $zone->name->string );
-    if ( $is_undelegated ) {
-        return 1;
-    }
-
     if ( should_run_test( 'basic02' ) ) {
         my %tag = map { $_->tag => 1 } @results;
         return !$tag{B02_NO_DELEGATION} && $tag{B02_AUTH_RESPONSE_SOA};


### PR DESCRIPTION
## Purpose

When running the full test suite (i.e. not a specific module nor test case), an [evaluation of the results from the Basic module](https://github.com/zonemaster/zonemaster-engine/blob/v6.0.0/lib/Zonemaster/Engine/Test.pm#L209-L212.) is made (specifically [what is returned by Basic02](https://github.com/zonemaster/zonemaster-engine/blob/v6.0.0/lib/Zonemaster/Engine/Test/Basic.pm#L101-L115)) before continuing onto other Test modules. Due to an [oversight in a previous refactoring](https://github.com/zonemaster/zonemaster-engine/pull/1312/files#diff-34b7101242fdbd9db6ba492a25f1d89810aca87dc06d7facddd4a7e994e39707R103-R117), this abort condition was changed, which made all undelegated tests to never abort, even without any working name server. This PR fixes that.

## Context

Release testing v2024.2

See https://github.com/zonemaster/zonemaster-cli/issues/402#issuecomment-2511899299

Fixes https://github.com/zonemaster/zonemaster/issues/1275

## How to test this PR

Unit tests should pass. Running the full test suite for an undelegated test should now properly abort when no working name servers are found:
```
$ zonemaster-cli --show-testcase --no-ipv6 --raw --level info --ns d.nic.example fr
   0.10 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=fr; nsname=d.nic.example
   0.16 ERROR    Unspecified    FAKE_DELEGATION_NO_IP  domain=fr; nsname=d.nic.example
   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v6.0.0
   0.00 INFO     Basic01        B01_CHILD_FOUND  domain=fr
   0.00 INFO     Basic01        B01_PARENT_DISREGARDED
   0.00 CRITICAL Basic02        B02_NO_WORKING_NS  domain="fr"
   0.00 ERROR    Basic02        B02_NS_NO_IP_ADDR  nsname=d.nic.example
   0.00 CRITICAL Unspecified    CANNOT_CONTINUE  domain=fr

$ zonemaster-cli --show-testcase --no-ipv6 --raw --level info --ns d.nic.fr/1.1.1.1 fr
   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v6.0.0
   0.00 INFO     Basic01        B01_CHILD_FOUND  domain=fr
   0.00 INFO     Basic01        B01_PARENT_DISREGARDED
   0.00 CRITICAL Basic02        B02_NO_WORKING_NS  domain="fr"
   0.00 ERROR    Basic02        B02_UNEXPECTED_RCODE  ns=d.nic.fr/1.1.1.1; rcode=SERVFAIL
   0.02 CRITICAL Unspecified    CANNOT_CONTINUE  domain=fr
```

And in the normal case (working NS):
```
$ zonemaster-cli --show-testcase --no-ipv6 --raw --level info --ns d.nic.fr fr
   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v6.0.0
   0.00 INFO     Basic01        B01_CHILD_FOUND  domain=fr
   0.00 INFO     Basic01        B01_PARENT_DISREGARDED
   0.00 INFO     Basic02        B02_AUTH_RESPONSE_SOA  domain="fr"; ns_list=d.nic.fr/194.0.9.1
   0.00 INFO     Unspecified    HAS_NAMESERVER_NO_WWW_A_TEST  zname="fr"
   0.01 INFO     Address01      NO_IP_PRIVATE_NETWORK
   2.27 INFO     Address02      NAMESERVERS_IP_WITH_REVERSE
   2.28 INFO     Address03      NAMESERVER_IP_PTR_MATCH
   2.28 NOTICE   Connectivity01 CN01_IPV6_DISABLED  ns_list=d.nic.fr/2001:678:c::1;f.ext.nic.fr/2001:67c:1010:11::53;g.ext.nic.fr/2001:678:4c::1
[ ... ]

$ zonemaster-cli --show-testcase --no-ipv6 --raw --level info --ns d.nic.fr/194.0.9.1 fr
   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v6.0.0
   0.00 INFO     Basic01        B01_CHILD_FOUND  domain=fr
   0.00 INFO     Basic01        B01_PARENT_DISREGARDED
   0.00 INFO     Basic02        B02_AUTH_RESPONSE_SOA  domain="fr"; ns_list=d.nic.fr/194.0.9.1
   0.00 INFO     Unspecified    HAS_NAMESERVER_NO_WWW_A_TEST  zname="fr"
   0.57 INFO     Address01      NO_IP_PRIVATE_NETWORK
   2.84 INFO     Address02      NAMESERVERS_IP_WITH_REVERSE
   2.85 INFO     Address03      NAMESERVER_IP_PTR_MATCH
   2.85 NOTICE   Connectivity01 CN01_IPV6_DISABLED  ns_list=d.nic.fr/2001:678:c::1;f.ext.nic.fr/2001:67c:1010:11::53;g.ext.nic.fr/2001:678:4c::1
[...]

$ zonemaster-cli --show-testcase --no-ipv6 --raw --level info fr
   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v6.0.0
   2.31 INFO     Basic01        B01_PARENT_FOUND  domain=.; ns_list=a.root-servers.net/198.41.0.4;b.root-servers.net/199.9.14.201;c.root-servers.net/192.33.4.12;d.root-servers.net/199.7.91.13;e.root-servers.net/192.203.230.10;f.root-servers.net/192.5.5.241;g.root-servers.net/192.112.36.4;h.root-servers.net/198.97.190.53;i.root-servers.net/192.36.148.17;j.root-servers.net/192.58.128.30;k.root-servers.net/193.0.14.129;l.root-servers.net/199.7.83.42;m.root-servers.net/202.12.27.33
   2.31 INFO     Basic01        B01_CHILD_FOUND  domain=fr
   2.77 INFO     Basic02        B02_AUTH_RESPONSE_SOA  domain="fr"; ns_list=d.nic.fr/194.0.9.1;f.ext.nic.fr/194.146.106.46;g.ext.nic.fr/194.0.36.1
   2.77 INFO     Unspecified    HAS_NAMESERVER_NO_WWW_A_TEST  zname="fr"
   2.80 INFO     Address01      NO_IP_PRIVATE_NETWORK
   5.05 INFO     Address02      NAMESERVERS_IP_WITH_REVERSE
   5.06 INFO     Address03      NAMESERVER_IP_PTR_MATCH
   5.06 NOTICE   Connectivity01 CN01_IPV6_DISABLED  ns_list=d.nic.fr/2001:678:c::1;f.ext.nic.fr/2001:67c:1010:11::53;g.ext.nic.fr/2001:678:4c::1
[ ... ]
```