### PR TITLE
Rename release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - develop
       - master
-      - 'releases/**'
+      - 'release/**'
   pull_request:
     branches:
       - develop
       - master
-      - 'releases/**'
+      - 'release/**'
 
 jobs:
   run-tests:


### PR DESCRIPTION
## Purpose

This PR updates the release branch pattern for Github Actions.

## Context

It was discovered during the v2024.2.1 release phase that CI wasn't running on the release branch. In the WG meeting 2024-02-27 we agreed to use `release/**` for release branches.

## Changes

* .github/workflows/ci.yml

## How to test this PR

TBD