### PR TITLE
Ignore and deprecate some profile properties

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -171,9 +171,6 @@ sub _build_dns {
 
     $res->retry( Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.retry} ) );
     $res->retrans( Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.retrans} ) );
-    $res->usevc( Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.usevc} ) );
-    $res->igntc( Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.igntc} ) );
-    $res->recurse( Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.recurse} ) );
     $res->debug( Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.debug} ) );
     $res->timeout( Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.timeout} ) );
 
@@ -225,10 +222,10 @@ sub query {
         }
     );
 
-    my $class     = $href->{class}     // 'IN';
-    my $dnssec    = $href->{dnssec}    // 0;
-    my $usevc     = $href->{usevc}     // $profile->get( q{resolver.defaults.usevc} );
-    my $recurse   = $href->{recurse}   // $profile->get( q{resolver.defaults.recurse} );
+    my $class   = $href->{class}   // 'IN';
+    my $dnssec  = $href->{dnssec}  // 0;
+    my $usevc   = $href->{usevc}   // 0;
+    my $recurse = $href->{recurse} // 0;
 
     if ( exists $href->{edns_details} and exists $href->{edns_details}{do} ) {
         $dnssec = $href->{edns_details}{do};
@@ -401,14 +398,17 @@ sub _query {
     );
 
     # Make sure we have a value for each flag
-    $flags{q{retry}}     = $href->{q{retry}}     // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.retry} );
-    $flags{q{retrans}}   = $href->{q{retrans}}   // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.retrans} );
-    $flags{q{dnssec}}    = $href->{q{dnssec}}    // 0;
-    $flags{q{usevc}}     = $href->{q{usevc}}     // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.usevc} );
-    $flags{q{igntc}}     = $href->{q{igntc}}     // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.igntc} );
-    $flags{q{fallback}}  = $href->{q{fallback}}  // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.fallback} );
-    $flags{q{recurse}}   = $href->{q{recurse}}   // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.recurse} );
-    $flags{q{timeout}}   = $href->{q{timeout}}   // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.timeout} );
+    $flags{q{retry}}   = $href->{q{retry}} // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.retry} );
+    $flags{q{retrans}} = $href->{q{retrans}}
+      // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.retrans} );
+    $flags{q{dnssec}}   = $href->{q{dnssec}} // 0;
+    $flags{q{usevc}}    = $href->{q{usevc}}  // 0;
+    $flags{q{igntc}}    = $href->{q{igntc}}  // 0;
+    $flags{q{fallback}} = $href->{q{fallback}}
+      // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.fallback} );
+    $flags{q{recurse}} = $href->{q{recurse}} // 0;
+    $flags{q{timeout}} = $href->{q{timeout}}
+      // Zonemaster::Engine::Profile->effective->get( q{resolver.defaults.timeout} );
 
     if ( exists $href->{edns_details} ) {
         $flags{q{dnssec}}    = $href->{edns_details}{do} // $flags{q{dnssec}};

--- a/lib/Zonemaster/Engine/Profile.pm
+++ b/lib/Zonemaster/Engine/Profile.pm
@@ -649,30 +649,15 @@ If it is set it has a value that is valid for that specific property.
 Here is a listing of all the properties and their respective sets of
 valid values.
 
-=head2 resolver.defaults.usevc
-
-A boolean. If true, only use TCP. Default false.
-
 =head2 resolver.defaults.retrans
 
 An integer between 1 and 255 inclusive. The number of seconds between retries.
 Default 3.
 
-=head2 resolver.defaults.recurse
-
-A boolean. If true, sets the RD flag in queries. Default false.
-
-This should almost certainly be kept false.
-
 =head2 resolver.defaults.retry
 
 An integer between 1 and 255 inclusive.
 The number of times a query is sent before we give up. Default 2.
-
-=head2 resolver.defaults.igntc
-
-A boolean. If false, UDP queries that get responses with the C<TC>
-flag set will be automatically resent over TCP. Default false.
 
 =head2 resolver.defaults.fallback
 
@@ -702,6 +687,18 @@ The source address all resolver objects should use when sending queries over IPv
 If set to "" (empty string), the OS default IPv6 address is used.
 
 Default: "" (empty string).
+
+=head2 resolver.defaults.igntc
+
+A boolean. Default false. Ignored. Deprecated and planned for removal in v2026.1. Remove it from your profile file.
+
+=head2 resolver.defaults.recurse
+
+A boolean. Default false. Ignored. Deprecated and planned for removal in v2026.1. Remove it from your profile file.
+
+=head2 resolver.defaults.usevc
+
+A boolean. Default false. Ignored. Deprecated and planned for removal in v2026.1. Remove it from your profile file.
 
 =head2 net.ipv4
 


### PR DESCRIPTION
## Purpose

Ignore and deprecate profile properties that complicate query parameter semantics for no good reason, and allows user configuration to cause Zonemaster to misbehave for no good reason.

## Context

Fixes the remainder of #1148.

## Changes

Ignore and deprecate these profile properties:
 * `resolver.defaults.igntc`
 * `resolver.defaults.recurse`
 * `resolver.defaults.usevc`

## How to test this PR

Here is a profile file that sets all four properties to unreasonable values:
```json
{"resolver":{"defaults":{"igntc":true,"recurse":true,"usevc":true}}}
```
I don't have any examples of zones that break with that profile, but it does break ASN lookups without the changes in this PR.