### PR TITLE
Preparation for v2025.1 release (Engine)

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,20 +2,22 @@ Release history for Zonemaster component Zonemaster-Engine
 
 v8.0.0 2025-06-26 (part of Zonemaster v2025.1 release)
 
- [Breaking change]
-- Improves performance by optimizing critical code sections #1420
-
- [Features]
+ [Breaking changes]
+- Changes the string representation of IPv6 addresses in "NS_CREATED"
+  messages #1420
 - Separates functions to trim whitespace and to normalize domain
   name, respectively #1316
+
+ [Features]
+- Updates local copies of IANA special IP registries #1456
 - Lowers all WARNING to NOTICE for test case Zone01 #1455
 - Downgrades ERROR to WARNING in test case DNSSEC03 #1452
+- Improves performance by optimizing critical code sections #1420
 
  [Fixes]
 - Updates translations (Danish, Norwegian) #1418, #1449
 - Updates Dockerfile for release 2025.1 #1460
 - Fixes test case DNSSEC10 for name servers sharing the same IPs #1457
-- Updates local copies of IANA special IP registries #1456
 - Adds blacklisting log message #1434
 - Fixes alias (CNAME) handling in Address03 test case #1432
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,25 @@
 Release history for Zonemaster component Zonemaster-Engine
 
+v8.0.0 2025-06-26 (part of Zonemaster v2025.1 release)
+
+ [Breaking change]
+- Improves performance by optimizing critical code sections #1420
+
+ [Features]
+- Separates functions to trim whitespace and to normalize domain
+  name, respectively #1316
+- Lowers all WARNING to NOTICE for test case Zone01 #1455
+- Downgrades ERROR to WARNING in test case DNSSEC03 #1452
+
+ [Fixes]
+- Updates translations (Danish, Norwegian) #1418, #1449
+- Updates Dockerfile for release 2025.1 #1460
+- Fixes test case DNSSEC10 for name servers sharing the same IPs #1457
+- Updates local copies of IANA special IP registries #1456
+- Adds blacklisting log message #1434
+- Fixes alias (CNAME) handling in Address03 test case #1432
+
+
 v7.1.0 2025-03-04 (part of Zonemaster v2024.2.1 release)
 
  [Release information]

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,7 +34,7 @@ requires 'Net::IP::XS'        => 0.21;
 requires 'Readonly'           => 0;
 requires 'Text::CSV'          => 0;
 requires 'YAML::XS'           => 0;
-requires 'Zonemaster::LDNS'   => 4.001000; # For v4.1.0
+requires 'Zonemaster::LDNS'   => 4.001001; # For v4.1.1
 
 test_requires 'Locale::PO'        => 0;
 test_requires 'Pod::Coverage'     => 0;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,7 +34,7 @@ requires 'Net::IP::XS'        => 0.21;
 requires 'Readonly'           => 0;
 requires 'Text::CSV'          => 0;
 requires 'YAML::XS'           => 0;
-requires 'Zonemaster::LDNS'   => 4.001001; # For v4.1.1
+requires 'Zonemaster::LDNS'   => 5.000000; # For v5.0.0
 
 test_requires 'Locale::PO'        => 0;
 test_requires 'Pod::Coverage'     => 0;

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -3,7 +3,7 @@ package Zonemaster::Engine;
 use v5.16.0;
 use warnings;
 
-use version; our $VERSION = version->declare("v7.1.0");
+use version; our $VERSION = version->declare("v8.0.0");
 
 BEGIN {
     # Locale::TextDomain (<= 1.20) doesn't know about File::ShareDir so give a helping hand.


### PR DESCRIPTION
## Purpose

This PR is a preparation for v2025.1 release.

## Changes
*  Changes
* lib/Zonemaster/Engine.pm
* Makefile.PL

## Note

CI will fail until https://github.com/zonemaster/zonemaster-ldns/pull/230

## How to test this PR

Review.