### PR TITLE
Fix error in memoization for MethodsV2 method Get-Parent-NS-IP

### DIFF
--- a/lib/Zonemaster/Engine/TestMethodsV2.pm
+++ b/lib/Zonemaster/Engine/TestMethodsV2.pm
@@ -256,7 +256,11 @@ sub get_parent_ns_ips {
 # Memoize get_parent_ns_ips() because it is expensive and gets called a few
 # times with identical parameters.
 
-memoize('get_parent_ns_ips');
+memoize('get_parent_ns_ips',
+        NORMALIZER => sub {
+            my ( $class, $zone ) = @_;
+            join "\034", ( $class, $zone->name );
+        });
 
 =over
 


### PR DESCRIPTION
## Purpose

This PR fixes a regression introduced by #1420 that could, in certain circumstances, cause MethodsV2 method [Get-Parent-NS-IP](https://github.com/zonemaster/zonemaster/blob/develop/docs/public/specifications/tests/MethodsV2.md#method-get-parent-ns-ip-addresses) to either (a) fail to use previously cached results or (b) return data for a different zone than the one that was requested. This, in turn, could cause intermittent unit test suite failures, especially in `t/methodsv2.t`.

I’ve provided a more elaborate technical discussion of the problem in the commit message.

As a bonus, the unit tests now run a little bit faster. I don’t expect any significant improvement on real-world tests, however.

### Performance benchmarks

I used [hyperfine](https://github.com/sharkdp/hyperfine) for my benchmarks.

 * Over 50 iterations of `prove -l t/methodsv2.t`, the average runtime went down by 24%, from 18.585 s ± 0.427 s to 14.109 s ± 0.281 s.
 * Over 10 iterations of `prove -l`, the average runtime went down by 3.7%, from 96.286 s ± 0.901 s to 92.639 s ± 0.781 s.
 * Over 30 iterations of `zonemaster-cli --restore ../some_saved_data servfail.fr`, there was no statistically significant improvement (from 1.096 s ± 0.068 s to 1.083 s ± 0.034 s).

## Context

Investigation of intermittent unit test failures in CI and nightly package builds.

## Changes

- Change computation of cache key for memoizing Get-Parent-NS-IP.

## How to test this PR

Run the test suite 50 times in a row and expect no failures. For example, with the following command:

```sh
( for i in `seq 1 50`; do echo "Run number $i"; prove -l t/methodsv2.t || exit 1; done )
```

Without the fix, the test suite fails intermittently. In my development setup, I have found that the `t/methodsv2.t` unit test failed about once every 25 runs before this fix is applied.