### PR TITLE
EDNS in undelegated test responses

### DIFF
--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -226,12 +226,17 @@ sub query {
     my $dnssec  = $href->{dnssec}  // 0;
     my $usevc   = $href->{usevc}   // 0;
     my $recurse = $href->{recurse} // 0;
+    my $edns_size;
 
-    if ( exists $href->{edns_details} and exists $href->{edns_details}{do} ) {
-        $dnssec = $href->{edns_details}{do};
+    if ( exists $href->{edns_details} ) {
+        $dnssec = $href->{edns_details}{do} // $dnssec;
+        $edns_size = $href->{edns_details}{size} // ( $href->{edns_size} // ( $dnssec ? $EDNS_UDP_PAYLOAD_DNSSEC_DEFAULT : $EDNS_UDP_PAYLOAD_DEFAULT ) );
+    }
+    else {
+        $edns_size = $href->{edns_size} // ( $dnssec ? $EDNS_UDP_PAYLOAD_DNSSEC_DEFAULT : 0 );
     }
 
-    my $edns_size = $href->{edns_size} // ( $dnssec ? $EDNS_UDP_PAYLOAD_DNSSEC_DEFAULT : 0 );
+    croak "edns_size (or edns_details->size) parameter must be a value between 0 and 65535" if $edns_size > 65535 or $edns_size < 0;
 
     # Fake a DS answer
     if ( $type eq 'DS' and $class eq 'IN' and $self->fake_ds->{ lc( $name ) } ) {
@@ -241,13 +246,29 @@ sub query {
         $p->aa( 1 );
         $p->do( $dnssec );
         $p->rd( $recurse );
+        $p->edns_size( $edns_size );
+
+        if ( $edns_size > 0 ) {
+            $p->set_edns_present;
+        }
+
+        if ( exists $href->{edns_details} ) {
+            $p->set_edns_present;
+
+            foreach my $flag ( keys %{ $href->{edns_details} } ) {
+                next if ( $flag eq 'do' or $flag eq 'size' );
+                my $method = "edns_$flag";
+                $p->$method( $href->{edns_details}{$flag} ) if $p->can( $method );
+            }
+        }
 
         foreach my $rr ( @{ $self->fake_ds->{ lc( $name ) } } ) {
             $p->unique_push( 'answer', $rr );
         }
 
-        my $res = Zonemaster::Engine::Packet->new( { packet => $p } );
         Zonemaster::Engine->logger->add( FAKE_DS_RETURNED => { name => "$name", type  => $type, class => $class, from => "$self" } );
+
+        my $res = Zonemaster::Engine::Packet->new( { packet => $p } );
         Zonemaster::Engine->logger->add( FAKE_PACKET_RETURNED => { packet => $res->string } );
         return $res;
     }
@@ -277,6 +298,21 @@ sub query {
             $p->do( $dnssec );
             $p->rd( $recurse );
             $p->answerfrom( $address->ip );
+            $p->edns_size( $edns_size );
+
+            if ( $edns_size > 0 ) {
+                $p->set_edns_present;
+            }
+
+            if ( exists $href->{edns_details} ) {
+                $p->set_edns_present;
+
+                foreach my $flag ( keys %{ $href->{edns_details} } ) {
+                    next if ( $flag eq 'do' or $flag eq 'size' );
+                    my $method = "edns_$flag";
+                    $p->$method( $href->{edns_details}{$flag} ) if $p->can( $method );
+                }
+            }
 
             Zonemaster::Engine->logger->add( FAKE_DELEGATION_RETURNED => { name  => "$name", type  => $type, class => $class, from  => "$self" } );
 
@@ -300,10 +336,7 @@ sub query {
                    q{EDNS_Z}              , $href->{edns_details}{z} // 0,
                    q{EDNS_EXTENDED_RCODE} , $href->{edns_details}{rcode} // 0,
                    q{EDNS_DATA}           , $href->{edns_details}{data} // q{} );
-        $edns_size = $href->{edns_details}{size} // ( $href->{edns_size} // ( $dnssec ? $EDNS_UDP_PAYLOAD_DNSSEC_DEFAULT : $EDNS_UDP_PAYLOAD_DEFAULT ) );
     }
-
-    croak "edns_size (or edns_details->size) parameter must be a value between 0 and 65535" if $edns_size > 65535 or $edns_size < 0;
 
     $md5->add( q{EDNS_UDP_SIZE} , $edns_size );
 
@@ -441,23 +474,16 @@ sub _query {
     }
     else {
         if ( exists $href->{edns_details} ) {
-            my $pkt = Zonemaster::LDNS::Packet->new("$name", $type, $href->{class} );
+            my $pkt = Zonemaster::LDNS::Packet->new( "$name", $type, $href->{class} );
             $pkt->set_edns_present();
 
-            $pkt->do($flags{q{dnssec}});
-            $pkt->edns_size($flags{q{edns_size}});
+            $pkt->do( $flags{q{dnssec}} );
+            $pkt->edns_size( $flags{q{edns_size}} );
 
-            if ( exists $href->{edns_details}{version} ) {
-                $pkt->edns_version($href->{edns_details}{version});
-            }
-            if ( exists $href->{edns_details}{z} ) {
-                $pkt->edns_z($href->{edns_details}{z});
-            }
-            if ( exists $href->{edns_details}{rcode} ) {
-                $pkt->edns_rcode($href->{edns_details}{rcode});
-            }
-            if ( exists $href->{edns_details}{data} ) {
-                $pkt->edns_data($href->{edns_details}{data});
+            foreach my $flag ( keys %{ $href->{edns_details} } ) {
+                next if ( $flag eq 'do' or $flag eq 'size' );
+                my $method = "edns_$flag";
+                $pkt->$method( $href->{edns_details}{$flag} ) if $pkt->can( $method );
             }
 
             $res = eval { $self->dns->query_with_pkt( $pkt ) };
@@ -837,7 +863,7 @@ Value overridden by C<edns_details-E<gt>{size}> (if also given). More details in
 
 =item edns_details
 
-A hash. An empty hash or a hash with any keys below will enable EDNS for the query.
+A hash. If defined, it enables EDNS for the query.
 
 The currently supported keys are 'version', 'z', 'do', 'rcode', 'size' and 'data'.
 See L<Zonemaster::LDNS::Packet> for more details (key names prefixed with 'edns_').


### PR DESCRIPTION
## Purpose

This PR include EDNS in responses of undelegated tests if it was used in the query. It will also (naively) include all EDNS fields from the query (i.e. EDNS version, RCODE, Z bit, etc -  _to the extent of LDNS capabilities_).

## Context

N/A.

## Changes

- For undelegated tests, respond with EDNS if it was present in the query.
- Refactoring

## How to test this PR

No unit test yet.
Manual testing:

- No EDNS:
```
$ perl -MZonemaster::Engine -E 'my $ns = Zonemaster::Engine->ns( "ns1", "127.1.0.1" ); $ns->add_fake_delegation("."); my $p = $ns->query(".", "SOA" ); say "\n
", $p->string, "\n" if defined($p);'

;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 0
;; flags: qr ; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;; .    IN      SOA

;; ANSWER SECTION:

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; Query time: 0 msec
;; SERVER: 127.1.0.1
;; WHEN: Thu Jan  1 01:00:00 1970
;; MSG SIZE  rcvd: 0
```
- EDNS (do=1, buffer size=999):
```
$ perl -MZonemaster::Engine -E 'my $ns = Zonemaster::Engine->ns( "ns1", "127.1.0.1" ); $ns->add_fake_delegation("."); my $p = $ns->query(".", "SOA", { do => 1, edns_size => 999 } ); say "\n", $p->string, "\n" if defined($p);'

;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 0
;; flags: qr ; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;; .    IN      SOA

;; ANSWER SECTION:

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; Query time: 0 msec
;; EDNS: version 0; flags: ; udp: 999
;; SERVER: 127.1.0.1
;; WHEN: Thu Jan  1 01:00:00 1970
;; MSG SIZE  rcvd: 0
```

- EDNS (version=2, buffer size=666, OPT=137)
```
$ perl -MZonemaster::Engine -E 'my $ns = Zonemaster::Engine->ns( "ns1", "127.1.0.1" ); $ns->add_fake_delegation("."); my $p = $ns->query(".", "DS", { edns_size => 999, edns_details => { size => 666, version => 2, data => 137*65536 } } ); say "\n", $p->string, "\n" if defined($p);'

;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 0
;; flags: qr aa ; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;; .    IN      DS

;; ANSWER SECTION:

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; Query time: 0 msec
;; EDNS: version 2; flags: ; udp: 666
; OPT=137:
;; SERVER: 127.1.0.1
;; WHEN: Thu Jan  1 01:00:00 1970
;; MSG SIZE  rcvd: 0
```
