### PR TITLE
Check for object type in returned values from some TestMethodsV2 methods used in Test Cases

### DIFF
--- a/lib/Zonemaster/Engine/Test/Connectivity.pm
+++ b/lib/Zonemaster/Engine/Test/Connectivity.pm
@@ -805,11 +805,8 @@ sub connectivity04 {
     my %ip_already_processed;
 
     my @nss = grep { $_->isa('Zonemaster::Engine::Nameserver') } (
-                Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) ?
-                    Zonemaster::Engine::TestMethodsV2->get_zone_ns_names_and_ips( $zone ) ?
-                        @{ Zonemaster::Engine::TestMethodsV2->get_zone_ns_names_and_ips( $zone ), Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) }
-                    : @{ Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) }
-                : ()
+                @{ Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) // [] },
+                @{ Zonemaster::Engine::TestMethodsV2->get_zone_ns_names_and_ips( $zone ) // [] }
               );
 
     foreach my $ns ( @nss ) {

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -3146,11 +3146,8 @@ sub dnssec10 {
     my ( @with_dnskey, @without_dnskey );
 
     my @nss = grep { $_->isa('Zonemaster::Engine::Nameserver') } (
-                Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) ?
-                    Zonemaster::Engine::TestMethodsV2->get_zone_ns_names_and_ips( $zone ) ?
-                        @{ Zonemaster::Engine::TestMethodsV2->get_zone_ns_names_and_ips( $zone ), Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) }
-                    : @{ Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) }
-                : ()
+                @{ Zonemaster::Engine::TestMethodsV2->get_del_ns_names_and_ips( $zone ) // [] },
+                @{ Zonemaster::Engine::TestMethodsV2->get_zone_ns_names_and_ips( $zone ) // [] }
               );
     my @ignored_nss;
 


### PR DESCRIPTION
## Purpose

Methods `Zonemaster::Engine::TestMethodsV2::get_{zone,del}_ns_names_and_ips()` can return a mix of `Zonemaster::Engine::Nameserver` or `Zonemaster::Engine::DNSName` objects, depending on whether the name could be resolved into an IP address. Due to a previous oversight, this can cause issues in Test Cases that use them. We can filter `Zonemaster::Engine::DNSName` objects out since they can't be queried.

Moreover it also fixes a buggy ternary expression in the same place (see https://github.com/zonemaster/zonemaster-engine/pull/1427#discussion_r1942398968 below). 

## Context

Fixes #1426 

## Changes

- Filter non-`Zonemaster::Engine::Nameserver` objects out of the list of to-be-queried name servers in Test Cases
- Rework buggy ternary expression to a working alternative

## How to test this PR

Unit tests could be created but they are kind of out of scope for either the TestMethodsV2 or the Test Cases themselves.
Manual testing (from #1426):
```
$ zonemaster-cli --level=info --no-ipv6 --show-testcase --test dnssec10 --test connectivity04 robindesboispaysage.fr

Seconds Level    Testcase       Message
======= ======== ============== =======
   0.00 INFO     Unspecified    Using version v7.0.0 of the Zonemaster engine.
  18.30 NOTICE   DNSSEC10       The zone is not DNSSEC signed or not properly DNSSEC signed. Testing for NSEC and NSEC3 has been skipped. Fetched from name servers "ns0.wixdns.net/216.239.32.101;ns1.wixdns.net/216.239.34.101".
   0.00 INFO     Unspecified    Using version v7.0.0 of the Zonemaster engine.
   2.01 INFO     Connectivity04 The following name server(s) are announced in unique IPv4 prefix(es): "ns0.wixdns.net/216.239.32.101;ns1.wixdns.net/216.239.34.101"
```
