### PR TITLE
Updates local copies of IANA special IP registries

### DIFF
--- a/share/iana-ipv4-special-registry.csv
+++ b/share/iana-ipv4-special-registry.csv
@@ -1,5 +1,6 @@
 Address Block,Name,RFC,Allocation Date,Termination Date,Source,Destination,Forwardable,Globally Reachable,Reserved-by-Protocol
-0.0.0.0/8,"""This host on this network""","[RFC1122], Section 3.2.1.3",1981-09,N/A,True,False,False,False,True
+0.0.0.0/8,"""This network""","[RFC791], Section 3.2",1981-09,N/A,True,False,False,False,True
+0.0.0.0/32,"""This host on this network""","[RFC1122], Section 3.2.1.3",1981-09,N/A,True,False,False,False,True
 10.0.0.0/8,Private-Use,[RFC1918],1996-02,N/A,True,True,True,False,False
 100.64.0.0/10,Shared Address Space,[RFC6598],2012-04,N/A,True,True,True,False,False
 127.0.0.0/8,Loopback,"[RFC1122], Section 3.2.1.3",1981-09,N/A,False [1],False [1],False [1],False [1],True
@@ -10,7 +11,7 @@ Address Block,Name,RFC,Allocation Date,Termination Date,Source,Destination,Forwa
 192.0.0.8/32,IPv4 dummy address,[RFC7600],2015-03,N/A,True,False,False,False,False
 192.0.0.9/32,Port Control Protocol Anycast,[RFC7723],2015-10,N/A,True,True,True,True,False
 192.0.0.10/32,Traversal Using Relays around NAT Anycast,[RFC8155],2017-02,N/A,True,True,True,True,False
-"192.0.0.170/32, 192.0.0.171/32",NAT64/DNS64 Discovery,"[RFC7050], Section 2.2",2013-02,N/A,False,False,False,False,True
+"192.0.0.170/32, 192.0.0.171/32",NAT64/DNS64 Discovery,"[RFC8880][RFC7050], Section 2.2",2013-02,N/A,False,False,False,False,True
 192.0.2.0/24,Documentation (TEST-NET-1),[RFC5737],2010-01,N/A,False,False,False,False,False
 192.31.196.0/24,AS112-v4,[RFC7535],2014-12,N/A,True,True,True,True,False
 192.52.193.0/24,AMT,[RFC7450],2014-12,N/A,True,True,True,True,False

--- a/share/iana-ipv6-special-registry.csv
+++ b/share/iana-ipv6-special-registry.csv
@@ -5,20 +5,24 @@ Address Block,Name,RFC,Allocation Date,Termination Date,Source,Destination,Forwa
 64:ff9b::/96,IPv4-IPv6 Translat.,[RFC6052],2010-10,N/A,True,True,True,True,False
 64:ff9b:1::/48,IPv4-IPv6 Translat.,[RFC8215],2017-06,N/A,True,True,True,False,False
 100::/64,Discard-Only Address Block,[RFC6666],2012-06,N/A,True,True,True,False,False
+100:0:0:1::/64,Dummy IPv6 Prefix,[RFC-ietf-mpls-p2mp-bfd-11],2025-04,N/A,True,False,False,False,False
 2001::/23,IETF Protocol Assignments,[RFC2928],2000-09,N/A,False [1],False [1],False [1],False [1],False
 2001::/32,TEREDO,"[RFC4380]
         [RFC8190]",2006-01,N/A,True,True,True,N/A [2],False
 2001:1::1/128,Port Control Protocol Anycast,[RFC7723],2015-10,N/A,True,True,True,True,False
 2001:1::2/128,Traversal Using Relays around NAT Anycast,[RFC8155],2017-02,N/A,True,True,True,True,False
+2001:1::3/128,DNS-SD Service Registration Protocol Anycast,[RFC-ietf-dnssd-srp-25],2024-04,N/A,True,True,True,True,False
 2001:2::/48,Benchmarking,[RFC5180][RFC Errata 1752],2008-04,N/A,True,True,True,False,False
 2001:3::/32,AMT,[RFC7450],2014-12,N/A,True,True,True,True,False
 2001:4:112::/48,AS112-v6,[RFC7535],2014-12,N/A,True,True,True,True,False
-2001:5::/32,EID Space for LISP (Managed by RIPE NCC),[RFC7954],2016-09,2019-09 [3],True [4],True,True,True,True [5]
 2001:10::/28,Deprecated (previously ORCHID),[RFC4843],2007-03,2014-03,,,,,
 2001:20::/28,ORCHIDv2,[RFC7343],2014-07,N/A,True,True,True,True,False
+2001:30::/28,Drone Remote ID Protocol Entity Tags (DETs) Prefix,[RFC9374],2022-12,N/A,True,True,True,True,False
 2001:db8::/32,Documentation,[RFC3849],2004-07,N/A,False,False,False,False,False
-2002::/16 [6],6to4,[RFC3056],2001-02,N/A,True,True,True,N/A [6],False
+2002::/16 [3],6to4,[RFC3056],2001-02,N/A,True,True,True,N/A [3],False
 2620:4f:8000::/48,Direct Delegation AS112 Service,[RFC7534],2011-05,N/A,True,True,True,True,False
+3fff::/20,Documentation,[RFC9637],2024-07,N/A,False,False,False,False,False
+5f00::/16,Segment Routing (SRv6) SIDs,[RFC9602],2024-04,N/A,True,True,True,False,False
 fc00::/7,Unique-Local,"[RFC4193]
-        [RFC8190]",2005-10,N/A,True,True,True,False [7],False
+        [RFC8190]",2005-10,N/A,True,True,True,False [4],False
 fe80::/10,Link-Local Unicast,[RFC4291],2006-02,N/A,True,True,False,False,True


### PR DESCRIPTION
## Purpose

Zonemaster stores a local copy of the IANA special IP registries and uses it in some Address test case. The registries have been updated by IANA. This PR updates the local copies.

## Context

* #1387 
* https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
* https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml

## How to test this PR

Review and unit tests must pass.
