### PR TITLE
Improve performance by optimizing critical code sections

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -231,6 +231,7 @@ sub reset {
     Zonemaster::Engine::Nameserver->empty_cache();
     $logger->clear_history() if $logger;
     Zonemaster::Engine::Recursor->clear_cache();
+    Zonemaster::Engine::TestMethodsV2->clear_cache();
     return;
 }
 
@@ -408,7 +409,8 @@ Set the logger's start time to the current time.
 =item reset()
 
 Reset logger start time to current time, empty the list of log messages, clear
-nameserver object cache and recursor cache.
+nameserver object cache, clear recursor cache and clear all cached results of
+MethodsV2.
 
 =back
 

--- a/lib/Zonemaster/Engine/DNSName.pm
+++ b/lib/Zonemaster/Engine/DNSName.pm
@@ -45,7 +45,7 @@ sub new {
         $attrs->{labels} = \@{ $input->labels };
     }
     elsif ( blessed $input && $input->isa( 'Zonemaster::Engine::Zone' ) ) {
-        $attrs->{labels} = [ split( /[.]/x, $input->name ) ];
+        $attrs->{labels} = \@{ $input->name->labels };
     }
     elsif ( ref $input eq '' ) {
         $attrs->{labels} = [ split( /[.]/x, $input ) ];

--- a/lib/Zonemaster/Engine/DNSName.pm
+++ b/lib/Zonemaster/Engine/DNSName.pm
@@ -65,10 +65,14 @@ sub new {
 sub string {
     my $self = shift;
 
-    my $name = join( '.', @{ $self->labels } );
-    $name = '.' if $name eq q{};
+    if ( not exists $self->{_string} ) {
+        my $string = join( '.', @{ $self->labels } );
+        $string = '.' if $string eq q{};
 
-    return $name;
+        $self->{_string} = $string;
+    }
+
+    return $self->{_string};
 }
 
 sub fqdn {
@@ -165,7 +169,7 @@ A reference to a list of strings, being the labels the DNS name is made up from.
 
 =over
 
-=item new($input) _or_ new({ labels => \@labellist})
+=item new($input) _or_ new({ labels => \@labellist })
 
 The constructor can be called with either a single argument or with a reference
 to a hash as in the example above.

--- a/lib/Zonemaster/Engine/DNSName.pm
+++ b/lib/Zonemaster/Engine/DNSName.pm
@@ -22,14 +22,11 @@ sub from_string {
     confess 'Argument must be a string: $domain'
       if !defined $domain || ref $domain ne '';
 
-    return $class->_new( { labels => [ split( /[.]/x, $domain ) ] } );
+    return Class::Accessor::new( $class, { labels => [ split( /[.]/x, $domain ) ] } );
 }
 
 sub new {
-    my $proto = shift;
-    confess "must be called with a single argument"
-      if scalar( @_ ) != 1;
-    my $input = shift;
+    my ( $class, $input ) = @_;
 
     my $attrs = {};
     if ( !defined $input ) {
@@ -62,22 +59,7 @@ sub new {
         confess "Unrecognized argument: " . $what;
     }
 
-    # Type constraints
-    confess "Argument must be an ARRAYREF: labels"
-      if exists $attrs->{labels}
-      && ref $attrs->{labels} ne 'ARRAY';
-
-    my $class = ref $proto || $proto;
-    return $class->_new( $attrs );
-}
-
-sub _new {
-    my $class = shift;
-    my $attrs = shift;
-
-    my $obj = Class::Accessor::new( $class, $attrs );
-
-    return $obj;
+    return Class::Accessor::new( $class, $attrs );
 }
 
 sub string {

--- a/lib/Zonemaster/Engine/DNSName.pm
+++ b/lib/Zonemaster/Engine/DNSName.pm
@@ -22,7 +22,16 @@ sub from_string {
     confess 'Argument must be a string: $domain'
       if !defined $domain || ref $domain ne '';
 
-    return Class::Accessor::new( $class, { labels => [ split( /[.]/x, $domain ) ] } );
+    my $obj = Class::Accessor::new( $class, { labels => [ split( /[.]/x, $domain ) ] } );
+
+    # We have the raw string, so we can precompute the string representation
+    # easily and cheaply so it can be immediately returned by the string()
+    # method instead of recomputing it from the labels list. The only thing we
+    # need to do is to remove any trailing dot except if it’s the only
+    # character.
+    $obj->{_string} = ( $domain =~ s/.\K [.] \z//rx );
+
+    return $obj;
 }
 
 sub new {

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -73,7 +73,7 @@ sub new {
       if !blessed $attrs->{name} || !$attrs->{name}->isa( 'Zonemaster::Engine::DNSName' );
 
     my $name = lc( q{} . $attrs->{name} );
-    $name = '$$$NONAME' unless $name;
+    $name = '$$$NONAME' if $name eq q{};
 
     my $address;
 

--- a/lib/Zonemaster/Engine/Packet.pm
+++ b/lib/Zonemaster/Engine/Packet.pm
@@ -107,26 +107,22 @@ sub is_redirect {
 
 sub get_records {
     my ( $self, $type, @section ) = @_;
+    @section = qw(answer authority additional) if !@section;
     my %sec = map { lc( $_ ) => 1 } @section;
     my @raw;
-
-    if ( !@section ) {
-        @raw = ( $self->packet->answer, $self->packet->authority, $self->packet->additional );
-    }
+    $type = uc( $type );
 
     if ( $sec{'answer'} ) {
-        push @raw, $self->packet->answer;
+        push @raw, grep { $_->type eq $type } $self->packet->answer;
     }
 
     if ( $sec{'authority'} ) {
-        push @raw, $self->packet->authority;
+        push @raw, grep { $_->type eq $type } $self->packet->authority;
     }
 
     if ( $sec{'additional'} ) {
-        push @raw, $self->packet->additional;
+        push @raw, grep { $_->type eq $type } $self->packet->additional;
     }
-
-    @raw = grep { $_->type eq uc( $type ) } @raw;
 
     return @raw;
 } ## end sub get_records
@@ -134,13 +130,19 @@ sub get_records {
 sub get_records_for_name {
     my ( $self, $type, $name, @section ) = @_;
 
-    return grep { name( $_->name ) eq name( $name ) } $self->get_records( $type, @section );
+    # Make sure $name is a Zonemaster::Engine::DNSName
+    $name = name( $name );
+
+    return grep { name( $_->name ) eq $name } $self->get_records( $type, @section );
 }
 
 sub has_rrs_of_type_for_name {
     my ( $self, $type, $name, @section ) = @_;
 
-    return ( grep { name( $_->name ) eq name( $name ) } $self->get_records( $type, @section ) ) > 0;
+    # Make sure $name is a Zonemaster::Engine::DNSName
+    $name = name( $name );
+
+    return ( grep { name( $_->name ) eq $name } $self->get_records( $type, @section ) ) > 0;
 }
 
 sub answerfrom {

--- a/lib/Zonemaster/Engine/TestMethodsV2.pm
+++ b/lib/Zonemaster/Engine/TestMethodsV2.pm
@@ -36,6 +36,8 @@ Takes a L<Zonemaster::Engine::Zone> object.
 
 Returns an arrayref of L<Zonemaster::Engine::Nameserver> objects, or C<undef> if no parent zone was found.
 
+The result of this Method is cached for performance reasons. This cache can be invalidated by calling C<clear_cache()> if necessary.
+
 =back
 
 =cut
@@ -784,6 +786,21 @@ sub get_zone_ns_ips {
     }
 
     return [ uniq sort @ns_ips ];
+}
+
+
+=over
+
+=item clear_cache()
+
+Clears previously cached results of the C<get_parent_ns_ips()> method.
+
+=back
+
+=cut
+
+sub clear_cache() {
+    Memoize::flush_cache(\&get_parent_ns_ips);
 }
 
 1;

--- a/lib/Zonemaster/Engine/Util.pm
+++ b/lib/Zonemaster/Engine/Util.pm
@@ -32,9 +32,9 @@ use Zonemaster::Engine::Constants qw[:ip :soa];
 use Zonemaster::Engine::DNSName;
 use Zonemaster::Engine::Profile;
 
-## no critic (Subroutines::RequireArgUnpacking)
 sub ns {
-    return Zonemaster::Engine->ns( @_ );
+    my ( $name, $address ) = @_;
+    return Zonemaster::Engine::Nameserver->new( { name => $name, address => $address } );
 }
 
 sub info {
@@ -71,14 +71,14 @@ sub ipversion_ok {
 }
 
 sub test_levels {
-
     return Zonemaster::Engine::Profile->effective->get( q{test_levels} );
 }
 
+## no critic (Subroutines::RequireArgUnpacking)
 sub name {
-    my ( $name ) = @_;
-
-    return Zonemaster::Engine::DNSName->new( $name );
+    # We do not unpack @_ here for performance reasons.
+    # If we did, the calling convention is: my ( $name ) = @_.
+    return Zonemaster::Engine::DNSName->new( @_ );
 }
 
 # Function from CPAN package Text::Capitalize that causes


### PR DESCRIPTION
## Purpose

This PR aims to improve performance of Zonemaster::Engine by speeding up some critical sections in the code base.

The net effect of these speedups mostly depends on network conditions: domains whose name servers are fast, work well and always respond to all queries will benefit the most from these changes, while domains having unresponsive name servers might not notice much of a difference. Runs of unit tests take 16% less time; runs of `zonemaster-cli` which use previous data (`--restore <FILE>`) also benefit greatly.

In practice, a test run on the first 1 000 domains of the [Tranco list generated on January 21st, 2025](https://tranco-list.eu/list/N3WNW) gave a rather disappointing 1,1 % decrease in run time. I suspect that this is due to a small number of domains that take considerable time to test because some of their name servers do not respond to some of the DNS messages Zonemaster sends.

While the CPU is clearly not the bottleneck for Zonemaster, it’s still nice to consume fewer CPU cycles when testing domains. Zonemaster does a lot of scatter-gather processing where the same query is sent to all name servers before processing all their responses. Parallelizing that will benefit Zonemaster the most.

## Context

Discussions on improving performance of Zonemaster during last face-to-face meeting.

## Changes

In a nutshell, the speedups are the result of the following types of changes:

 * Memoize the result of MethodsV2’s get_parent_ns_ips();
 * Use memoization or precompute data when it is cheap to do so in order to speed up further accesses to such data;
 * Avoid calling the same function or method repeatedly on the same parameters, except if the side-effects are needed;
 * Avoid unpacking `@_` in the most critical functions.

Reviewers are strongly encouraged to look at each commit one by one, as each commit message thoroughly documents what was done.

I’m setting the V-Major tag because one of the commits changes the string representation of IPv6 addresses in `NS_CREATED` messages. Previously, IPv6 addresses were represented in full (e.g. 2001:0db8:0000:0008:0000:0000:0000:0001); now they are represented using their short and canonical representation (e.g. 2001:db8:0:8::1). Technically, this change could break software processing IPv6 addresses naively in `NS_CREATED` messages.

## How to test this PR

Unit tests must still pass.

If curious about performance improvements, the benchmark I used is:
```
zonemaster-cli --save saved_data --no-ipv6 servfail.fr # this needs to be done only once
perl -d:NYTProf $(which zonemaster-cli) --restore saved_data --no-ipv6 servfail.fr && nytprofhtml
```
