### PR TITLE
Harden Nameserver15 against creative version strings

### DIFF
--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -1747,10 +1747,10 @@ sub nameserver15 {
                         push @wrong_record_class, $ns;
                     }
 
-                    my $string = $rr->txtdata;
+                    my $string = Zonemaster::Engine::Util::escape($rr->txtdata);
                     $string =~ s/^\s+|\s+$//g; # Remove leading and trailing spaces
 
-                    if ( $string and $string ne "") {
+                    if ( $string ne "" ) {
                         push @{ $txt_data{$string}{$query_name} }, $ns;
                         delete $sending_version_query{$ns};
                     }

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -5,17 +5,17 @@ use warnings;
 
 use version; our $VERSION = version->declare( "v1.1.0" );
 
+use JSON::PP;
 use List::MoreUtils qw[uniq none];
 use Locale::TextDomain qw[Zonemaster-Engine];
-use Readonly;
-use JSON::PP;
 use Net::IP::XS;
+use Readonly;
 
-use Zonemaster::Engine::Profile;
 use Zonemaster::Engine::Constants qw[:ip];
+use Zonemaster::Engine::Profile;
 use Zonemaster::Engine::Test::Address;
-use Zonemaster::Engine::Util;
 use Zonemaster::Engine::TestMethods;
+use Zonemaster::Engine::Util qw( escape_unprintable );
 
 =head1 NAME
 
@@ -1747,7 +1747,7 @@ sub nameserver15 {
                         push @wrong_record_class, $ns;
                     }
 
-                    my $string = Zonemaster::Engine::Util::escape($rr->txtdata);
+                    my $string = escape_unprintable($rr->txtdata);
                     $string =~ s/^\s+|\s+$//g; # Remove leading and trailing spaces
 
                     if ( $string ne "" ) {

--- a/lib/Zonemaster/Engine/Util.pm
+++ b/lib/Zonemaster/Engine/Util.pm
@@ -186,28 +186,37 @@ sub serial_gt {
            );
 }
 
-
-sub escape {
-    my ( $input ) = @_;
-
-    state sub code_to_escape {
-        if ( $_[0] == 92 ) {
+{
+    # HACK: It would be cleaner to use a state variable, but Perl versions
+    # older than 5.28.0 disallow initializing list state variables, e.g.
+    # writing “state @a = qw(a b c)”.
+    #
+    # A workaround could be to use a state arrayref variable for the
+    # substitution table, but this incurs a performance penalty.
+    #
+    # Once we support Perl ⩾ 5.28, we can rewrite this function using proper
+    # state variables. See also:
+    # <https://perldoc.perl.org/5.28.0/perldelta#Initialisation-of-aggregate-state-variables>.
+    my @substitution_table = map {
+        if ( $_ == 92 ) {
             '\\\\'
         }
-        elsif ( $_[0] >= 32 and $_[0] <= 126 ) {
-            chr $_[0]
+        elsif ( $_ >= 32 and $_ <= 126 ) {
+            chr $_
         }
         else {
-            sprintf '\%03d', $_[0]
+            sprintf '\%03d', $_
         }
+    } 0..255;
+
+    sub escape {
+        my ( $input ) = @_;
+
+        my $output = '';
+        $output .= $substitution_table[$_] foreach (unpack "C*", $input);
+
+        return $output;
     }
-
-    state @substitution_table = map { code_to_escape($_) } 0..255;
-
-    my $output = '';
-    $output .= $substitution_table[$_] foreach (unpack "C*", $input);
-
-    return $output;
 }
 
 1;

--- a/lib/Zonemaster/Engine/Util.pm
+++ b/lib/Zonemaster/Engine/Util.pm
@@ -8,6 +8,7 @@ use version; our $VERSION = version->declare("v1.1.13");
 use Exporter 'import';
 BEGIN {
     our @EXPORT_OK = qw[
+      escape
       info
       ipversion_ok
       name
@@ -185,6 +186,30 @@ sub serial_gt {
            );
 }
 
+
+sub escape {
+    my ( $input ) = @_;
+
+    state sub code_to_escape {
+        if ( $_[0] == 92 ) {
+            '\\\\'
+        }
+        elsif ( $_[0] >= 32 and $_[0] <= 126 ) {
+            chr $_[0]
+        }
+        else {
+            sprintf '\%03d', $_[0]
+        }
+    }
+
+    state @substitution_table = map { code_to_escape($_) } 0..255;
+
+    my $output = '';
+    $output .= $substitution_table[$_] foreach (unpack "C*", $input);
+
+    return $output;
+}
+
 1;
 
 =head1 NAME
@@ -284,6 +309,31 @@ Check if a test is blacklisted and should run or not.
 =item ipversion_ok
 
 Check if IP version operations are permitted. Tests are done against Zonemaster::Engine::Profile->effective content.
+
+=item escape
+
+Replaces all non-ASCII characters and control characters in a byte string with
+decimal escape codes. The resulting string only contains printable ASCII
+characters, which makes it safer for display on a terminal or for storage in a
+database.
+
+For example, C<"hello \x1B[34mworld!\x1B[0m\\\xFF"> is turned into
+C<'hello \027[34mworld!\027[0m\\\255'>.
+
+Do not use this function on character strings, or it might produce invalid
+results. Only use it on byte strings, e.g. UTF-8 encoded text returned by
+calling Encode::encode() on a character string, or raw data received from
+Zonemaster-LDNS.
+
+Space (ASCII 0x20) characters are left as they are, but all other ASCII
+whitespace characters, i.e. HORIZONTAL TAB (ASCII 0x09), LINE FEED (ASCII
+0x0A), VERTICAL TAB (ASCII 0x0B), FORM FEED (ASCII 0x0C) and CARRIAGE RETURN
+(ASCII 0x0D) will be replaced by their equivalent decimal escapes.
+
+Beware that the resulting string might still contain sequences of characters
+that can be dangerous in other contexts, requiring further escaping. For
+example, if the string is meant to be displayed on an HTML GUI, the result
+must have angle brackets and ampersand characters escaped in a second pass.
 
 =item test_levels
 

--- a/lib/Zonemaster/Engine/Util.pm
+++ b/lib/Zonemaster/Engine/Util.pm
@@ -8,7 +8,7 @@ use version; our $VERSION = version->declare("v1.1.13");
 use Exporter 'import';
 BEGIN {
     our @EXPORT_OK = qw[
-      escape
+      escape_unprintable
       info
       ipversion_ok
       name
@@ -209,7 +209,7 @@ sub serial_gt {
         }
     } 0..255;
 
-    sub escape {
+    sub escape_unprintable {
         my ( $input ) = @_;
 
         my $output = '';
@@ -319,7 +319,7 @@ Check if a test is blacklisted and should run or not.
 
 Check if IP version operations are permitted. Tests are done against Zonemaster::Engine::Profile->effective content.
 
-=item escape
+=item escape_unprintable
 
 Replaces all non-ASCII characters and control characters in a byte string with
 decimal escape codes. The resulting string only contains printable ASCII

--- a/t/util.t
+++ b/t/util.t
@@ -123,7 +123,7 @@ EOF
     }
 };
 
-subtest 'escape' => sub {
+subtest 'escape_unprintable' => sub {
     my @cases = (
         {
             input => 'hello world!',
@@ -143,7 +143,7 @@ subtest 'escape' => sub {
         # The following line is a hack that ensures that $bytes is a
         # byte-oriented string, instead of a character-oriented one.
         my $bytes = encode( 'Latin1', $case->{input} );
-        is Zonemaster::Engine::Util::escape( $bytes ), $case->{expected};
+        is Zonemaster::Engine::Util::escape_unprintable( $bytes ), $case->{expected};
     }
 };
 

--- a/t/util.t
+++ b/t/util.t
@@ -2,6 +2,9 @@ use Test::More;
 use Test::Differences;
 use Test::Exception;
 
+use Encode qw(encode);
+use utf8;
+
 BEGIN { use_ok( 'Zonemaster::Engine::Util', qw( info name ns parse_hints ) ) }
 
 isa_ok( ns( 'name', '::1' ), 'Zonemaster::Engine::Nameserver' );
@@ -117,6 +120,30 @@ EOF
                 parse_hints( $case->{hints} )
             } $case->{error}, $case->{name};
         }
+    }
+};
+
+subtest 'escape' => sub {
+    my @cases = (
+        {
+            input => 'hello world!',
+            expected => 'hello world!',
+        },
+        {
+            input => "escape this: \x1B\x7F\x80\xFF\x00\x0D\x0A\\",
+            expected => 'escape this: \027\127\128\255\000\013\010\\\\',
+        },
+        {
+            input => encode('UTF-8', 'cassé'),
+            expected => 'cass\195\169'
+        }
+    );
+
+    for my $case ( @cases ) {
+        # The following line is a hack that ensures that $bytes is a
+        # byte-oriented string, instead of a character-oriented one.
+        my $bytes = encode( 'Latin1', $case->{input} );
+        is Zonemaster::Engine::Util::escape( $bytes ), $case->{expected};
     }
 };
 


### PR DESCRIPTION
## Purpose

This PR addresses situations where Zonemaster-GUI fails to display a test’s results if at least one of the byte strings obtained in response of `version.bind` or `version.server/CH/TXT` queries contained specific sequences of non-ASCII bytes.

The same issue could also lead to injection of terminal control codes (e.g. [ANSI escape codes]) in zonemaster-cli.

Before:
<img width="1110" height="179" alt="image" src="https://github.com/user-attachments/assets/6ccd6673-562a-4497-a4ca-96f37a8abf83" />

After:
<img width="1111" height="169" alt="image" src="https://github.com/user-attachments/assets/38fcbf73-397a-43e2-ab26-1d08fd7ea1bb" />

And it also works on the GUI:
<img width="708" height="475" alt="image" src="https://github.com/user-attachments/assets/b24db302-4ee7-40e7-8823-4c0bd03fda36" />

## Context

See the following issues for context:
* zonemaster/zonemaster-backend#1216
* zonemaster/zonemaster#1437
* zonemaster/zonemaster-gui#544
* zonemaster/zonemaster-cli#458

## Changes

* Add string escaping function in `Zonemaster::Engine::Util`;
* In Nameserver15, convert `version.bind`/`version.server` strings using that function before logging the message.

**Note**: this PR will not fix test results that already are in the database. To fix old tests, we would need a migration script in Zonemaster-Backend.

## How to test this PR

* Unit tests were added and should still pass.
* With Zonemaster-CLI, run `zonemaster-cli --test nameserver15 servfail.fr`. One of the name servers’ version strings contains [ANSI escape codes] and various non-ASCII and non-printable characters. They should all be replaced with backslash-escaped decimal codes, and no text should appear in blue.
* With Zonemaster-Backend installed and running, run `zmtest servfail.fr`. The results should appear normally, instead of getting an internal server error message. A test against `s42.re` should also complete successfully and have its results display normally.


[ANSI escape codes]: https://en.wikipedia.org/wiki/ANSI_escape_code