### PR TITLE
Correctly set EDNS buffer size through 'edns_details'

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -440,29 +440,23 @@ sub _query {
             my $pkt = Zonemaster::LDNS::Packet->new("$name", $type, $href->{class} );
             $pkt->set_edns_present();
 
+            $pkt->do($flags{q{dnssec}});
+            $pkt->edns_size($flags{q{edns_size}});
+
             if ( exists $href->{edns_details}{version} ) {
                 $pkt->edns_version($href->{edns_details}{version});
             }
-    	    if ( exists $href->{edns_details}{z} ) {
+            if ( exists $href->{edns_details}{z} ) {
                 $pkt->edns_z($href->{edns_details}{z});
             }
-    	    if ( exists $href->{edns_details}{do} ) {
-                $pkt->do($href->{edns_details}{do});
-            }
-            elsif ( $flags{q{dnssec}} ) {
-                $pkt->do($flags{q{dnssec}});
-            }
-    	    if ( exists $href->{edns_details}{size} ) {
-                $pkt->edns_size($href->{edns_details}{size});
-            }
-    	    if ( exists $href->{edns_details}{rcode} ) {
+            if ( exists $href->{edns_details}{rcode} ) {
                 $pkt->edns_rcode($href->{edns_details}{rcode});
             }
             if ( exists $href->{edns_details}{data} ) {
                 $pkt->edns_data($href->{edns_details}{data});
             }
 
-    	    $res = eval { $self->dns->query_with_pkt( $pkt ) };
+            $res = eval { $self->dns->query_with_pkt( $pkt ) };
         }
         else {
             $res = eval { $self->dns->query( "$name", $type, $href->{class} ) };


### PR DESCRIPTION
## Purpose

This PR proposes a fix to EDNS queries sent with `edns_details` (and without `edns_details->size`, so in test cases Nameserver{02, 10, 11, 12} which were not functioning properly - queries were sent but with an empty EDNS buffer size (0), so some name servers could not respond properly).

The cause seems that to be that setting the `edns_size` parameter to the underlying `Zonemaster::LDNS` resolver object isn't sufficient when `Zonemaster::LDNS::query_with_pkt()` is used. It bypasses the resolver-level properties, see [ldns_resolver_send_pkt()](https://www.nlnetlabs.nl/documentation/ldns/resolver_8c.html#af90dc5b176e210bc66d9346875a1c8e8) vs [ldns_resolver_send()](https://www.nlnetlabs.nl/documentation/ldns/resolver_8c.html#afabcb49d64a677c3d682fc0e8d362da9) - and in particular the omitted call to [ldns_resolver_prepare_query_pkt()](https://www.nlnetlabs.nl/documentation/ldns/resolver_8c.html#a6971f59adba5df65f92cc6cd71a753c5). We have to explicitly set it in the given `Zonemaster::LDNS::Packet` object.

## Context

Fixes #1428 

## Changes

- Always set EDNS buffer size through `edns_details`

## How to test this PR

This is not caught in current unit tests for several reasons:
- Lack of coverage (see https://github.com/zonemaster/zonemaster-engine/issues/1146)
- Most of those test cases output no message when there is no response on the initial EDNS SOA query, but also when everything is working fine

Manual testing (from #1428):
```
$ zonemaster-cli 131.193.130.in-addr.arpa --ns ns1.newroztelecom.com --ns ns2.newroztelecom.com --ns ns3.newroztelecom.com --ns ns4.newroztelecom.com --show-testcase --test nameserver02 --no-ipv6 --level info --raw
   0.00 INFO     Unspecified    GLOBAL_VERSION  version=v7.0.0
   0.67 INFO     Nameserver02   EDNS0_SUPPORT  ns_list=ns3.newroztelecom.com/95.170.204.172;ns4.newroztelecom.com/95.170.204.167;ns1.newroztelecom.com/93.91.200.200;ns2.newroztelecom.com/93.91.200.201
```
