### PR TITLE
Update Dockerfile for release 2025.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,24 +11,31 @@ RUN apk add --no-cache \
     perl-module-build-tiny \
     # Compile-time dependencies
     perl-app-cpanminus \
+    perl-class-accessor \
     perl-clone \
     perl-file-sharedir \
     perl-file-slurp \
     perl-io-socket-inet6 \
     perl-list-moreutils \
     perl-locale-msgfmt \
+    perl-log-any \
     perl-lwp-protocol-https \
     perl-mail-spf \
     perl-module-install \
     perl-pod-coverage \
+    perl-readonly \
     perl-sub-override \
     perl-test-differences \
     perl-test-exception \
     perl-test-fatal \
+    perl-test-nowarnings \
     perl-test-pod \
     perl-text-csv \
+    perl-yaml \
+    perl-yaml-libyaml \
  && cpanm --no-wget --from=https://cpan.metacpan.org/ \
     Email::Valid \
+    List::Compare \
     Locale::PO \
     Locale::TextDomain \
     Module::Find \
@@ -51,15 +58,19 @@ RUN apk add --no-cache \
     # All the locales we need and more
     musl-locales \
     # Run-time dependencies
+    perl-class-accessor \
     perl-clone \
     perl-file-sharedir \
     perl-file-slurp \
     perl-io-socket-inet6 \
     perl-list-moreutils \
     perl-locale-msgfmt \
+    perl-log-any \
     perl-mail-spf \
     perl-mailtools \
     perl-module-install \
     perl-net-ip \
+    perl-readonly \
     perl-text-csv \
-    perl-try-tiny
+    perl-try-tiny \
+    perl-yaml-libyaml


### PR DESCRIPTION
## Purpose

This PR fixes issues in the Dockerfile preventing images based on `develop` from being built.

## Context

Release testing for release 2025.1.

## Changes

 * Add 7 missing build-time dependencies
 * Add 4 missing run-time dependencies

## How to test this PR

Build the Docker image according to [the documented instructions](https://github.com/zonemaster/zonemaster/blob/master/docs/internal/maintenance/ReleaseProcess-create-docker-image.md). The build process should complete successfully. Then, perform the “smoke test”:
```
docker run --rm zonemaster/engine:local perl -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("BASIC", "zonemaster.net")'
```

This command should show no output for at most a minute or two, before displaying messages from Zonemaster-Engine.
