### PR TITLE
Updates Perl version in CI (Engine)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           - develop
           #- latest
         perl:
-          - '5.38'
-          - '5.34'
-          - '5.26'
+          - '5.40'
+          - '5.36'
+          - '5.32'
         runner:
           - ubuntu-22.04
 


### PR DESCRIPTION
## Purpose

To meet the Perl versions in the OSs in upcoming v2025.1 release, the tested Perl versions have been updated in CI.

## Context

https://github.com/zonemaster/zonemaster/pull/1387/files#diff-9f68c9af0040a1f9733498c8cc9b32588b3ee03e3e4e33c27dda89c42a1804c1

## How to test this PR

Review and unit tests should pass.