### PR TITLE
Fix edge cases in Get-Delegation and Get-Del-NS-Names-and-IPs when dealing with fake delegation

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -23,6 +23,7 @@ lib/Zonemaster/Engine/Nameserver/Cache/LocalCache.pm
 lib/Zonemaster/Engine/Nameserver/Cache.pm
 lib/Zonemaster/Engine/Nameserver/Cache/RedisCache.pm
 lib/Zonemaster/Engine/Nameserver.pm
+lib/Zonemaster/Engine/NameserverSet.pm
 lib/Zonemaster/Engine/Normalization/Error.pm
 lib/Zonemaster/Engine/Normalization.pm
 lib/Zonemaster/Engine/NSArray.pm
@@ -80,6 +81,7 @@ t/nameserver-axfr.data
 t/nameserver-axfr.t
 t/nameserver.data
 t/nameserver.t
+t/nameserverset.t
 t/normalization.t
 t/packet.t
 t/pod-coverage.t

--- a/lib/Zonemaster/Engine/DNSName.pm
+++ b/lib/Zonemaster/Engine/DNSName.pm
@@ -99,13 +99,17 @@ sub str_cmp {
     # Treat undefined value as root
     my $other = $_[1] // q{};
 
-    if ( blessed $other and $other->isa( 'Zonemaster::Engine::DNSName' ) ) {
-        return $me cmp uc( $other->{_string} // $other->string() );
-    }
-    else {
-        # Assume $other is a string; remove trailing dot except if only character
-        return $me cmp uc( $other =~ s/.\K [.] \z//xr );
-    }
+    my $comparison = do {
+        if ( blessed $other and $other->isa( 'Zonemaster::Engine::DNSName' ) ) {
+            $me cmp uc( $other->{_string} // $other->string() );
+        }
+        else {
+            # Assume $other is a string; remove trailing dot except if only character
+            $me cmp uc( $other =~ s/.\K [.] \z//xr );
+        }
+    };
+
+    return $_[2] ? -$comparison : $comparison;
 }
 
 sub next_higher {

--- a/lib/Zonemaster/Engine/Nameserver.pm
+++ b/lib/Zonemaster/Engine/Nameserver.pm
@@ -577,7 +577,20 @@ sub string {
 sub compare {
     my ( $self, $other, $reverse ) = @_;
 
-    return $self->string cmp $other->string;
+    my $comparison = do {
+        if ( ref $other and $other->isa('Zonemaster::Engine::Nameserver') ) {
+            $self->name cmp $other->name ||
+                $self->address->version <=> $other->address->version ||
+                $self->address->intip <=> $other->address->intip;
+        }
+        else {
+            $self->string cmp $other
+        }
+    };
+
+    $comparison = -$comparison if $reverse;
+
+    return $comparison;
 }
 
 

--- a/lib/Zonemaster/Engine/NameserverSet.pm
+++ b/lib/Zonemaster/Engine/NameserverSet.pm
@@ -1,0 +1,338 @@
+package Zonemaster::Engine::NameserverSet;
+
+use v5.26.0;
+use warnings;
+
+use Scalar::Util qw(blessed);
+
+use Zonemaster::Engine::DNSName;
+use Zonemaster::Engine::Nameserver;
+
+####
+#### Constructors
+####
+
+sub new {
+    my ( $proto, @initial_items ) = @_;
+    my $class = ref $proto || $proto;
+
+    my $self = {
+        _names => {},
+    };
+
+    bless $self, $class;
+    $self->push( @initial_items );
+
+    return $self;
+}
+
+####
+#### Mutators
+####
+
+sub push {
+    my ( $self, @items ) = @_;
+
+    for my $item ( @items ) {
+        next if not defined $item;
+        next if $item eq '';
+
+        if ( $item->isa('Zonemaster::Engine::DNSName') ) {
+            if ( not exists $self->{_names}{lc $item} ) {
+                $self->{_names}{lc $item} = $item;
+            }
+        }
+        elsif ( $item->isa('Zonemaster::Engine::Nameserver') ) {
+            my ( $name, $addr ) = ( $item->name, $item->address->short );
+
+            my $r = \$self->{_names}{lc $name};
+            if ( not defined $$r or ref $$r ne 'HASH' ) {
+                $$r = {};
+            }
+            $$r->{$addr} = $item;
+        }
+        else {
+            my $name = Zonemaster::Engine::DNSName->new( "$item" );
+            if ( not exists $self->{_names}{lc $name} ) {
+                $self->{_names}{lc $item} = $name;
+            }
+        }
+    }
+
+    return $self;
+}
+
+####
+#### Access to items
+####
+
+sub get {
+    my ( $self, $name ) = @_;
+
+    if ( not exists $self->{_names}{ lc $name } ) {
+        return ();
+    }
+
+    my $r = $self->{_names}{ lc $name };
+    if ( ref $r eq 'HASH' ) {
+        return values %$r;
+    }
+
+    return $r;
+}
+
+sub get_ips {
+    my ( $self, $name ) = @_;
+
+    if ( exists $self->{_names}{ lc $name } ) {
+        my $r = $self->{_names}{ lc $name };
+        if ( ref $r eq 'HASH' ) {
+            return values %$r;
+        }
+    }
+
+    return ();
+}
+
+sub items {
+    my ( $self ) = @_;
+
+    my @items;
+
+    for my $k ( keys %{ $self->{_names} } ) {
+        my $r = $self->{_names}{$k};
+        if ( ref $r eq 'HASH' ) {
+            CORE::push( @items, map { $r->{$_} } keys %$r );
+        }
+        else {
+            CORE::push( @items, $r );
+        }
+    }
+
+    return @items;
+}
+
+sub names {
+    my ( $self ) = @_;
+
+    my @result;
+
+    for my $k ( keys %{ $self->{_names} } ) {
+        my $r = $self->{_names}{$k};
+        if ( ref $r eq 'HASH' ) {
+            CORE::push( @result, ( values %$r )[0]->name() );
+        }
+        else {
+            CORE::push( @result, $r );
+        }
+    }
+
+    return @result;
+}
+
+sub sorted_items {
+    my ( $self ) = @_;
+
+    my @items;
+
+    for my $k ( sort keys %{ $self->{_names} } ) {
+        my $r = $self->{_names}{$k};
+        if ( ref $r eq 'HASH' ) {
+            CORE::push( @items, sort map { $r->{$_} } keys %$r );
+        }
+        else {
+            CORE::push( @items, $r );
+        }
+    }
+
+    return @items;
+}
+
+####
+#### Basic operations
+####
+
+sub is_empty {
+    my ( $self ) = @_;
+
+    return ( scalar %{ $self->{_names} } == 0 );
+}
+
+####
+#### Set theory operations
+####
+
+sub difference {
+    my ( $self, $other ) = @_;
+
+    my $only_in_left = __PACKAGE__->new();
+    my $only_in_right = __PACKAGE__->new();
+
+    my @left_items = $self->sorted_items();
+    my @right_items = $other->sorted_items();
+
+    while ( @left_items and @right_items ) {
+        my $cmp = $left_items[0] cmp $right_items[0];
+        if ( $cmp < 0 ) {
+            $only_in_left->push( shift @left_items );
+        }
+        elsif ( $cmp == 0 ) {
+            shift @left_items;
+            shift @right_items;
+        }
+        elsif ( $cmp > 0 ) {
+            $only_in_right->push( shift @right_items );
+        }
+    }
+    $only_in_left->push( @left_items );
+    $only_in_right->push( @right_items );
+
+    return ( $only_in_left, $only_in_right );
+}
+
+sub equals {
+    my ( $self, $other ) = @_;
+
+    my @left_items = $self->sorted_items();
+    my @right_items = $other->sorted_items();
+
+    while ( @left_items and @right_items ) {
+        if ( shift @left_items ne shift @right_items ) {
+            return 0;
+        }
+    }
+
+    return ( scalar @left_items == 0 and scalar @right_items == 0 );
+}
+
+1;
+
+=encoding UTF-8
+
+=head1 NAME
+
+Zonemaster::Engine::NameserverSet - a set supporting DNS name/IP pairs and plain DNS names
+
+=head1 SYNOPSIS
+
+    use Zonemaster::Engine::NameserverSet;
+
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    my $ns1 = Zonemaster::Engine::Nameserver->new({ name => 'ns.nic.example', address => '2001:db8::8:53' });
+    my $ns2 = Zonemaster::Engine::Nameserver->new({ name => 'ns.nic.example', address => '2001:db8::9:53' });
+    $set->push( $ns1, $ns2 );
+
+    my $name = Zonemaster::Engine::DNSName->new( 'ns2.nic.example' );
+    $set->push( $name );
+
+    $set->get( 'ns.nic.example' );  # returns $ns1 and $ns2 in list context
+    $set->get( 'ns2.nic.example' ); # returns $name in list context
+
+    # Retrieve items
+    my @items = $set->items; # or $set->sorted_items
+
+=head1 DESCRIPTION
+
+Zonemaster::Engine::NameserverSet implements a collection type that is
+specialized for holding a mix of name/IP pairs (represented as
+L<Zonemaster::Engine::Nameserver> objects) and bare domain names (represented
+as L<Zonemaster::Engine::DNSName> objects).
+
+In other words, it is a collection type that stores mappings of name server
+names to zero, one or more IP addresses.
+
+=head1 METHODS
+
+=over
+
+=item new()
+
+Constructs a new empty name server set.
+
+=item push( $name_or_ns )
+
+Adds an item to the set, which can either be a L<Zonemaster::Engine::DNSName>
+or a L<Zonemaster::Engine::Nameserver> object.
+
+This method obeys the following rules:
+
+=over
+
+=item *
+
+If C<$name_or_ns> is a L<Zonemaster::Engine::DNSName>, it is added to the set
+if and only if the set contains no L<Zonemaster::Engine::DNSName> object with
+the same name nor any L<Zonemaster::Engine::Nameserver> objects with the same
+name.
+
+=item *
+
+If C<$name_or_ns> is a L<Zonemaster::Engine::Nameserver>, it is added to
+the set if and only if the set contains no other
+L<Zonemaster::Engine::Nameserver> with the same name and address.
+
+=item *
+
+If C<$name_or_ns> is a L<Zonemaster::Engine::Nameserver> and the set already
+contains a L<Zonemaster::Engine::DNSName> object with the same name, the
+nameserver object replaces the plain DNS name in the set.
+
+=back
+
+=item get( $name )
+
+Returns a list of all items whose name is equivalent to C<$name>, or an empty
+list if no match.
+
+If only a L<Zonemaster::Engine::DNSName> is stored in the set, that name
+as a single return value (or a singleton list in list context).
+
+If one or more L<Zonemaster::Engine::Nameserver> objects with matching C<$name> are
+stored in the set, returns a list comprising of those objects.
+
+=item get_ips( $name )
+
+Returns a list of all L<Zonemaster::Engine::Nameserver> objects with matching
+C<$name> that are stored in the set.
+
+If only a L<Zonemaster::Engine::DNSName> of the same C<$name> is stored in the
+set, this function returns undef.
+
+=item items()
+
+Returns the entire contents of the set as a list, in an unspecified order.
+
+=item names()
+
+Returns the unique list of names associated with the objects stored in the
+set, both plain L<Zonemaster::Engine::DNSName> objects or the names of
+L<Zonemaster::Engine::Nameserver> objects.
+
+All names are returned as L<Zonemaster::Engine::DNSName> objects.
+
+=item sorted_items()
+
+Returns the entire contents of the set as a list, in a deterministic order.
+
+Items are sorted lexicographically based on their names, and if multiple
+L<Zonemaster::Engine::Nameserver> objects have the same name, these are sorted
+on IP addresses such that IPv4 addresses are sorted before IPv6 addresses, and
+within an address family, each address is sorted based on their integer
+values.
+
+=item is_empty()
+
+Returns true if and only ef the set contains no items.
+
+=item difference( $other_set )
+
+Computes the difference between two sets. Returns a pair of sets: the first
+one contains the items only occurring in the left set (i.e. left minus right),
+the second one the items only in the right set (i.e. right minus left).
+
+=item equals( $other_set )
+
+Returns true if and only if the set is equal to C<$other_set>.
+
+=back

--- a/lib/Zonemaster/Engine/TestMethodsV2.pm
+++ b/lib/Zonemaster/Engine/TestMethodsV2.pm
@@ -9,6 +9,7 @@ use Carp;
 use List::MoreUtils qw[uniq];
 use Memoize;
 
+use Zonemaster::Engine::NameserverSet;
 use Zonemaster::Engine::Util;
 
 =head1 NAME
@@ -393,24 +394,51 @@ Returns an arrayref of L<Zonemaster::Engine::Nameserver> objects, or C<undef> if
 sub _get_delegation {
     my ( $class, $zone ) = @_;
 
+    # Takes the names from NS resource records from a packet ($p)’s section ($ns_section), plus the
+    # address records from the additional section belonging to those NS names that are in-domain
+    # with respect to the zone name, and returns the combined names and possibly IPs as a
+    # Zonemaster::Engine::NameserverSet.
+    my sub packet_ns_names_and_in_domain_ips {
+        my ( $p, $ns_section ) = @_;
+
+        # Set of NS names from $ns_section ('authority' or 'additional') section
+        my %ns_names = map { lc name( $_->nsdname() ) => 1 }
+            $p->get_records_for_name( 'NS', $zone, $ns_section );
+
+        # List of A/AAAA records from additional section for NS names
+        # that are in-domain wrt. the zone name
+        my @additional =
+            map {
+                my $name = name( $_->owner() );
+
+                # Filters out A and AAAA records with invalid IP addresses
+                my $addr = Net::IP::XS->new( $_->address );
+                ( defined $addr ) ? ns( $name, $addr ) : ()
+            }
+            grep {
+                my $name = name( lc $_->owner() );
+                exists $ns_names{$name} and
+                    $zone->name->is_in_bailiwick($name) and
+                    ( $_->type eq 'A' or $_->type eq 'AAAA' )
+                }
+            $p->additional;
+
+        return Zonemaster::Engine::NameserverSet->new( keys %ns_names, @additional );
+    }
+
     my $is_undelegated = Zonemaster::Engine::Recursor->has_fake_addresses( $zone->name->string );
-    my %delegation_ns;
-    my %aa_ns;
-    my @ib_ns;
+    my $result = Zonemaster::Engine::NameserverSet->new();
 
     if ( $is_undelegated ) {
         for my $ns_name ( Zonemaster::Engine::Recursor->get_fake_names( $zone->name->string ) ) {
-            if ( $zone->name->is_in_bailiwick( name( $ns_name ) ) ) {
-                for my $ns_ip ( Zonemaster::Engine::Recursor->get_fake_addresses( $zone->name->string, $ns_name ) ){
-                    push @ib_ns, ns( $ns_name, $ns_ip);
-                }
+            my @ns_ips = Zonemaster::Engine::Recursor->get_fake_addresses( $zone->name->string, $ns_name );
+            if ( $zone->name->is_in_bailiwick( name( $ns_name ) ) and scalar @ns_ips ) {
+                $result->push( map { ns( $ns_name, $_ ) } @ns_ips );
             }
             else {
-                push @ib_ns, name( $ns_name );
+                $result->push( name( $ns_name ) );
             }
         }
-
-        return [ uniq sort @ib_ns ];
     }
     elsif ( $zone->name->string eq '.' ) {
         return [ uniq sort Zonemaster::Engine::Recursor->root_servers() ];
@@ -423,95 +451,41 @@ sub _get_delegation {
         for my $ns ( @{ $parent_ref } ) {
             my $p = $ns->query( $zone->name, q{NS} );
 
-            if ( $p and $p->rcode eq q{NOERROR} ) {
-                if ( $p->is_redirect ){
-                    for my $rr ( $p->get_records_for_name( q{NS}, $zone->name->string, q{authority} ) ) {
-                        $delegation_ns{$rr->nsdname} = [] unless exists $delegation_ns{$rr->nsdname};
-                    }
+            next unless $p and $p->rcode eq q{NOERROR};
 
-                    for my $rr ( $p->get_records( q{A}, q{additional} ), $p->get_records( q{AAAA}, q{additional} ) ) {
-                        if ( $zone->name->is_in_bailiwick( name( $rr->owner ) ) and scalar grep { $_ eq $rr->owner } keys %delegation_ns ) {
-                            push @{ $delegation_ns{$rr->owner} }, $rr->address;
-                        }
-                    }
-                }
-                elsif ( $p->aa and scalar $p->get_records_for_name( q{NS}, $zone->name->string, q{answer} ) ) {
-                    for my $rr ( $p->get_records_for_name( q{NS}, $zone->name->string, q{answer} ) ) {
-                        $aa_ns{$rr->nsdname} = [] unless exists $aa_ns{$rr->nsdname};
-                    }
+            if ( $p->is_redirect ) {
+                $result->push( packet_ns_names_and_in_domain_ips( $p, 'authority' )->items() );
+            }
+            elsif ( $p->aa and scalar $p->get_records_for_name( q{NS}, $zone->name->string, q{answer} ) ) {
+                $result->push( packet_ns_names_and_in_domain_ips( $p, 'answer' )->items() );
 
-                    for my $rr ( $p->get_records( q{A}, q{additional} ), $p->get_records( q{AAAA}, q{additional} ) ) {
-                        if ( $zone->name->is_in_bailiwick( name( $rr->owner ) ) and scalar grep { $_ eq $rr->owner } keys %aa_ns ) {
-                            push @{ $aa_ns{$rr->owner} }, $rr->address;
-                        }
-                    }
+                for my $ns_name ( grep { not $result->get_ips( $_ ) } $result->names() ) {
+                    for my $qtype ( q{A}, q{AAAA} ) {
+                        my $p = Zonemaster::Engine::Recursor->recurse( $ns_name, $qtype );
 
-                    for my $ns_name ( keys %aa_ns ) {
-                        unless ( scalar $aa_ns{$ns_name} ) {
-                            for my $qtype ( q{A}, q{AAAA} ) {
-                                my $p = Zonemaster::Engine::Recursor->recurse( $ns_name, $qtype );
+                        next unless $p and $p->rcode eq q{NOERROR};
 
-                                if ( $p and $p->rcode eq q{NOERROR} ) {
-                                    if ( $p->has_rrs_of_type_for_name( q{CNAME}, $ns_name, q{answer} ) ) {
-                                        my %cnames = map { name( $_->owner ) => name( $_->cname ) } $p->get_records( q{CNAME}, q{answer} );
-                                        my $target = $ns_name;
-                                        $target = $cnames{$target} while $cnames{$target};
+                        # Follow possible CNAME chain starting from the QNAME in the answer packet.
+                        # That QNAME might be different from $ns_name if, to follow the CNAME chain
+                        # to the end, the recursor had to restart the query multiple times. This can
+                        # happen if CNAME chains cross zones.
+                        my %cnames = map {
+                            lc name( $_->owner ) => lc name( $_->cname )
+                        } $p->get_records( q{CNAME}, q{answer} );
 
-                                        for my $rr ( $p->get_records_for_name( $qtype, $target ) ) {
-                                            push @{ $aa_ns{$ns_name} }, $rr->address;
-                                        }
-                                    }
-                                    # CNAME was followed in a new recursive query
-                                    elsif ( name( ($p->question)[0]->owner ) ne $ns_name and grep { $_->tag eq 'CNAME_FOLLOWED_OUT_OF_ZONE' and grep /^$ns_name$/, values %{ $_->args } } @{ Zonemaster::Engine->logger->entries } ) {
-                                        my $cname_ns_name = name( ($p->question)[0]->owner );
-                                        my $target = $cname_ns_name;
+                        my $target = name( ($p->question)[0]->owner );
+                        $target = $cnames{$target} while exists $cnames{$target};
 
-                                        if ( $p->has_rrs_of_type_for_name( q{CNAME}, $cname_ns_name, q{answer} ) ) {
-                                            my %cnames = map { name( $_->owner ) => name( $_->cname ) } $p->get_records( q{CNAME}, q{answer} );
-                                            $target = $cnames{$target} while $cnames{$target};
-                                        }
-
-                                        for my $rr ( $p->get_records_for_name( $qtype, $target ) ) {
-                                            push @{ $aa_ns{$ns_name} }, $rr->address;
-                                        }
-                                    }
-                                    elsif ( $p->has_rrs_of_type_for_name( $qtype, $ns_name ) ) {
-                                        for my $rr ( $p->get_records_for_name( $qtype, $ns_name ) ) {
-                                            push @{ $aa_ns{$ns_name} }, $rr->address;
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        $result->push(
+                            map { ns( $ns_name, $_->address ) }
+                            $p->get_records_for_name( $qtype, $target ) );
                     }
                 }
             }
         }
     }
 
-    my $hash_ref;
-    if ( scalar keys %delegation_ns ) {
-        $hash_ref = \%delegation_ns;
-    }
-    elsif ( scalar keys %aa_ns ) {
-        $hash_ref = \%aa_ns;
-    }
-    else {
-        return [];
-    }
-
-    for my $ns_name ( keys %{ $hash_ref } ) {
-        if ( scalar @{ %{ $hash_ref }{$ns_name} } ) {
-            for my $ns_ip ( uniq @{ %{ $hash_ref }{$ns_name} } ) {
-                push @ib_ns, ns( $ns_name, $ns_ip );
-            }
-        }
-        else {
-            push @ib_ns, name( $ns_name );
-        }
-    }
-
-    return [ uniq sort @ib_ns ];
+    return [ $result->items() ];
 }
 
 =over
@@ -540,13 +514,11 @@ sub get_del_ns_names_and_ips {
 
     return undef unless defined $ns_ref;
 
-    my @ns_names = grep { $_->isa('Zonemaster::Engine::DNSName') } @{ $ns_ref };
+    my @ns_names = grep { $_->isa('Zonemaster::Engine::DNSName') and ! $zone->name->is_in_bailiwick( $_ ) } @{ $ns_ref };
 
     my $oob_ns_ref = $class->_get_oob_ips( $zone, \@ns_names );
 
-    @{ $ns_ref } = grep { $_->isa('Zonemaster::Engine::Nameserver') } @{ $ns_ref };
-
-    return [ uniq sort (@{ $ns_ref }, @{ $oob_ns_ref }) ];
+    return [ Zonemaster::Engine::NameserverSet->new( @$ns_ref, @$oob_ns_ref )->items() ];
 }
 
 =over

--- a/lib/Zonemaster/Engine/TestMethodsV2.pm
+++ b/lib/Zonemaster/Engine/TestMethodsV2.pm
@@ -9,6 +9,7 @@ use Carp;
 use List::MoreUtils qw[uniq];
 use Memoize;
 
+use Zonemaster::Engine::NameserverSet;
 use Zonemaster::Engine::Util;
 
 =head1 NAME
@@ -393,24 +394,51 @@ Returns an arrayref of L<Zonemaster::Engine::Nameserver> objects, or C<undef> if
 sub _get_delegation {
     my ( $class, $zone ) = @_;
 
+    # Takes the names from NS resource records from a packet ($p)’s section ($ns_section), plus the
+    # address records from the additional section belonging to those NS names that are in-domain
+    # with respect to the zone name, and returns the combined names and possibly IPs as a
+    # Zonemaster::Engine::NameserverSet.
+    my sub packet_ns_names_and_in_domain_ips {
+        my ( $p, $ns_section ) = @_;
+
+        # Set of NS names from authority section
+        my %authority = map { lc name( $_->nsdname() ) => 1 }
+            $p->get_records_for_name( 'NS', $zone, $ns_section );
+
+        # List of A/AAAA records from additional section for NS names
+        # that are in-domain wrt. the zone name
+        my @additional =
+            map {
+                my $name = name( $_->owner() );
+
+                # Filters out A and AAAA records with invalid IP addresses
+                my $addr = Net::IP::XS->new( $_->address );
+                ( defined $addr ) ? ns( $name, $addr ) : ()
+            }
+            grep {
+                my $name = name( lc $_->owner() );
+                exists $authority{$name} and
+                    $zone->name->is_in_bailiwick($name) and
+                    ( $_->type eq 'A' or $_->type eq 'AAAA' )
+                }
+            $p->additional;
+
+        return Zonemaster::Engine::NameserverSet->new( keys %authority, @additional );
+    }
+
     my $is_undelegated = Zonemaster::Engine::Recursor->has_fake_addresses( $zone->name->string );
-    my %delegation_ns;
-    my %aa_ns;
-    my @ib_ns;
+    my $result = Zonemaster::Engine::NameserverSet->new();
 
     if ( $is_undelegated ) {
         for my $ns_name ( Zonemaster::Engine::Recursor->get_fake_names( $zone->name->string ) ) {
-            if ( $zone->name->is_in_bailiwick( name( $ns_name ) ) ) {
-                for my $ns_ip ( Zonemaster::Engine::Recursor->get_fake_addresses( $zone->name->string, $ns_name ) ){
-                    push @ib_ns, ns( $ns_name, $ns_ip);
-                }
+            my @ns_ips = Zonemaster::Engine::Recursor->get_fake_addresses( $zone->name->string, $ns_name );
+            if ( $zone->name->is_in_bailiwick( name( $ns_name ) ) and scalar @ns_ips ) {
+                $result->push( map { ns( $ns_name, $_ ) } @ns_ips );
             }
             else {
-                push @ib_ns, name( $ns_name );
+                $result->push( name( $ns_name ) );
             }
         }
-
-        return [ uniq sort @ib_ns ];
     }
     elsif ( $zone->name->string eq '.' ) {
         return [ uniq sort Zonemaster::Engine::Recursor->root_servers() ];
@@ -423,95 +451,41 @@ sub _get_delegation {
         for my $ns ( @{ $parent_ref } ) {
             my $p = $ns->query( $zone->name, q{NS} );
 
-            if ( $p and $p->rcode eq q{NOERROR} ) {
-                if ( $p->is_redirect ){
-                    for my $rr ( $p->get_records_for_name( q{NS}, $zone->name->string, q{authority} ) ) {
-                        $delegation_ns{$rr->nsdname} = [] unless exists $delegation_ns{$rr->nsdname};
-                    }
+            next unless $p and $p->rcode eq q{NOERROR};
 
-                    for my $rr ( $p->get_records( q{A}, q{additional} ), $p->get_records( q{AAAA}, q{additional} ) ) {
-                        if ( $zone->name->is_in_bailiwick( name( $rr->owner ) ) and scalar grep { $_ eq $rr->owner } keys %delegation_ns ) {
-                            push @{ $delegation_ns{$rr->owner} }, $rr->address;
-                        }
-                    }
-                }
-                elsif ( $p->aa and scalar $p->get_records_for_name( q{NS}, $zone->name->string, q{answer} ) ) {
-                    for my $rr ( $p->get_records_for_name( q{NS}, $zone->name->string, q{answer} ) ) {
-                        $aa_ns{$rr->nsdname} = [] unless exists $aa_ns{$rr->nsdname};
-                    }
+            if ( $p->is_redirect ) {
+                $result->push( packet_ns_names_and_in_domain_ips( $p, 'authority' )->items() );
+            }
+            elsif ( $p->aa and scalar $p->get_records_for_name( q{NS}, $zone->name->string, q{answer} ) ) {
+                $result->push( packet_ns_names_and_in_domain_ips( $p, 'answer' )->items() );
 
-                    for my $rr ( $p->get_records( q{A}, q{additional} ), $p->get_records( q{AAAA}, q{additional} ) ) {
-                        if ( $zone->name->is_in_bailiwick( name( $rr->owner ) ) and scalar grep { $_ eq $rr->owner } keys %aa_ns ) {
-                            push @{ $aa_ns{$rr->owner} }, $rr->address;
-                        }
-                    }
+                for my $ns_name ( grep { not $result->get_ips( $_ ) } $result->names() ) {
+                    for my $qtype ( q{A}, q{AAAA} ) {
+                        my $p = Zonemaster::Engine::Recursor->recurse( $ns_name, $qtype );
 
-                    for my $ns_name ( keys %aa_ns ) {
-                        unless ( scalar $aa_ns{$ns_name} ) {
-                            for my $qtype ( q{A}, q{AAAA} ) {
-                                my $p = Zonemaster::Engine::Recursor->recurse( $ns_name, $qtype );
+                        next unless $p and $p->rcode eq q{NOERROR};
 
-                                if ( $p and $p->rcode eq q{NOERROR} ) {
-                                    if ( $p->has_rrs_of_type_for_name( q{CNAME}, $ns_name, q{answer} ) ) {
-                                        my %cnames = map { name( $_->owner ) => name( $_->cname ) } $p->get_records( q{CNAME}, q{answer} );
-                                        my $target = $ns_name;
-                                        $target = $cnames{$target} while $cnames{$target};
+                        # Follow possible CNAME chain starting from the QNAME in the answer packet.
+                        # That QNAME might be different from $ns_name if, to follow the CNAME chain
+                        # to the end, the recursor had to restart the query multiple times. This can
+                        # happen if CNAME chains cross zones.
+                        my %cnames = map {
+                            lc name( $_->owner ) => lc name( $_->cname )
+                        } $p->get_records( q{CNAME}, q{answer} );
 
-                                        for my $rr ( $p->get_records_for_name( $qtype, $target ) ) {
-                                            push @{ $aa_ns{$ns_name} }, $rr->address;
-                                        }
-                                    }
-                                    # CNAME was followed in a new recursive query
-                                    elsif ( name( ($p->question)[0]->owner ) ne $ns_name and grep { $_->tag eq 'CNAME_FOLLOWED_OUT_OF_ZONE' and grep /^$ns_name$/, values %{ $_->args } } @{ Zonemaster::Engine->logger->entries } ) {
-                                        my $cname_ns_name = name( ($p->question)[0]->owner );
-                                        my $target = $cname_ns_name;
+                        my $target = name( ($p->question)[0]->owner );
+                        $target = $cnames{$target} while exists $cnames{$target};
 
-                                        if ( $p->has_rrs_of_type_for_name( q{CNAME}, $cname_ns_name, q{answer} ) ) {
-                                            my %cnames = map { name( $_->owner ) => name( $_->cname ) } $p->get_records( q{CNAME}, q{answer} );
-                                            $target = $cnames{$target} while $cnames{$target};
-                                        }
-
-                                        for my $rr ( $p->get_records_for_name( $qtype, $target ) ) {
-                                            push @{ $aa_ns{$ns_name} }, $rr->address;
-                                        }
-                                    }
-                                    elsif ( $p->has_rrs_of_type_for_name( $qtype, $ns_name ) ) {
-                                        for my $rr ( $p->get_records_for_name( $qtype, $ns_name ) ) {
-                                            push @{ $aa_ns{$ns_name} }, $rr->address;
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        $result->push(
+                            map { ns( $ns_name, $_->address ) }
+                            $p->get_records_for_name( $qtype, $target ) );
                     }
                 }
             }
         }
     }
 
-    my $hash_ref;
-    if ( scalar keys %delegation_ns ) {
-        $hash_ref = \%delegation_ns;
-    }
-    elsif ( scalar keys %aa_ns ) {
-        $hash_ref = \%aa_ns;
-    }
-    else {
-        return [];
-    }
-
-    for my $ns_name ( keys %{ $hash_ref } ) {
-        if ( scalar @{ %{ $hash_ref }{$ns_name} } ) {
-            for my $ns_ip ( uniq @{ %{ $hash_ref }{$ns_name} } ) {
-                push @ib_ns, ns( $ns_name, $ns_ip );
-            }
-        }
-        else {
-            push @ib_ns, name( $ns_name );
-        }
-    }
-
-    return [ uniq sort @ib_ns ];
+    return [ $result->items() ];
 }
 
 =over
@@ -540,13 +514,11 @@ sub get_del_ns_names_and_ips {
 
     return undef unless defined $ns_ref;
 
-    my @ns_names = grep { $_->isa('Zonemaster::Engine::DNSName') } @{ $ns_ref };
+    my @ns_names = grep { $_->isa('Zonemaster::Engine::DNSName') and ! $zone->name->is_in_bailiwick( $_ ) } @{ $ns_ref };
 
     my $oob_ns_ref = $class->_get_oob_ips( $zone, \@ns_names );
 
-    @{ $ns_ref } = grep { $_->isa('Zonemaster::Engine::Nameserver') } @{ $ns_ref };
-
-    return [ uniq sort (@{ $ns_ref }, @{ $oob_ns_ref }) ];
+    return [ Zonemaster::Engine::NameserverSet->new( @$ns_ref, @$oob_ns_ref )->items() ];
 }
 
 =over

--- a/t/methodsv2.t
+++ b/t/methodsv2.t
@@ -765,7 +765,8 @@ my %subtests = (
               ns1.parent.child-ns-cname-4.methodsv2.xa/fda1:b2:c3:0:127:40:1:41
               ns2.parent.child-ns-cname-4.methodsv2.xa/127.40.1.42
               ns2.parent.child-ns-cname-4.methodsv2.xa/fda1:b2:c3:0:127:40:1:42 ) ],
-        [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51 ) ],
+        [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51
+              ns2-cname.child.parent.child-ns-cname-4.methodsv2.xa ) ],
         [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51
               ns2-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.52 ) ],
         [ ],

--- a/t/methodsv2.t
+++ b/t/methodsv2.t
@@ -765,7 +765,8 @@ my %subtests = (
               ns1.parent.child-ns-cname-4.methodsv2.xa/fda1:b2:c3:0:127:40:1:41
               ns2.parent.child-ns-cname-4.methodsv2.xa/127.40.1.42
               ns2.parent.child-ns-cname-4.methodsv2.xa/fda1:b2:c3:0:127:40:1:42 ) ],
-        [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51 ) ],
+        [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51
+              ns2-cname.child.parent.child-ns-cname-4.methodsv2.xa ) ],
         [ qw( ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51
               ns2-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.52 ) ],
         [ ],
@@ -844,6 +845,21 @@ my %subtests = (
               ns2.child.parent.parent-ns-same-ip-2.methodsv2.xa/fda1:b2:c3:0:127:40:1:52 ) ],
         [ ],
     ],
+    'UNDEL-MISSING-GLUE-1' => [
+        1,
+        q(child.parent.undel-missing-glue-1.methodsv2.xa),
+        [ ], # No parent data
+        [ qw( ns1.child.parent.undel-missing-glue-1.methodsv2.xa
+              ns2.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.52
+              ns2.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:52 ) ],
+        [ qw( ns1.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.51
+              ns1.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:51
+              ns2.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.52
+              ns2.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:52 ) ],
+        [ qw( ns1.child.parent.undel-missing-glue-1.methodsv2.xa
+              ns2.child.parent.undel-missing-glue-1.methodsv2.xa/127.40.1.52
+              ns2.child.parent.undel-missing-glue-1.methodsv2.xa/fda1:b2:c3:0:127:40:1:52 ) ]
+    ]
 );
 
 

--- a/t/nameserver.t
+++ b/t/nameserver.t
@@ -187,6 +187,47 @@ subtest 'dnssec, edns_size and edns_details{do, size} flags behavior for queries
     dies_ok { $p = $ns->query( 'fr', 'SOA', { "edns_details" => { "size" => -1 } } ); }      "dies when edns_size (set with edns_details->size) is lower than 0";
 };
 
+subtest 'comparisons' => sub {
+    my $ns1 = Zonemaster::Engine->ns( 'a.test', '2001:db8::1' );
+    my $ns2 = Zonemaster::Engine->ns( 'b.test', '2001:db8::1' );
+
+    ok( $ns1 eq $ns1 );
+    ok( $ns1 lt $ns2 );
+    ok( $ns2 gt $ns1 );
+    ok( "a.test/2001:db8::1" eq $ns1 );
+    ok( "b.test/2001:db8::1" gt $ns1 );
+};
+
+subtest 'sorting' => sub {
+    my @unsorted = (
+        Zonemaster::Engine->ns( 'localhost.test', '::1' ),
+        Zonemaster::Engine->ns( 'localhost.test', '127.0.0.1' ),
+        Zonemaster::Engine->ns( 'a.test', '192.0.2.150' ),
+        Zonemaster::Engine->ns( 'a.test', '192.0.2.1' ),
+        Zonemaster::Engine::DNSName->new( 'b.test' ),
+        Zonemaster::Engine->ns( 'a.test', '2001:db8::1000' ),
+        Zonemaster::Engine->ns( 'a.test', '2001:db8::1' ),
+        'm.test',
+        Zonemaster::Engine->ns( 'b.test', '3ffe::b' )
+    );
+
+    my @sorted = map { "$_" } sort @unsorted;
+
+    my @expected = qw(
+                       a.test/192.0.2.1
+                       a.test/192.0.2.150
+                       a.test/2001:db8::1
+                       a.test/2001:db8::1000
+                       b.test
+                       b.test/3ffe::b
+                       localhost.test/127.0.0.1
+                       localhost.test/::1
+                       m.test
+               );
+
+    is_deeply( \@sorted, \@expected ) or diag( "This is what we got:\n" . join( "\n", @sorted ));
+};
+
 Zonemaster::Engine::Profile->effective->set( q{resolver.source4}, q{127.0.0.1} );
 my $ns_test = new_ok( 'Zonemaster::Engine::Nameserver' => [ { name => 'ns.nic.se', address => '212.247.7.228' } ] );
 is($ns_test->dns->source, '127.0.0.1', 'Source IPv4 address set.');

--- a/t/nameserverset.t
+++ b/t/nameserverset.t
@@ -1,0 +1,549 @@
+use v5.24.0;
+use warnings;
+
+use List::Util;
+
+use Test::More;
+
+use Zonemaster::Engine;
+use Zonemaster::Engine::DNSName;
+use Zonemaster::Engine::Nameserver;
+
+BEGIN { use_ok 'Zonemaster::Engine::NameserverSet'; }
+
+subtest 'creating empty set' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    isa_ok( $set, 'Zonemaster::Engine::NameserverSet' );
+    ok( $set->is_empty(), '$set->is_empty() is true' );
+    is( scalar $set->items, 0, 'set is empty' );
+};
+
+subtest 'is_empty() method' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    ok( $set->is_empty(), 'is_empty() is true on empty set' );
+
+    $set->push( 'not.empty.anymore.test' );
+
+    ok( ! $set->is_empty(), 'is_empty() is false if set is nonempty' );
+};
+
+subtest 'pushing nothing is a non-operation' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    $set->push();
+    ok( $set->is_empty(), 'set is still empty' );
+};
+
+subtest 'push() methods returns self' => sub {
+    isa_ok(
+        Zonemaster::Engine::NameserverSet->new()->push(),
+        'Zonemaster::Engine::NameserverSet',
+        'push() method returns the object'
+    );
+};
+
+subtest 'pushing a DNS name onto an empty set' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+    ok( $set->is_empty(), 'set is still empty' );
+
+    $set->push( Zonemaster::Engine::DNSName->new( 'one.test' ) );
+
+    ok( ! $set->is_empty(), 'set is no longer empty' );
+    is( scalar $set->items, 1, 'set contains one item' );
+    is( 'one.test', ($set->items)[0] );
+};
+
+subtest 'pushing a nameserver onto an empty set' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    $set->push(
+        Zonemaster::Engine::Nameserver->new( {
+            name => 'ns1.one.test',
+            address => '2001:db8::'
+        } )
+    );
+
+    is( scalar $set->items, 1, 'set contains one item' );
+    is( 'ns1.one.test/2001:db8::', ($set->items)[0] );
+};
+
+subtest 'pushing a plain string onto an empty set' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    $set->push('plain.string.test');
+    is( scalar $set->items, 1, 'set contains one item' );
+    is( 'plain.string.test', ($set->items)[0] );
+    isa_ok( ($set->items)[0], 'Zonemaster::Engine::DNSName' );
+};
+
+subtest 'pushing an empty string is a non-operation' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    is( scalar $set->push('')->items(), 0, 'set does not grow' );
+};
+
+subtest 'pushing undef is a non-operation' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    is( scalar $set->push(undef)->items(), 0, 'set does not grow' );
+};
+
+subtest 'pushing two equivalent DNS names' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+    $set->push( Zonemaster::Engine::DNSName->new( 'one.test' ) );
+    my $old_size = scalar $set->items;
+
+    $set->push( Zonemaster::Engine::DNSName->new( 'ONE.TEST' ) );
+
+    is( scalar $set->items, $old_size, 'set still contains one item' );
+    is( 'one.test', ($set->items)[0] );
+};
+
+subtest 'pushing a mix of equivalent DNS names and strings' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+
+    $set->push(
+        'HeLLo.TeST',
+        Zonemaster::Engine::DNSName->new('HELLO.TEST'),
+        Zonemaster::Engine::DNSName->new('HEllo.TEst'),
+        'hello.test'
+    );
+
+    is( scalar $set->items, 1, 'set contains exactly one item' );
+    is( 'hello.test', ($set->items)[0] );
+};
+
+subtest 'pushing two distinct DNS names' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new();
+    $set->push( Zonemaster::Engine::DNSName->new( 'one.test' ) );
+
+    my $old_size = scalar $set->items;
+    $set->push( Zonemaster::Engine::DNSName->new( 'two.test' ) );
+    is( scalar $set->items, $old_size + 1, 'set size grew by one' );
+
+    my @set_items = $set->items;
+    ok( grep { $_ eq 'one.test' } @set_items );
+    ok( grep { $_ eq 'two.test' } @set_items );
+};
+
+subtest 'new() can also create non-empty sets from a list' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        map { Zonemaster::Engine::DNSName->new( $_ ) }
+        qw( one.test two.test three.test )
+    );
+    is( scalar $set->items, 3, 'set contains three items' );
+};
+
+subtest 'pushing two names and a nameserver' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'one.test' ),
+        Zonemaster::Engine::DNSName->new( 'two.test' )
+    );
+    my $old_size = scalar $set->items;
+
+    $set->push( Zonemaster::Engine::Nameserver->new({
+        name => 'three.test',
+        address => '2001:db8::3:1'
+    } ) );
+
+    is( scalar $set->items, $old_size + 1, 'set grows by one' );
+};
+
+subtest 'set only holds unique nameservers' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'one.test' ),
+        Zonemaster::Engine::DNSName->new( 'two.test' ),
+        Zonemaster::Engine::Nameserver->new( {
+            name => 'three.test',
+            address => '2001:db8::3:1'
+        } )
+    );
+    my $old_size = scalar $set->items;
+
+    $set->push( Zonemaster::Engine::Nameserver->new({
+        name => 'THREE.TEST.',
+        address => '2001:db8::3:1'
+    } ) );
+
+    is( scalar $set->items, $old_size, 'set does not grow' );
+};
+
+subtest 'overwriting a DNS name with a name server' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'one.test' ),
+        Zonemaster::Engine::DNSName->new( 'two.test' ),
+        Zonemaster::Engine::Nameserver->new( {
+            name => 'three.test',
+            address => '2001:db8::3:1'
+        } )
+    );
+    my $old_size = scalar $set->items;
+
+    ok( grep( { $_ eq 'one.test' } $set->items ), 'one.test is in the set' );
+
+    $set->push( Zonemaster::Engine::Nameserver->new({
+        name => 'OnE.TeSt',
+        address => '2001:db8::1:1'
+    } ) );
+
+    my @set_items = $set->items;
+    is( scalar @set_items, $old_size, 'set size did not grow' );
+    ok( !grep( { $_ eq 'one.test' } @set_items ), 'one.test is no longer in the set' );
+    ok( grep( { $_ eq 'one.test/2001:db8::1:1' } @set_items ), 'the new name server is in the set' );
+};
+
+subtest 'pushing a DNS name when a name server already exists' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'one.test' ),
+        Zonemaster::Engine::DNSName->new( 'two.test' ),
+        Zonemaster::Engine::Nameserver->new( {
+            name => 'three.test',
+            address => '2001:db8::3:1'
+        } )
+    );
+    my $old_size = scalar $set->items;
+
+    $set->push(
+        Zonemaster::Engine::DNSName->new( 'THREE.TEST' ),
+        'THREE.TEST'
+    );
+
+    my @set_items = $set->items;
+    is( scalar $set->items, $old_size, 'set size did not grow' );
+    ok( ! grep( { lc $_ eq 'three.test' } @set_items ), 'the name is not in the set' )
+        or diag join(", ", @set_items);
+    ok( grep( { $_ eq 'three.test/2001:db8::3:1' } @set_items ), 'the nameserver is still there' )
+        or diag join(", ", @set_items);
+};
+
+subtest 'adding a name server with same name but different IP' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::Nameserver->new( {
+            name => 'one.test',
+            address => '2001:db8::1:1'
+        } ),
+        Zonemaster::Engine::DNSName->new( 'two.test' ),
+        Zonemaster::Engine::Nameserver->new( {
+            name => 'three.test',
+            address => '2001:db8::3:1'
+        } )
+    );
+    my $old_size = scalar $set->items;
+
+    $set->push( Zonemaster::Engine::Nameserver->new({
+        name => 'one.test',
+        address => '2001:db8::2:1'
+    } ) );
+
+    my @set_items = $set->items;
+    is( scalar @set_items, $old_size + 1, 'set size increased by one' );
+    ok( grep( { $_ eq 'one.test/2001:db8::1:1' } @set_items ), 'the old name server still is in the set' );
+    ok( grep( { $_ eq 'one.test/2001:db8::2:1' } @set_items ), 'the new name server is in the set' );
+};
+
+subtest 'sorted_items() method' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new('b.test'),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '127.0.0.1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bc::'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bbbb::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '203.0.113.234'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '192.0.2.2'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '192.0.2.101'
+        }),
+    );
+
+    my @ordered_items = map { "$_" } $set->sorted_items();
+
+    my @expected = qw(
+                         a.test/127.0.0.1
+                         a.test/::1
+                         b.test
+                         d.test/192.0.2.2
+                         d.test/192.0.2.101
+                         d.test/203.0.113.234
+                         d.test/2001:db8:bc::
+                         d.test/2001:db8:bbbb::1
+                 );
+
+    is_deeply( \@ordered_items, \@expected, 'ordering items works as it should' )
+        or diag("Here’s how \$set->sorted_items() sorted the items:\n"
+                . join "\n", map { " * $_" } @ordered_items );
+};
+
+subtest 'names() method' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new('B.TEST'),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'A.TEST',
+            address => '127.0.0.1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bc::'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'D.TEST',
+            address => '2001:db8:bbbb::1'
+        })
+    );
+
+    my @names = $set->names();
+
+    is( scalar @names, 3, 'correct list size' );
+    ok( grep({ $_ eq 'a.test' } @names), 'a.test is in the list' );
+    ok( grep({ $_ eq 'b.test' } @names), 'b.test is in the list' );
+    ok( grep({ $_ eq 'd.test' } @names), 'd.test is in the list' );
+    ok( List::Util::all(sub { $_->isa('Zonemaster::Engine::DNSName') }, @names),
+        'names() returns DNSName objects' );
+};
+
+subtest 'get() method' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new('B.TEST'),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'A.TEST',
+            address => '127.0.0.1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bc::'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'D.TEST',
+            address => '2001:db8:bbbb::1'
+        })
+    );
+
+    my @a = $set->get('A.TeSt');
+    is( scalar @a, 2, 'get a.test gives correct number of items' );
+    ok( grep({ $_ eq 'a.test/::1' } @a) );
+    ok( grep({ $_ eq 'a.test/127.0.0.1' } @a) );
+
+    my @b = $set->get('b.test');
+    is( scalar @b, 1, 'get b.test gives correct amount of items' );
+    ok( $b[0] eq 'b.test' );
+
+    is( $set->get('b.test'), 'b.test' );
+
+    is( scalar do { my @c = $set->get('c.test'); @c }, 0,
+        'get c.test in list context return empty array');
+    is( $set->get('c.test'), undef,
+        'get c.test in scalar context returns undef');
+
+    my @d = $set->get( Zonemaster::Engine::DNSName->new('d.test') );
+    is( scalar @d, 2,
+        'passing a DNSName to get() instead of a string also works');
+};
+
+subtest 'get_ips() method' => sub {
+    my $set = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new('B.TEST'),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'A.TEST',
+            address => '127.0.0.1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bc::'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'D.TEST',
+            address => '2001:db8:bbbb::1'
+        })
+    );
+
+    my @a = $set->get_ips('A.TeSt');
+    is( scalar @a, 2, 'get_ips a.test gives correct number of items' );
+    ok( grep({ $_ eq 'a.test/::1' } @a) );
+    ok( grep({ $_ eq 'a.test/127.0.0.1' } @a) );
+
+    my @b = $set->get_ips('b.test');
+    is( scalar @b, 0, 'get_ips b.test gives correct amount of items' );
+
+    is( scalar do { my @c = $set->get_ips('c.test'); @c }, 0,
+        'get_ips c.test in list context return empty array');
+    is( $set->get_ips('c.test'), undef,
+        'get_ips c.test in scalar context returns undef');
+
+    my @d = $set->get_ips( Zonemaster::Engine::DNSName->new('d.test') );
+    is( scalar @d, 2,
+        'passing a DNSName to get_ips() instead of a string also works');
+};
+
+subtest 'difference() method on two empty sets' => sub {
+    my $set_a = Zonemaster::Engine::NameserverSet->new();
+    my $set_b = Zonemaster::Engine::NameserverSet->new();
+
+    my ( $lhs, $rhs ) = $set_a->difference( $set_b );
+    is( scalar $lhs->items(), 0, 'set a minus set b is empty' );
+    is( scalar $rhs->items(), 0, 'set b minus set a is empty' );
+};
+
+subtest 'difference() method on non-empty sets' => sub {
+    my $set_a = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new('B.TEST'),
+        Zonemaster::Engine::DNSName->new('e.TEST'),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'A.TEST',
+            address => '127.0.0.1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bc::'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'D.TEST',
+            address => '2001:db8:bbbb::1'
+        })
+    );
+
+    my $set_b = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new('b.test'),
+        Zonemaster::Engine::DNSName->new('c.test'),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '127.0.0.1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bc::'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bbbb::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '203.0.113.234'
+        }),
+    );
+
+    my ( $only_in_a, $only_in_b ) = $set_a->difference( $set_b );
+
+    isa_ok( $only_in_a, 'Zonemaster::Engine::NameserverSet' );
+    isa_ok( $only_in_b, 'Zonemaster::Engine::NameserverSet' );
+
+    is_deeply(
+        [ map { "$_" } $only_in_a->sorted_items() ],
+        [ qw( a.test/::1 e.TEST ) ]
+    );
+    is_deeply(
+        [ map { "$_" } $only_in_b->sorted_items() ],
+        [ qw( c.test d.test/203.0.113.234 ) ]
+    );
+};
+
+subtest 'equals() on two empty sets' => sub {
+    my $set_a = Zonemaster::Engine::NameserverSet->new();
+    my $set_b = Zonemaster::Engine::NameserverSet->new();
+
+    ok( $set_a->equals( $set_b ), 'two empty sets are equal to each other' );
+};
+
+subtest 'equals() on two nonempty sets' => sub {
+    my $set_a = Zonemaster::Engine::NameserverSet->new();
+    my $set_b = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'hello.test' )
+    );
+
+    ok( ! $set_a->equals( $set_b ), 'both sets are not equal' );
+};
+
+subtest 'equals() on two different sets' => sub {
+    my $set_a = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'hello.test' )
+    );
+
+    my $set_b = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'hello2.test' )
+    );
+
+    ok( ! $set_a->equals( $set_b ), 'equals() returns false on sets containing different items' );
+};
+
+subtest 'equals() on sub- and supersets' => sub {
+    my $set_a = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'hello.test' )
+    );
+
+    my $set_b = Zonemaster::Engine::NameserverSet->new(
+        Zonemaster::Engine::DNSName->new( 'hello.test' ),
+        Zonemaster::Engine::DNSName->new( 'hello2.test' )
+    );
+
+    ok( ! $set_a->equals( $set_b ),
+        'one set is not equal to a strict superset of oneself' );
+    ok( ! $set_b->equals( $set_a ),
+        'one set is not equal to a strict subset of oneself' );
+};
+
+subtest 'equals() on equal sets' => sub {
+    my @input = (
+        Zonemaster::Engine::DNSName->new('b.test'),
+        Zonemaster::Engine::DNSName->new('c.test'),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'a.test',
+            address => '127.0.0.1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bc::'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '2001:db8:bbbb::1'
+        }),
+        Zonemaster::Engine::Nameserver->new({
+            name => 'd.test',
+            address => '203.0.113.234'
+        }),
+    );
+
+    my $set_a = Zonemaster::Engine::NameserverSet->new( @input );
+    my $set_b = Zonemaster::Engine::NameserverSet->new( @input );
+
+    ok( $set_a->equals( $set_b ),
+        'two non-empty sets with same items test equal');
+};
+
+done_testing;


### PR DESCRIPTION
## Purpose

Both the Get-Delegation and Get-Del-NS-Names-and-IPs methods in MethodsV2 had implementations that deviated slightly from the specifications, in such a way that they could return incorrect data in some edge cases involving fake delegation. This PR brings these methods back in line with the specification; they now return correct results in these situations.

In order to help fix this bug, I’ve introduced a new class for a new type of data structure called a NameserverSet. This class implements sets that specialize in holding a mix of Nameserver and DNSName objects. The inspiration comes from the Consistency05 specification update in zonemaster/zonemaster#1523, where the test procedure prescribes sets containing a mix of name/IP pairs and plain names, where adding a name/IP pair to a set already containing the same name also removes the plain name. NameserverSet objects have the same semantics.

Although I initially used NameserverSets to update the implementation of Consistency05, I then stumbled upon the problem described in #1545. Then, I discovered that NameserverSets were a very useful abstraction to help fix the issue. We use these sort of sets of either Nameservers, DNSNames or both in many places in the codebase and I hope that NameserverSets could help make the code more concise, both in test methods and test cases.

*Note:* this PR also introduces another user-visible change. One of the commits improves the `cmp` operator overloads in the Zonemaster::Engine::DNSName and Zonemaster::Engine::Nameserver classes. Name server lists in CLI and GUI output are now properly sorted on name server name first, IP version second, and numeric IP address number (as a 32-bit integer in IPv4 and 128-bit integer in IPv6) third. For example, `ns1.example/2001:db8::1111` sorts after `ns1.example/2001:db8::2`. Some message tags might still contain name server lists sorted differently, depending on how the test cases are implemented.

## Context

Fixes #1545.

## Changes

* Improve the `cmp` operator overloads in Zonemaster::Engine::DNSName and Zonemaster::Engine::Nameserver
* Introduce the `Zonemaster::Engine::NameserverSet` class
* Fix an incorrect implementation of Get-Delegation and Get-Del-NS-Names-and-IPs, bringing it back in line with the specification
* Refactor these two methods (and especially Get-Del-NS-Names-and-IPs) in order to improve general code style

## How to test this PR

* Unit tests should still pass.
* Run the reproducer script in #1545. Its output should match the following text:
```
ok 1
ok 2
1..2
```
