### PR TITLE
Adds missing tag in list of tags for DNSSEC10

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,7 +3,9 @@ Release history for Zonemaster component Zonemaster-Engine
 v9.0.0 2026-06-29 (part of Zonemaster v2026.1 release)
 
  [Breaking changes]
- - Removes deprecated profile properties (#1532)
+ - Removes deprecated profile properties,
+   resolver.defaults.recurse, resolver.defaults.igntc
+   and resolver.defaults.usevc (#1532)
  - Changes saved packets’ serialization format (#1517, #1531)
 
  [Features]
@@ -16,7 +18,7 @@ v9.0.0 2026-06-29 (part of Zonemaster v2026.1 release)
  - Replaces Perl INIT block with explicit initialization (#1530)
  - Hardens test case Nameserver15 against creative version
    strings (#1528)
- - Updates test case DNSSEC10 implementation (#1523)
+ - Updates test case DNSSEC10 implementation (#1523, #1539)
 
 
 v8.1.1 2026-03-04 (part of Zonemaster v2025.2.1 release)

--- a/lib/Zonemaster/Engine/Test/DNSSEC.pm
+++ b/lib/Zonemaster/Engine/Test/DNSSEC.pm
@@ -560,6 +560,7 @@ sub metadata {
               DS10_NSEC_RRSIG_NOT_YET_VALID
               DS10_NSEC_RRSIG_NO_DNSKEY
               DS10_NSEC_RRSIG_VERIFY_ERROR
+              DS10_NONSTANDARD_NSEC_RESPONSE
               DS10_SERVER_NO_DNSSEC
               DS10_ZONE_NO_DNSSEC
               )


### PR DESCRIPTION
## Purpose

This PR adds a tag that was missing for DNSSEC10. Also updates `Changes` with this PR plus a smaller editorial update.

## How to test this PR

* CI should pass
* Review
