### PR TITLE
Fix missing value in Zone11 message tag

### DIFF
--- a/lib/Zonemaster/Engine/Test/Zone.pm
+++ b/lib/Zonemaster/Engine/Test/Zone.pm
@@ -1586,7 +1586,7 @@ sub zone11 {
     }
     elsif ( List::MoreUtils::all { $_ eq '' } keys %spf_ns ) {
         if ( $zone->name eq '.' or $zone->name->next_higher eq '.' or $zone->name =~ /\.arpa$/ ) {
-            push @results, _emit_log( Z11_NO_SPF_NON_MAIL_DOMAIN => {} );
+            push @results, _emit_log( Z11_NO_SPF_NON_MAIL_DOMAIN => { domain => $zone->name } );
         }
         else {
             push @results, _emit_log( Z11_NO_SPF_FOUND => { domain => $zone->name } );


### PR DESCRIPTION
## Purpose

This PR fixes a missing value for message tag `Z11_NO_SPF_NON_MAIL_DOMAIN` in `Zone11` test case.

## How to test this PR

Tests should still pass.

Manual testing:
- Before this PR:
```
$ zonemaster-cli --show-testcase --level INFO --test zone11 --no-ipv6 fr

Seconds Level    Testcase       Message
======= ======== ============== =======
   0.00 INFO     Unspecified    Using version v8.1.0 of the Zonemaster engine.
   9.72 INFO     Zone11         No SPF policy was found for {domain}, which is a type of domain (root, TLD or under .ARPA) not expected to be used for email.
```
- After:
```
$ zonemaster-cli --show-testcase --level INFO --test zone11 --no-ipv6 fr

Seconds Level    Testcase       Message
======= ======== ============== =======
   0.00 INFO     Unspecified    Using version v8.1.0 of the Zonemaster engine.
   9.70 INFO     Zone11         No SPF policy was found for fr, which is a type of domain (root, TLD or under .ARPA) not expected to be used for email.
```
