### PR TITLE
Replace Perl INIT block with explicit initialization

### DIFF
--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -250,7 +250,7 @@ This manual describes the main L<Zonemaster::Engine> module. If what you're afte
 
 =item init_engine()
 
-Run the initialization tasks if they have not been run already. This method is called automatically in INIT block.
+Run the initialization tasks if they have not been run already. This method is called automatically at runtime.
 
 =item test_zone($name)
 

--- a/lib/Zonemaster/Engine.pm
+++ b/lib/Zonemaster/Engine.pm
@@ -26,19 +26,16 @@ use Zonemaster::Engine::Test;
 use Zonemaster::Engine::Recursor;
 use Zonemaster::Engine::ASNLookup;
 
-INIT {
-    init_engine();
-}
-
 our $logger;
 our $recursor = Zonemaster::Engine::Recursor->new;
 
-my $init_done = 0;
-
+my $init_done;
 sub init_engine {
     return if $init_done++;
     Zonemaster::Engine::Recursor::init_recursor();
 }
+
+init_engine();
 
 sub logger {
     return $logger //= Zonemaster::Engine::Logger->new;

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -8,7 +8,6 @@ use version; our $VERSION = version->declare("v1.1.16");
 use Class::Accessor qw[ antlers ];
 
 use Zonemaster::Engine::DNSName;
-use Zonemaster::Engine;
 use Zonemaster::Engine::Packet;
 use Zonemaster::Engine::Nameserver::Cache;
 use Zonemaster::Engine::Recursor;

--- a/lib/Zonemaster/Engine/Recursor.pm
+++ b/lib/Zonemaster/Engine/Recursor.pm
@@ -14,7 +14,7 @@ use Net::IP::XS;
 use List::MoreUtils qw[uniq];
 use Memoize;
 
-use Zonemaster::Engine;
+use Zonemaster::Engine::Nameserver;
 use Zonemaster::Engine::DNSName;
 use Zonemaster::Engine::Util qw( name ns parse_hints );
 use Zonemaster::Engine::Constants ":cname";

--- a/lib/Zonemaster/Engine/Test/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Test/Nameserver.pm
@@ -15,7 +15,7 @@ use Zonemaster::Engine::Constants qw[:ip];
 use Zonemaster::Engine::Profile;
 use Zonemaster::Engine::Test::Address;
 use Zonemaster::Engine::TestMethods;
-use Zonemaster::Engine::Util qw( escape_unprintable );
+use Zonemaster::Engine::Util qw( escape_unprintable scramble_case );
 
 =head1 NAME
 

--- a/lib/Zonemaster/Engine/Util.pm
+++ b/lib/Zonemaster/Engine/Util.pm
@@ -28,10 +28,10 @@ BEGIN {
 use Net::DNS::ZoneFile;
 use Pod::Simple::SimpleTree;
 
-use Zonemaster::Engine;
 use Zonemaster::Engine::Constants qw[:ip :soa];
 use Zonemaster::Engine::DNSName;
 use Zonemaster::Engine::Profile;
+use Zonemaster::Engine::Nameserver;
 
 sub ns {
     my ( $name, $address ) = @_;

--- a/t/logger.t
+++ b/t/logger.t
@@ -3,11 +3,12 @@ use Test::Fatal;
 use File::Slurp;
 
 BEGIN {
+    use_ok( 'Zonemaster::Engine' );
+    use_ok( 'Zonemaster::Engine::Util' );
     use_ok( 'Zonemaster::Engine::Logger' );
     use_ok( 'Zonemaster::Engine::Logger::Entry' );
     use_ok( 'Zonemaster::Engine::Exception' );
 }
-use Zonemaster::Engine::Util;
 
 my $log = Zonemaster::Engine->logger;
 

--- a/t/nameserver-axfr.t
+++ b/t/nameserver-axfr.t
@@ -4,8 +4,8 @@ use warnings;
 use Test::More;
 
 use Test::Fatal;
+use Zonemaster::Engine;
 use Zonemaster::Engine::Util;
-use Zonemaster::Engine::Nameserver;
 use Zonemaster::LDNS;
 use Sub::Override;
 

--- a/t/util.t
+++ b/t/util.t
@@ -5,7 +5,10 @@ use Test::Exception;
 use Encode qw(encode);
 use utf8;
 
-BEGIN { use_ok( 'Zonemaster::Engine::Util', qw( info name ns parse_hints ) ) }
+BEGIN {
+    use_ok( 'Zonemaster::Engine' );
+    use_ok( 'Zonemaster::Engine::Util', qw( info name ns parse_hints ) )
+}
 
 isa_ok( ns( 'name', '::1' ), 'Zonemaster::Engine::Nameserver' );
 isa_ok( info( 'TAG', {} ), 'Zonemaster::Engine::Logger::Entry' );


### PR DESCRIPTION
## Purpose

This PR removes the use of a Perl INIT block in Engine and replaces it with an explicit call to `init_engine()` at module load time.

The current use of INIT causes warnings when `Zonemaster::Engine` is loaded in environments where Perl’s INIT phase has already completed (e.g. PSGI/Plack-based deployments). Since the initialization logic is already idempotent, the INIT block is no longer necessary.

## Context

Fixes https://github.com/zonemaster/zonemaster-engine/issues/1439

## Changes

- Replace INIT block with an explicit call to `init_engine()` at module load time

## How to test this PR

- Unit tests should still pass.
- Starting Zonemaster-Backend should no longer show a "Too late to run INIT block" warning message.
