### PR TITLE
Update DNSSEC05 message IDs

### DIFF
--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -986,42 +986,44 @@ Readonly my %TAG_DESCRIPTIONS => (
     },
     DS05_ALGO_DEPRECATED => sub {
         __x    # DNSSEC:DS05_ALGO_DEPRECATED
-          'The DNSKEY with tag {keytag} uses deprecated algorithm number {algo_num} ("{algo_descr}", '
-          . '{algo_mnemo}), on name servers "{ns_list}".',
+          'The DNSKEY with tag {keytag} uses deprecated algorithm number {algo_num} ("{algo_descr}", {algo_mnemo}). '
+          . 'Fetched from name servers "{ns_list}".',
           @_;
     },
     DS05_ALGO_NOT_RECOMMENDED => sub {
         __x    # DNSSEC:DS05_ALGO_NOT_RECOMMENDED
-          'The DNSKEY with tag {keytag} uses an algorithm number {algo_num} ("{algo_descr}", {algo_mnemo}), '
-          . 'which is not recommended to be used. Fetched from name servers "{ns_list}".',
+          'The DNSKEY with tag {keytag} uses unrecommended algorithm number {algo_num} ("{algo_descr}", {algo_mnemo}). '
+          . 'Fetched from name servers "{ns_list}".',
           @_;
     },
     DS05_ALGO_NOT_ZONE_SIGN => sub {
         __x    # DNSSEC:DS05_ALGO_NOT_ZONE_SIGN
-          'The DNSKEY with tag {keytag} uses algorithm number not meant for zone signing, algorithm number '
-          . '{algo_num} ("{algo_descr}", {algo_mnemo}), on name servers "{ns_list}".',
+          'The DNSKEY with tag {keytag} uses algorithm number {algo_num} ("{algo_descr}", {algo_mnemo}) which is '
+          . 'not meant for zone signing. Fetched from name servers "{ns_list}".',
           @_;
     },
     DS05_ALGO_OK => sub {
         __x    # DNSSEC:DS05_ALGO_OK
-          'The DNSKEY with tag {keytag} uses algorithm number {algo_num} ("{algo_descr}", {algo_mnemo}), '
-          . 'which is OK. Fetched from name servers "{ns_list}".',
+          'The DNSKEY with tag {keytag} uses algorithm number {algo_num} ("{algo_descr}", {algo_mnemo}). '
+          . 'Fetched from name servers "{ns_list}".',
           @_;
     },
     DS05_ALGO_PRIVATE => sub {
         __x    # DNSSEC:DS05_ALGO_PRIVATE
-          'The DNSKEY with tag {keytag} uses algorithm number {algo_num} for private use on name '
-          . 'servers "{ns_list}".',
+          'The DNSKEY with tag {keytag} uses algorithm number {algo_num} which is '
+          . 'reserved for private use. Fetched from name servers "{ns_list}".',
           @_;
     },
     DS05_ALGO_RESERVED => sub {
         __x    # DNSSEC:DS05_ALGO_RESERVED
-          'The DNSKEY with tag {keytag} uses reserved algorithm number {algo_num} on name servers "{ns_list}".',
+          'The DNSKEY with tag {keytag} uses reserved algorithm number {algo_num}. '
+          . 'Fetched from name servers "{ns_list}".',
           @_;
     },
     DS05_ALGO_UNASSIGNED => sub {
         __x    # DNSSEC:DS05_ALGO_UNASSIGNED
-          'The DNSKEY with tag {keytag} uses unassigned algorithm number {algo_num} on name servers "{ns_list}".',
+          'The DNSKEY with tag {keytag} uses unassigned algorithm number {algo_num}. '
+          . 'Fetched from name servers "{ns_list}".',
           @_;
     },
     DS05_NO_RESPONSE => sub {


### PR DESCRIPTION
## Purpose

This PR updates DNSSEC05 message IDs as specified in https://github.com/zonemaster/zonemaster/pull/1448.

## Context

https://github.com/zonemaster/zonemaster/pull/1448

## Changes

- Message IDs

## How to test this PR

1. Unit tests should still pass.
2. Check that the updates match the ones in https://github.com/zonemaster/zonemaster/pull/1448. 
3. Run DNSSEC05 on a signed zone and check the output, e.g. with zonemaster-cli:
```
$ zonemaster-cli --show-testcase --level INFO --test dnssec05 --no-ipv6 afnic.fr

Seconds Level    Testcase       Message
======= ======== ============== =======
   0.00 INFO     Unspecified    Using version v8.0.0 of the Zonemaster engine.
  12.80 INFO     DNSSEC05       The DNSKEY with tag 54074 uses algorithm number 13 ("ECDSA Curve P-256 with SHA-256", ECDSAP256SHA256). Fetched from name servers "g.ext.nic.fr/194.0.36.1;ns1.nic.fr/192.134.4.1;ns2.nic.fr/192.93.0.4;ns3.nic.fr/192.134.0.49".
  12.80 INFO     DNSSEC05       The DNSKEY with tag 32674 uses algorithm number 13 ("ECDSA Curve P-256 with SHA-256", ECDSAP256SHA256). Fetched from name servers "g.ext.nic.fr/194.0.36.1;ns1.nic.fr/192.134.4.1;ns2.nic.fr/192.93.0.4;ns3.nic.fr/192.134.0.49".
```
