### PR TITLE
Hide git diff output for t/*.data files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# While technically text, diffs are meaningless on test data files.
+t/*.data -diff

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -71,6 +71,9 @@
 ^MYMETA\.
 #!end included /usr/share/perl/5.20/ExtUtils/MANIFEST.SKIP
 
+# More Git configuration files
+\B\.gitattributes\b
+
 # For GitHub action
 ^\.github/
 


### PR DESCRIPTION
## Purpose

This PR proposes a Git configuration change so as to no longer display diffs on `t/*.data` files.

While technically ASCII text files, the contents should be treated as binary. Diffs on these files are big and noisy, slow down tooling, and don’t make sense to human readers anyway.

Quoting from the [gitattributes(5) man page](https://git-scm.com/docs/gitattributes):

> Git usually guesses correctly whether a blob contains text or binary data by examining the beginning of the contents. However, sometimes you may want to override its decision, either because a blob contains binary data later in the file, or because the content, while technically composed of text characters, is opaque to a human reader. For example, many postscript files contain only ASCII characters, but produce noisy and meaningless diffs.

This change has no user-visible effects.

Before:

```
commit 4ef927672bb44cb37bd464a56fc707e5c9b2aaaa
Author: [Thomas Green] <thomas.green@afnic.fr>
Date:   Wed Nov 27 14:30:02 2024 +0100

    Update unit test data

diff --git a/t/Test-dnssec10.data b/t/Test-dnssec10.data
index cd51547e..92774b92 100644
--- a/t/Test-dnssec10.data
+++ b/t/Test-dnssec10.data
@@ -1,204 +1,204 @@
…
# Over 400 lines of diff output
```

After:
```
$ git show 4ef927672bb44cb37bd464a56fc707e5c9b2aaaa
commit 4ef927672bb44cb37bd464a56fc707e5c9b2aaaa
Author: [Thomas Green] <thomas.green@afnic.fr>
Date:   Wed Nov 27 14:30:02 2024 +0100

    Update unit test data

diff --git a/t/Test-dnssec10.data b/t/Test-dnssec10.data
index cd51547e..92774b92 100644
Binary files a/t/Test-dnssec10.data and b/t/Test-dnssec10.data differ
```

## Context

Adding unit tests to the PR in #1422.

## Changes

* Add a `.gitattributes` file to treat test data files as binary.

## How to test this PR

Run the command: `git show 4ef927672bb44cb37bd464a56fc707e5c9b2aaaa`.

The output should be less than 20 lines long and end with a brief statement: `Binary files a/t/Test-dnssec10.data and b/t/Test-dnssec10.data differ`.
