### PR TITLE
Revert "Remove obsolete TO_JSON methods"

### DIFF
--- a/lib/Zonemaster/Engine/DNSName.pm
+++ b/lib/Zonemaster/Engine/DNSName.pm
@@ -155,6 +155,12 @@ sub prepend {
     return $self->new( { labels => \@labels } );
 }
 
+sub TO_JSON {
+    my ( $self ) = @_;
+
+    return $self->string;
+}
+
 1;
 
 =head1 NAME
@@ -233,6 +239,10 @@ See also L<https://tools.ietf.org/html/rfc7719#section-6>.
 =item prepend($label)
 
 Returns a new L<Zonemaster::Engine::DNSName> object, representing the called one with the given label prepended.
+
+=item TO_JSON
+
+Helper method for JSON encoding.
 
 =back
 

--- a/lib/Zonemaster/Engine/Packet.pm
+++ b/lib/Zonemaster/Engine/Packet.pm
@@ -157,6 +157,12 @@ sub answerfrom {
     return $from;
 }
 
+sub TO_JSON {
+    my ( $self ) = @_;
+
+    return { 'Zonemaster::Engine::Packet' => $self->packet };
+}
+
 1;
 
 =head1 NAME
@@ -225,6 +231,10 @@ C<authority> and C<additional>, only RRs from those sections are returned.
 =item answerfrom
 
 Wrapper for the underlying packet method, that replaces undefined values with the string C<E<lt>unknownE<gt>>.
+
+=item TO_JSON
+
+Support method for L<JSON> to be able to serialize these objects.
 
 =back
 

--- a/t/logger.t
+++ b/t/logger.t
@@ -1,6 +1,7 @@
-use Test::More;
-use Test::Fatal;
 use File::Slurp;
+use JSON::PP;
+use Test::Fatal;
+use Test::More;
 
 BEGIN {
     use_ok( 'Zonemaster::Engine' );
@@ -35,6 +36,35 @@ isa_ok( $entry, 'Zonemaster::Engine::Logger::Entry' );
 ok( scalar( @{ Zonemaster::Engine->logger->entries } ) >= 2, 'expected number of entries' );
 
 like( "$entry", qr/System:Unspecified:TEST an=argument/, 'stringification overload' );
+
+$entry = info( 'TEST2', { an => 'argument', domain => Zonemaster::Engine::Util::name( 'logger.test.example' ) } );
+
+# FIXME: Ideally, we really should instead have domain=logger.test.example
+# without the double quotes around the domain name.
+#
+# Providing the domain name as a regular string gives us no double quotes
+# around the domain name. Providing it directly as a
+# Zonemaster::Engine::DNSName does give us double quotes, however. That’s
+# because blessed objects get turned into their JSON representations, while
+# regular strings are interpolated as they are. The TO_JSON method for DNSName
+# objects returns a simple string, which is then converted into JSON in the
+# usual double-quoted notation.
+#
+# It’s an annoying inconsistency, but any attempt at a fix might cause
+# repercussions when translating a log entry to a human language, a string, or
+# JSON. For now, we expect the broken behavior, but that should be fixed
+# someday.
+is(
+    "$entry",
+    'System:Unspecified:TEST2 an=argument; domain="logger.test.example"',
+    'stringification overload works with DNS names' );
+is_deeply(
+    (decode_json $log->json)->[-1]->{args},
+    {
+        an => 'argument',
+        domain => 'logger.test.example'
+    },
+    'entry arguments serialize to JSON' );
 
 is( $entry->level, 'DEBUG', 'right level' );
 my $example = Zonemaster::Engine::Logger::Entry->new({ module => 'Basic', tag => 'B02_NS_BROKEN', testcase => 'Basic02' } );


### PR DESCRIPTION
## Purpose

This PR reverts a commit introduced in #1517 that deleted what I thought was dead code. It turns out it wasn’t dead code at all.

The issue manifests itself by the fact that some messages, like `B02_AUTH_RESPONSE_SOA`, get `null` instead of a domain name for the `domain` argument when converted to either the raw representation, or JSON.

I wrongly assumed that no other place in the code would attempt to convert domain names to JSON by calling the `TO_JSON` method. Also, JSON::PP is set up in such a way that when a blessed reference is to be converted and the class has no `TO_JSON` method, its JSON representation is `null` instead of generating a fatal error. Hence the appearance of `null`s in raw log entry representation or JSON representations.

## Context

Follow-up to #1517.

## Changes

* Revert a commit removing `TO_JSON` methods in two classes
* Add unit tests

## How to test this PR

Unit tests have been added and should pass.

For good measure, run the following command and expect the following output:
```
$ zonemaster-cli --test basic02 --level info zonemaster.net --json | \
    jq '.results[] | select(.tag == "B02_AUTH_RESPONSE_SOA") | .args.domain'
"zonemaster.net"
```