### PR TITLE
Fix inactive upward referral guard

### DIFF
--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -275,6 +275,7 @@ sub _resolve_cname {
 sub _recurse {
     my ( $class, $name, $type, $dns_class, $state ) = @_;
     $name = q{} . name( $name );
+    $state->{qname} //= $name;
 
     if ( $state->{in_progress}{$name}{$type} ) {
         return;


### PR DESCRIPTION
## Purpose

This PR proposes a fix to a long-lasting inactive upward referral guard of Zonemaster's recursor.

## Context

Fixes #1488 

## Changes

- `lib/Zonemaster/Engine/Recursor.pm`

## How to test this PR

Unit tests are not updated but should still pass.
