### PR TITLE
Fix infinite recursion bug when NS record points to CNAME

### DIFF
--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -245,7 +245,7 @@ sub _resolve_cname {
     }
 
     # CNAME target has already been followed (outer loop); no need to recurse
-    if ( $state->{tseen}{lc( $target )}  ) {
+    if ( exists $state->{in_progress}{lc( $target )}{$type} ) {
         Zonemaster::Engine->logger->add( CNAME_LOOP_OUTER => { name => $name, target => $target, targets_seen => join( ';', keys %{ $state->{tseen} } ) } );
         return ( undef, $state );
     }
@@ -263,7 +263,7 @@ sub _resolve_cname {
     unless ( $name->is_in_bailiwick( $target ) ) {
         Zonemaster::Engine->logger->add( CNAME_FOLLOWED_OUT_OF_ZONE => { name => $name, target => $target } );
         ( $p, $state ) = $class->_recurse( $target, $type, $dns_class,
-            { ns => [ root_servers() ], count => 0, common => 0, seen => {}, tseen => $state->{tseen}, tcount => $state->{tcount}, glue => {} });
+            { ns => [ root_servers() ], count => 0, common => 0, seen => {}, tseen => $state->{tseen}, tcount => $state->{tcount}, glue => {}, in_progress => $state->{in_progress} });
     }
     else {
         # What do do here?

--- a/t/methodsv2.t
+++ b/t/methodsv2.t
@@ -757,6 +757,18 @@ my %subtests = (
               ns4-cname.child-ns-cname-3.methodsv2.xa/fda1:b2:c3:0:127:40:1:34 ) ],
         [ ],
     ],
+    'CHILD-NS-CNAME-4' => [
+        1,
+        q(child.parent.child-ns-cname-4.methodsv2.xa),
+        [ qw( 127.40.1.41
+              fda1:b2:c3:0:127:40:1:41
+              127.40.1.42
+              fda1:b2:c3:0:127:40:1:42 ) ],
+        [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51 ) ],
+        [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51
+              ns2-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.52 ) ],
+        [ ],
+    ],
     'PARENT-NS-CNAME-1' => [
         1,
         q(child.parent.parent-ns-cname-1.methodsv2.xa),


### PR DESCRIPTION
## Purpose

This PR fixes an infinite recursion bug that could be triggered when, somewhere in the delegation chain, an NS record points to an alias.

### Problem description

In a nutshell: suppose that `a.example` is a zone whose authoritative nameserver is `ns.a.example`. But `ns.a.example` is an alias for `real-ns.a.example`. When the recursor tries to resolve `ns.a.example` to IP addresses, it chases the alias: this causes it to restart a query for `real-ns.a.example`. In the process, it needs to resolve `ns.a.example` to an IP address so it can query that name server for `real-ns.a.example`. However, the recursor threw away the context that led it to chase `real-ns.a.example` in the first place, that is: resolving `ns.a.example`.

Because of that, Zonemaster tries to resolve `ns.a.example`, which is aliased to `real-ns.a.example`, but to resolve `real-ns.a.example`, it needs to resolve `ns.a.example`, which is aliased to `real-ns.a.example`, and to resolve that name, it needs to resolve `ns.a.example`, which is aliased to `real-ns.a.example`, and so on. It’s an infinite loop that isn’t technically a CNAME chain nor an NS chain, but some hybrid of both.

### Solution

All we need to do is to keep the original query’s context around when performing a subordinate query caused by an alias (CNAME record). That way, when chasing `real-ns.a.example`, the recursor notices that it needs to resolve `ns.a.example`, which is a resolution that it is already attempting to perform, and therefore bails out instead of looping indefinitely.

## Context

Fixes #1421.

## Changes

* When initializing the state structure for a subordinate query caused by chasing an alias, copy the `in_progress` table from the original query’s state to the subordinate query’s.
* The first change prevents `CNAME_LOOP_OUTER` messages to be generated when detecting a CNAME loop across zones. We need to change the condition for generating those messages so that it uses the `in_progress` table.

## How to test this PR

Unit tests for MethodsV2 have been updated and should complete without error.

Another option is to run `zonemaster-cli --test basic02 chi-eureseine.fr`. The program should complete with `Looks OK.`, instead of printing dozens of `Deep recursion` warnings.
